### PR TITLE
Repo cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,10 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
+    lintOptions {
+        disable 'GradleCompatible'
+    }
 }
 
 dependencies {
@@ -29,6 +33,8 @@ dependencies {
     compile project(':aztec')
     compile project(':glide-loader')
     compile project(':picasso-loader')
+
+    //noinspection GradleCompatible
     compile "com.android.support:appcompat-v7:25.3.1"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.wordpress:utils:1.14.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile project(':aztec')
     compile project(':glide-loader')
     compile project(':picasso-loader')
-    compile "com.android.support:appcompat-v7:25.1.0"
+    compile "com.android.support:appcompat-v7:25.3.1"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.wordpress:utils:1.14.0"
 }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/ApplicationTest.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/ApplicationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.aztec
 
 import android.app.Application

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -46,6 +46,7 @@ class MainActivity : AppCompatActivity(),
         OnRequestPermissionsResultCallback,
         PopupMenu.OnMenuItemClickListener,
         View.OnTouchListener {
+
     companion object {
         private val HEADING =
                 "<h1>Heading 1</h1>" +

--- a/app/src/main/res/layout-v17/activity_main.xml
+++ b/app/src/main/res/layout-v17/activity_main.xml
@@ -32,9 +32,11 @@
                 android:paddingEnd="16dp"
                 android:paddingLeft="16dp"
                 android:paddingRight="16dp"
+                android:paddingStart="16dp"
                 android:paddingTop="16dp"
                 android:scrollbars="vertical"
                 android:imeOptions="flagNoExtractUi"
+                android:fontFamily="serif"
                 aztec:historyEnable="true"
                 aztec:historySize="10"/>
 
@@ -48,11 +50,13 @@
                 android:paddingEnd="16dp"
                 android:paddingLeft="16dp"
                 android:paddingRight="16dp"
+                android:paddingStart="16dp"
                 android:paddingTop="16dp"
                 android:scrollbars="vertical"
                 android:textSize="14sp"
                 android:visibility="gone"
                 android:imeOptions="flagNoExtractUi"
+                android:fontFamily="monospace"
                 aztec:codeBackgroundColor="@android:color/transparent"
                 aztec:codeTextColor="@android:color/white"/>
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -25,15 +25,15 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-v4:25.1.0"
+    compile "com.android.support:support-v4:25.3.1"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
-    compile 'org.jsoup:jsoup:1.9.2'
+    compile 'org.jsoup:jsoup:1.10.2'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.1.4'
+    testCompile 'org.robolectric:robolectric:3.3.2'
 
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:25.3.1'
     //https://github.com/robolectric/robolectric/issues/1932
     testCompile 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
 }

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
     compile 'org.jsoup:jsoup:1.9.2'
-    compile "org.wordpress:utils:1.14.0"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.4'

--- a/aztec/src/androidTest/kotlin/org/wordpress/aztec/ApplicationTest.kt
+++ b/aztec/src/androidTest/kotlin/org/wordpress/aztec/ApplicationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.aztec
 
 import android.app.Application

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -53,7 +53,7 @@ import org.xml.sax.Attributes
 import java.util.*
 
 @Suppress("UNUSED_PARAMETER")
-class AztecText : EditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListener {
+class AztecText : android.support.v7.widget.AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListener {
 
     companion object {
         val BLOCK_EDITOR_HTML_KEY = "RETAINED_BLOCK_HTML_KEY"

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -17,6 +17,7 @@
 
 package org.wordpress.aztec
 
+import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -146,6 +147,7 @@ class AztecText : android.support.v7.widget.AppCompatEditText, TextWatcher, Unkn
         isInCalypsoMode = isCompatibleWithCalypso
     }
 
+    @SuppressLint("ResourceType")
     private fun init(attrs: AttributeSet?) {
         disableTextChangedListener()
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -52,6 +52,7 @@ import org.wordpress.aztec.watchers.*
 import org.xml.sax.Attributes
 import java.util.*
 
+@Suppress("UNUSED_PARAMETER")
 class AztecText : EditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListener {
 
     companion object {
@@ -218,7 +219,7 @@ class AztecText : EditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListe
         // triggers ClickableSpan onClick() events
         movementMethod = EnhancedMovementMethod
 
-        //Detect the press of backspace from hardware keyboard when no characters are deleted (eg. at 0 index of EditText)
+        // detect the press of backspace from hardware keyboard when no characters are deleted (eg. at 0 index of EditText)
         setOnKeyListener { v, keyCode, event ->
             var consumeKeyEvent = false
             history.beforeTextChanged(toFormattedHtml())
@@ -253,7 +254,7 @@ class AztecText : EditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListe
         InlineTextWatcher.install(inlineFormatter, this)
 
         // NB: text change handler should not alter text before "afterTextChanged" is called otherwise not all watchers
-        //  will have the chance to run their "beforeTextChanged" and "onTextChanged" with the same string!
+        // will have the chance to run their "beforeTextChanged" and "onTextChanged" with the same string!
 
         BlockElementWatcher(this)
                 .add(HeadingHandler())

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/ListItemHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/ListItemHandler.kt
@@ -26,19 +26,19 @@ class ListItemHandler : BlockHandler<AztecListItemSpan>(AztecListItemSpan::class
         }
 
         if (block.end == parent.end) {
-            // just remove listitem when entering a newline on an empty item at the end of the list
+            // just remove list item when entering a newline on an empty item at the end of the list
             block.remove()
         }
     }
 
     override fun handleNewlineAtEmptyBody() {
-        // just remove listitem when entering a newline on an empty item at the end of the list
+        // just remove list item when entering a newline on an empty item at the end of the list
         block.remove()
     }
 
     // fun handleNewlineAtTextEnd()
     // got a newline while being at the end-of-text. We'll let the current list item engulf it and will wait
-    //  for the end-of-text marker event in order to attach the new list item to it when that happens.
+    // for the end-of-text marker event in order to attach the new list item to it when that happens.
 
     override fun handleNewlineInBody() {
         // newline added at some position inside the bullet so, end the current bullet and append a new one

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -91,7 +91,7 @@ object Format {
         // keep <br> tags inside captions and remove line breaks
         if (content.contains("[caption")) {
             preserve_br = true
-            p = Pattern.compile("\\[caption[\\s\\S]+?\\[/caption\\]")
+            p = Pattern.compile("\\[caption[\\s\\S]+?\\[/caption]")
             m = p.matcher(content)
             sb = StringBuffer()
             if (m.find()) {
@@ -234,7 +234,7 @@ object Format {
         if (html.contains("[caption' )")) {
             preserve_br = true
 
-            p = Pattern.compile("\\[caption[\\s\\S]+?\\[/caption\\]")
+            p = Pattern.compile("\\[caption[\\s\\S]+?\\[/caption]")
             m = p.matcher(html)
             sb = StringBuffer()
             while (m.find()) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -18,7 +18,7 @@ import org.wordpress.aztec.History
 import org.wordpress.aztec.R
 import org.wordpress.aztec.spans.AztecCursorSpan
 
-class SourceViewEditText : EditText, TextWatcher {
+class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatcher {
 
     @ColorInt var tagColor = ContextCompat.getColor(context, R.color.html_tag)
         internal set

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -1,5 +1,6 @@
 package org.wordpress.aztec.source
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.os.Parcel
@@ -18,6 +19,7 @@ import org.wordpress.aztec.History
 import org.wordpress.aztec.R
 import org.wordpress.aztec.spans.AztecCursorSpan
 
+@SuppressLint("SupportAnnotationUsage")
 class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatcher {
 
     @ColorInt var tagColor = ContextCompat.getColor(context, R.color.html_tag)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -22,10 +22,9 @@ import android.graphics.Typeface
 import android.os.Parcel
 import android.text.ParcelableSpan
 import android.text.TextPaint
-import android.text.TextUtils
 import android.text.style.MetricAffectingSpan
-import org.wordpress.aztec.formatting.InlineFormatter
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.formatting.InlineFormatter
 
 class AztecCodeSpan : MetricAffectingSpan, ParcelableSpan, AztecInlineSpan {
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -98,7 +98,7 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
         }
 
         // get the TextView's target width
-        val want = calculateWantedWidth(textView?.widthMeasureSpec ?: 0)
+        calculateWantedWidth(textView?.widthMeasureSpec ?: 0)
                 .minus(textView?.compoundPaddingLeft ?: 0)
                 .minus(textView?.compoundPaddingRight ?: 0)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -7,7 +7,6 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.text.BoringLayout
 import android.text.Layout
-import android.text.StaticLayout
 import android.text.style.DynamicDrawableSpan
 import android.view.View
 import org.wordpress.aztec.AztecText

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -3,13 +3,12 @@ package org.wordpress.aztec.spans
 import android.graphics.Paint
 import android.text.Spanned
 import android.text.TextPaint
-import android.text.TextUtils
 import android.text.style.LineHeightSpan
 import android.text.style.MetricAffectingSpan
 import android.text.style.UpdateLayout
+import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.TextFormat
 import org.wordpress.aztec.formatting.BlockFormatter
-import org.wordpress.aztec.AztecAttributes
 
 class AztecHeadingSpan @JvmOverloads constructor(
         override var nestingLevel: Int,

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalLineSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalLineSpan.kt
@@ -1,19 +1,7 @@
 package org.wordpress.aztec.spans
 
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.Rect
 import android.graphics.drawable.Drawable
-import android.text.BoringLayout
-import android.text.Layout
-import android.text.StaticLayout
-import android.text.TextUtils
-import android.text.style.DynamicDrawableSpan
-import android.text.style.ImageSpan
-import android.view.View
-import org.wordpress.android.util.DisplayUtils
-import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.AztecAttributes
 
 class AztecHorizontalLineSpan(context: Context, drawable: Drawable, override var nestingLevel: Int) :

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import org.wordpress.aztec.AztecAttributes
 
 class AztecListItemSpan(override var nestingLevel: Int, override var attributes: AztecAttributes = AztecAttributes()) : AztecBlockSpan {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -19,11 +19,11 @@ abstract class AztecListSpan(override var nestingLevel: Int, var verticalPadding
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
-        if (start === spanStart || start < spanStart) {
+        if (start == spanStart || start < spanStart) {
             fm.ascent -= verticalPadding
             fm.top -= verticalPadding
         }
-        if (end === spanEnd || spanEnd < end) {
+        if (end == spanEnd || spanEnd < end) {
             fm.descent += verticalPadding
             fm.bottom += verticalPadding
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaClickableSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaClickableSpan.kt
@@ -5,6 +5,6 @@ import android.view.View
 
 class AztecMediaClickableSpan(private val mediaSpan: AztecMediaSpan) : ClickableSpan() {
     override fun onClick(view: View) {
-        this.mediaSpan.onClick(view)
+        this.mediaSpan.onClick()
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -103,7 +103,7 @@ class AztecMediaSpan(context: Context, drawable: Drawable?, override var attribu
         return sb.toString()
     }
 
-    fun onClick(view: View) {
+    fun onClick() {
         onMediaTappedListener?.mediaTapped(attributes, getWidth(imageDrawable), getHeight(imageDrawable))
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -5,16 +5,11 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
-import android.text.BoringLayout
-import android.text.Layout
-import android.text.StaticLayout
-import android.text.style.DynamicDrawableSpan
 import android.view.Gravity
 import android.view.View
+import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.AztecText.OnMediaTappedListener
-import org.xml.sax.Attributes
-import org.wordpress.aztec.AztecAttributes
 import java.util.*
 
 class AztecMediaSpan(context: Context, drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -21,9 +21,8 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.Layout
 import android.text.Spanned
-import android.text.TextUtils
-import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.formatting.BlockFormatter
 
 class AztecOrderedListSpan(
         override var nestingLevel: Int,

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -32,12 +32,12 @@ class AztecPreformatSpan(
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
-        if (start === spanStart || start < spanStart) {
+        if (start == spanStart || start < spanStart) {
             fm.ascent -= preformatStyle.verticalPadding
             fm.top -= preformatStyle.verticalPadding
         }
 
-        if (end === spanEnd || spanEnd < end) {
+        if (end == spanEnd || spanEnd < end) {
             fm.descent += preformatStyle.verticalPadding
             fm.bottom += preformatStyle.verticalPadding
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -23,13 +23,12 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.text.Layout
 import android.text.Spanned
-import android.text.TextUtils
 import android.text.style.LineBackgroundSpan
 import android.text.style.LineHeightSpan
 import android.text.style.QuoteSpan
 import android.text.style.UpdateLayout
-import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.formatting.BlockFormatter
 
 
 class AztecQuoteSpan(

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -49,11 +49,11 @@ class AztecQuoteSpan(
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
-        if (start === spanStart || start < spanStart) {
+        if (start == spanStart || start < spanStart) {
             fm.ascent -= quoteStyle.verticalPadding
             fm.top -= quoteStyle.verticalPadding
         }
-        if (end === spanEnd || spanEnd < end) {
+        if (end == spanEnd || spanEnd < end) {
             fm.descent += quoteStyle.verticalPadding
             fm.bottom += quoteStyle.verticalPadding
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecRelativeSizeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecRelativeSizeSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import android.text.style.RelativeSizeSpan
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStrikethroughSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStrikethroughSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import android.text.style.StrikethroughSpan
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStyleSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStyleSpan.kt
@@ -1,7 +1,6 @@
 package org.wordpress.aztec.spans
 
 import android.graphics.Typeface
-import android.text.TextUtils
 import android.text.style.StyleSpan
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSubscriptSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSubscriptSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import android.text.style.SubscriptSpan
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSuperscriptSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSuperscriptSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import android.text.style.SuperscriptSpan
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTypefaceSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTypefaceSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import android.text.style.TypefaceSpan
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -19,10 +19,9 @@ package org.wordpress.aztec.spans
 
 import android.os.Parcel
 import android.text.TextPaint
-import android.text.TextUtils
 import android.text.style.URLSpan
-import org.wordpress.aztec.formatting.LinkFormatter
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.formatting.LinkFormatter
 
 class AztecURLSpan : URLSpan, AztecInlineSpan {
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnderlineSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnderlineSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import android.text.style.UnderlineSpan
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -21,9 +21,8 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.Layout
 import android.text.Spanned
-import android.text.TextUtils
-import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.formatting.BlockFormatter
 
 class AztecUnorderedListSpan(
         override var nestingLevel: Int,

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
@@ -1,10 +1,9 @@
 package org.wordpress.aztec.spans
 
 import android.text.TextPaint
-import android.text.TextUtils
 import android.text.style.CharacterStyle
-import org.xml.sax.Attributes
 import org.wordpress.aztec.AztecAttributes
+import org.xml.sax.Attributes
 
 class FontSpan : CharacterStyle, AztecInlineSpan {
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
@@ -5,15 +5,10 @@ import android.text.style.CharacterStyle
 import org.wordpress.aztec.AztecAttributes
 import org.xml.sax.Attributes
 
-class FontSpan : CharacterStyle, AztecInlineSpan {
+class FontSpan(attrs: Attributes) : CharacterStyle(), AztecInlineSpan {
 
     private var TAG: String = "font"
     override var attributes: AztecAttributes = AztecAttributes()
-
-    @JvmOverloads
-    constructor(attrs: Attributes) : super() {
-        this.attributes = AztecAttributes(attrs)
-    }
 
     override fun getStartTag(): String {
         if (attributes.isEmpty()) {
@@ -27,5 +22,9 @@ class FontSpan : CharacterStyle, AztecInlineSpan {
     }
 
     override fun updateDrawState(tp: TextPaint?) {
+    }
+
+    init {
+        this.attributes = AztecAttributes(attrs)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphFlagged.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphFlagged.kt
@@ -1,5 +1,8 @@
 package org.wordpress.aztec.spans
 
+import android.annotation.SuppressLint
+
+@SuppressLint("NewApi")
 interface ParagraphFlagged {
     var startBeforeCollapse: Int
     fun clearStartBeforeCollapse() { startBeforeCollapse = -1 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextUtils
 import android.text.style.ParagraphStyle
 import org.wordpress.aztec.AztecAttributes
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownClickableSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownClickableSpan.kt
@@ -6,6 +6,6 @@ import android.view.View
 class UnknownClickableSpan(private val unknownHtmlSpan: UnknownHtmlSpan) : ClickableSpan() {
 
     override fun onClick(widget: View) {
-        this.unknownHtmlSpan.onClick(widget)
+        this.unknownHtmlSpan.onClick()
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
@@ -12,7 +12,7 @@ class UnknownHtmlSpan(
         private val onClickListener: OnUnknownHtmlClickListener?
     ) : ImageSpan(context, drawable), AztecParagraphStyle, AztecNestable {
 
-    fun onClick(view: View) {
+    fun onClick() {
         onClickListener?.onUnknownHtmlClicked(this)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
@@ -3,6 +3,7 @@ package org.wordpress.aztec.toolbar
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.support.v4.content.ContextCompat
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -37,7 +38,7 @@ class RippleToggleButton : ToggleButton, OnLongClickListener {
 
         setOnLongClickListener(this)
 
-        val rippleColor = resources.getColor(R.color.format_bar_ripple_animation)
+        val rippleColor = ContextCompat.getColor(context, R.color.format_bar_ripple_animation)
 
         mFillPaint = Paint()
         mFillPaint!!.isAntiAlias = true

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/TextDeleter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/TextDeleter.kt
@@ -43,7 +43,7 @@ class TextDeleter private constructor(aztecText: AztecText) : TextWatcher {
         }
 
         fun isMarkedForDeletion(spannable: Spannable, start: Int, end: Int): Boolean {
-            return spannable.getSpans(0, spannable.length, MarkForDeletion::class.java).any()
+            return spannable.getSpans(start, end, MarkForDeletion::class.java).any()
         }
     }
 }

--- a/aztec/src/main/res/layout-v17/dialog_photo_media.xml
+++ b/aztec/src/main/res/layout-v17/dialog_photo_media.xml
@@ -14,8 +14,7 @@
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:drawableLeft="@drawable/ic_video_grey_c_24dp"
-        android:drawableStart="@drawable/ic_video_grey_c_24dp"
+        android:drawableStart="@drawable/ic_camera_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
         android:ellipsize="end"
         android:gravity="center_vertical"
@@ -26,17 +25,17 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
+        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_camera"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>
 
     <TextView
-        android:id="@+id/media_videos"
+        android:id="@+id/media_photos"
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:drawableLeft="@drawable/ic_videos_grey_c_24dp"
-        android:drawableStart="@drawable/ic_videos_grey_c_24dp"
+        android:drawableStart="@drawable/ic_photos_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
         android:ellipsize="end"
         android:gravity="center_vertical"
@@ -47,7 +46,8 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
-        android:text="@string/media_dialog_videos"
+        android:paddingStart="@dimen/margin_dialog"
+        android:text="@string/media_dialog_photos"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>
 
@@ -56,7 +56,6 @@
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:drawableLeft="@drawable/ic_library_grey_c_24dp"
         android:drawableStart="@drawable/ic_library_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
         android:ellipsize="end"
@@ -68,6 +67,7 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
+        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_library"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>

--- a/aztec/src/main/res/layout-v17/dialog_video_media.xml
+++ b/aztec/src/main/res/layout-v17/dialog_video_media.xml
@@ -14,7 +14,6 @@
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:drawableLeft="@drawable/ic_video_grey_c_24dp"
         android:drawableStart="@drawable/ic_video_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
         android:ellipsize="end"
@@ -26,6 +25,7 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
+        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_camera"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>
@@ -35,7 +35,6 @@
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:drawableLeft="@drawable/ic_videos_grey_c_24dp"
         android:drawableStart="@drawable/ic_videos_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
         android:ellipsize="end"
@@ -47,6 +46,7 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
+        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_videos"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>
@@ -56,7 +56,6 @@
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:drawableLeft="@drawable/ic_library_grey_c_24dp"
         android:drawableStart="@drawable/ic_library_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
         android:ellipsize="end"
@@ -68,6 +67,7 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
+        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_library"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>

--- a/aztec/src/main/res/layout/dialog_photo_media.xml
+++ b/aztec/src/main/res/layout/dialog_photo_media.xml
@@ -13,6 +13,7 @@
         android:id="@+id/media_camera"
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
+        android:focusable="true"
         android:drawableLeft="@drawable/ic_camera_grey_c_24dp"
         android:drawableStart="@drawable/ic_camera_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
@@ -25,7 +26,6 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
-        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_camera"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>
@@ -34,6 +34,7 @@
         android:id="@+id/media_photos"
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
+        android:focusable="true"
         android:drawableLeft="@drawable/ic_photos_grey_c_24dp"
         android:drawableStart="@drawable/ic_photos_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
@@ -46,7 +47,6 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
-        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_photos"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>
@@ -55,6 +55,7 @@
         android:id="@+id/media_library"
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
+        android:focusable="true"
         android:drawableLeft="@drawable/ic_library_grey_c_24dp"
         android:drawableStart="@drawable/ic_library_grey_c_24dp"
         android:drawablePadding="@dimen/margin_dialog"
@@ -67,7 +68,6 @@
         android:paddingEnd="@dimen/margin_dialog"
         android:paddingLeft="@dimen/margin_dialog"
         android:paddingRight="@dimen/margin_dialog"
-        android:paddingStart="@dimen/margin_dialog"
         android:text="@string/media_dialog_library"
         android:textAppearance="?android:attr/textAppearanceMedium" >
     </TextView>

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecCommentTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecCommentTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.aztec
 
 import android.app.Activity

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.aztec
 
 import android.test.AndroidTestCase

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.aztec
 
 import android.test.AndroidTestCase

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.aztec
 
 import android.test.AndroidTestCase

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.1'
+    ext.kotlin_version = '1.1.2'
     repositories {
         jcenter()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -23,6 +23,6 @@ android {
 dependencies {
     compile project(':aztec')
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.github.bumptech.glide:glide:3.7.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 22 20:08:25 CEST 2016
+#Fri Apr 28 23:01:31 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile project(':aztec')
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }


### PR DESCRIPTION
After going through Aztec's dependencies I noticed we had an unnecessary dependency on WP utils library, so I got rid of it. 

Also, [Kotlin 1.1.2 was released](https://blog.jetbrains.com/kotlin/2017/04/kotlin-1-1-2-is-out/) so I thought I might as well update all of the dependencies. It's right after a release so it should be safe and we have lots of time to notice if somethings not right.

I removed a couple of Lint warnings, while at it.