### PR TITLE
Repetitive code cleanup

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -347,9 +347,9 @@ class AztecParser {
 
     private fun withinBlock(out: StringBuilder, text: Spanned, start: Int, end: Int,
                             blockSpan: AztecBlockSpan, parents: ArrayList<AztecNestable>?, nestingLevel: Int) {
-        out.append("<${blockSpan.getStartTag()}>")
+        out.append("<${blockSpan.startTag}>")
         withinHtml(out, text, start, end, parents, nestingLevel)
-        out.append("</${blockSpan.getEndTag()}>")
+        out.append("</${blockSpan.endTag}>")
 
         if (end > 0
                 && text[end - 1] == Constants.NEWLINE
@@ -402,7 +402,7 @@ class AztecParser {
                 val span = spans[j]
 
                 if (span is AztecInlineSpan) {
-                    out.append("<${span.getStartTag()}>")
+                    out.append("<${span.startTag}>")
                 }
 
                 if (span is CommentSpan) {
@@ -416,7 +416,7 @@ class AztecParser {
                 }
 
                 if (span is AztecHorizontalLineSpan) {
-                    out.append("<${span.getStartTag()}>")
+                    out.append("<${span.startTag}>")
                     i = next
                 }
 
@@ -436,7 +436,7 @@ class AztecParser {
                 val span = spans[j]
 
                 if (span is AztecInlineSpan) {
-                    out.append("</${span.getEndTag()}>")
+                    out.append("</${span.endTag}>")
                 }
 
                 if (span is AztecCommentSpan || span is CommentSpan) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -13,7 +13,6 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.View
-import android.widget.EditText
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.History
 import org.wordpress.aztec.R

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -19,8 +19,6 @@ package org.wordpress.aztec.spans
 
 import android.graphics.Color
 import android.graphics.Typeface
-import android.os.Parcel
-import android.text.ParcelableSpan
 import android.text.TextPaint
 import android.text.style.MetricAffectingSpan
 import org.wordpress.aztec.AztecAttributes

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -26,58 +26,18 @@ import android.text.style.MetricAffectingSpan
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.formatting.InlineFormatter
 
-class AztecCodeSpan : MetricAffectingSpan, ParcelableSpan, AztecInlineSpan {
+class AztecCodeSpan(override var attributes: AztecAttributes = AztecAttributes()) : MetricAffectingSpan(), AztecInlineSpan {
 
-    private val TAG: String = "code"
+    override val TAG = "code"
 
     private var codeBackground: Int = 0
     private var codeBackgroundAlpha: Float = 0.0f
     private var codeColor: Int = 0
 
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    constructor(attributes: AztecAttributes = AztecAttributes()) : super() {
-        this.attributes = attributes
-    }
-
     constructor(codeStyle: InlineFormatter.CodeStyle, attributes: AztecAttributes = AztecAttributes()) : this(attributes) {
         this.codeBackground = codeStyle.codeBackground
         this.codeBackgroundAlpha = codeStyle.codeBackgroundAlpha
         this.codeColor = codeStyle.codeColor
-    }
-
-    constructor(src: Parcel) {
-        this.codeBackground = src.readInt()
-        this.codeBackgroundAlpha = src.readFloat()
-        this.codeColor = src.readInt()
-    }
-
-    override fun getSpanTypeId(): Int {
-        return getSpanTypeIdInternal()
-    }
-
-    fun getSpanTypeIdInternal(): Int {
-        return AztecSpanIds.CODE_SPAN
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        dest.writeInt(codeBackground)
-        dest.writeInt(codeColor)
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
     }
 
     override fun updateDrawState(tp: TextPaint?) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
@@ -6,5 +6,4 @@ class AztecCursorSpan  {
     companion object {
         val AZTEC_CURSOR_TAG = "aztec_cursor"
     }
-
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -17,6 +17,9 @@ class AztecHeadingSpan @JvmOverloads constructor(
         var headerStyle: BlockFormatter.HeaderStyle = BlockFormatter.HeaderStyle(0)
     ) : MetricAffectingSpan(), AztecBlockSpan, LineHeightSpan, UpdateLayout {
 
+    override val TAG: String
+        get() = heading.tag
+
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 
@@ -32,6 +35,15 @@ class AztecHeadingSpan @JvmOverloads constructor(
     var previousFontMetrics: Paint.FontMetricsInt? = null
     var previousTextScale: Float = 1.0f
 
+    enum class Heading constructor(internal val scale: Float, internal val tag: String) {
+        H1(SCALE_H1, "h1"),
+        H2(SCALE_H2, "h2"),
+        H3(SCALE_H3, "h3"),
+        H4(SCALE_H4, "h4"),
+        H5(SCALE_H5, "h5"),
+        H6(SCALE_H6, "h6")
+    }
+
     companion object {
         private val SCALE_H1: Float = 1.73f
         private val SCALE_H2: Float = 1.32f
@@ -40,7 +52,7 @@ class AztecHeadingSpan @JvmOverloads constructor(
         private val SCALE_H5: Float = 0.72f
         private val SCALE_H6: Float = 0.60f
 
-        fun getTextFormat(tag: String): TextFormat {
+        fun tagToTextFormat(tag: String): TextFormat {
             when (tag.toLowerCase()) {
                 "h1" -> return TextFormat.FORMAT_HEADING_1
                 "h2" -> return TextFormat.FORMAT_HEADING_2
@@ -71,7 +83,7 @@ class AztecHeadingSpan @JvmOverloads constructor(
 
     constructor(nestingLevel: Int, tag: String, attrs: AztecAttributes = AztecAttributes(),
             headerStyle: BlockFormatter.HeaderStyle = BlockFormatter.HeaderStyle(0))
-            : this(nestingLevel, getTextFormat(tag), attrs, headerStyle)
+            : this(nestingLevel, tagToTextFormat(tag), attrs, headerStyle)
 
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned
@@ -114,26 +126,6 @@ class AztecHeadingSpan @JvmOverloads constructor(
 
     }
 
-    enum class Heading constructor(internal val scale: Float) {
-        H1(SCALE_H1),
-        H2(SCALE_H2),
-        H3(SCALE_H3),
-        H4(SCALE_H4),
-        H5(SCALE_H5),
-        H6(SCALE_H6)
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return getTag()
-        }
-        return getTag() + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return getTag()
-    }
-
     override fun updateDrawState(textPaint: TextPaint) {
         textPaint.textSize *= heading.scale
         textPaint.isFakeBoldText = true
@@ -147,17 +139,5 @@ class AztecHeadingSpan @JvmOverloads constructor(
         previousTextScale = heading.scale
 
         textPaint.textSize *= heading.scale
-    }
-
-    private fun getTag(): String {
-        when (heading.scale) {
-            SCALE_H1 -> return "h1"
-            SCALE_H2 -> return "h2"
-            SCALE_H3 -> return "h3"
-            SCALE_H4 -> return "h4"
-            SCALE_H5 -> return "h5"
-            SCALE_H6 -> return "h6"
-            else -> return "h1"
-        }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalLineSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalLineSpan.kt
@@ -4,21 +4,9 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecAttributes
 
-class AztecHorizontalLineSpan(context: Context, drawable: Drawable, override var nestingLevel: Int) :
+class AztecHorizontalLineSpan(context: Context, drawable: Drawable, override var nestingLevel: Int,
+                              override var attributes: AztecAttributes = AztecAttributes()) :
         AztecDynamicImageSpan(context, drawable), AztecFullWidthImageSpan, AztecSpan {
 
-    private val TAG: String = "hr"
-
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
+    override val TAG: String = "hr"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
@@ -4,20 +4,8 @@ import org.wordpress.aztec.AztecAttributes
 
 class AztecListItemSpan(override var nestingLevel: Int, override var attributes: AztecAttributes = AztecAttributes()) : AztecBlockSpan {
 
-    private val TAG = "li"
+    override val TAG = "li"
 
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
-
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaClickableSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaClickableSpan.kt
@@ -4,6 +4,7 @@ import android.text.style.ClickableSpan
 import android.view.View
 
 class AztecMediaClickableSpan(private val mediaSpan: AztecMediaSpan) : ClickableSpan() {
+
     override fun onClick(view: View) {
         this.mediaSpan.onClick()
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -6,7 +6,6 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.view.Gravity
-import android.view.View
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.AztecText.OnMediaTappedListener

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -30,18 +30,7 @@ class AztecOrderedListSpan(
         var listStyle: BlockFormatter.ListStyle = BlockFormatter.ListStyle(0, 0, 0, 0, 0)
     ) : AztecListSpan(nestingLevel, listStyle.verticalPadding) {
 
-    private val TAG = "ol"
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
+    override val TAG = "ol"
 
     override fun getLeadingMargin(first: Boolean): Int {
         return listStyle.indicatorMargin + 2 * listStyle.indicatorWidth + listStyle.indicatorPadding

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -19,13 +19,14 @@ class AztecPreformatSpan(
         var preformatStyle: BlockFormatter.PreformatStyle = BlockFormatter.PreformatStyle(0, 0f, 0, 0)
     ) : AztecBlockSpan, LeadingMarginSpan, LineBackgroundSpan, LineHeightSpan, TypefaceSpan("monospace") {
 
+    override val TAG: String = "pre"
+
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 
     val rect = Rect()
 
     private val MARGIN = 16
-    private val TAG: String = "pre"
 
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned
@@ -70,19 +71,7 @@ class AztecPreformatSpan(
         paint.color = color
     }
 
-    override fun getEndTag(): String {
-        return TAG
-    }
-
     override fun getLeadingMargin(first: Boolean): Int {
         return MARGIN
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-
-        return TAG + " " + attributes
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -42,7 +42,7 @@ class AztecQuoteSpan(
 
     val rect = Rect()
 
-    private val TAG: String = "blockquote"
+    override val TAG: String = "blockquote"
 
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned
@@ -57,17 +57,6 @@ class AztecQuoteSpan(
             fm.descent += quoteStyle.verticalPadding
             fm.bottom += quoteStyle.verticalPadding
         }
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
     }
 
     override fun getLeadingMargin(first: Boolean): Int {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecRelativeSizeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecRelativeSizeSpan.kt
@@ -3,16 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.style.RelativeSizeSpan
 import org.wordpress.aztec.AztecAttributes
 
-open class AztecRelativeSizeSpan @JvmOverloads constructor(var tag: String, size: Float, override var attributes: AztecAttributes = AztecAttributes()) : RelativeSizeSpan(size), AztecInlineSpan {
+open class AztecRelativeSizeSpan @JvmOverloads constructor(private var tag: String, size: Float, override var attributes: AztecAttributes = AztecAttributes()) : RelativeSizeSpan(size), AztecInlineSpan {
 
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return tag
-        }
-        return tag + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return tag
-    }
+    override val TAG = tag
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSpan.kt
@@ -1,8 +1,23 @@
 package org.wordpress.aztec.spans
 
+import android.annotation.SuppressLint
+
+@SuppressLint("NewApi")
 interface AztecSpan : AztecAttributedSpan {
 
-    fun getStartTag(): String
-    fun getEndTag(): String
+    val TAG: String
+        get
 
+    val startTag: String
+        get() {
+            if (attributes.isEmpty()) {
+                return TAG
+            }
+            return TAG + " " + attributes
+        }
+
+    val endTag: String
+        get() {
+            return TAG
+        }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSpanIds.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSpanIds.kt
@@ -1,5 +1,0 @@
-package org.wordpress.aztec.spans
-
-object AztecSpanIds {
-    const val CODE_SPAN: Int = 1000
-}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStrikethroughSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStrikethroughSpan.kt
@@ -3,25 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.style.StrikethroughSpan
 import org.wordpress.aztec.AztecAttributes
 
-class AztecStrikethroughSpan() : StrikethroughSpan(), AztecInlineSpan {
+class AztecStrikethroughSpan(private var tag: String = "del", override var attributes: AztecAttributes = AztecAttributes()) : StrikethroughSpan(), AztecInlineSpan {
 
-    private var tag: String = "del"
-
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    constructor(tag: String, attributes: AztecAttributes = AztecAttributes()) : this() {
-        this.tag = tag
-        this.attributes = attributes
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return tag
-        }
-        return tag + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return tag
-    }
+    override val TAG = tag
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStyleSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStyleSpan.kt
@@ -4,32 +4,17 @@ import android.graphics.Typeface
 import android.text.style.StyleSpan
 import org.wordpress.aztec.AztecAttributes
 
-open class AztecStyleSpan : StyleSpan, AztecInlineSpan {
+open class AztecStyleSpan(style: Int, override var attributes: AztecAttributes = AztecAttributes()) : StyleSpan(style), AztecInlineSpan {
 
-    var tag: String = ""
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    constructor(style: Int, attributes: AztecAttributes = AztecAttributes()) : super(style) {
-        this.attributes = attributes
-
+    override val TAG by lazy {
         when (style) {
             Typeface.BOLD -> {
-                tag = "b"
+                return@lazy "b"
             }
             Typeface.ITALIC -> {
-                tag = "i"
+                return@lazy "i"
             }
         }
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return tag
-        }
-        return tag + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return tag
+        throw IllegalArgumentException()
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSubscriptSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSubscriptSpan.kt
@@ -3,24 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.style.SubscriptSpan
 import org.wordpress.aztec.AztecAttributes
 
-class AztecSubscriptSpan : SubscriptSpan, AztecInlineSpan {
+class AztecSubscriptSpan @JvmOverloads constructor(override var attributes: AztecAttributes = AztecAttributes()) : SubscriptSpan(), AztecInlineSpan {
 
-    private var TAG: String = "sub"
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    @JvmOverloads
-    constructor(attributes: AztecAttributes = AztecAttributes()) : super() {
-        this.attributes = attributes
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
+    override val TAG = "sub"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSuperscriptSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecSuperscriptSpan.kt
@@ -3,24 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.style.SuperscriptSpan
 import org.wordpress.aztec.AztecAttributes
 
-class AztecSuperscriptSpan : SuperscriptSpan, AztecInlineSpan {
+class AztecSuperscriptSpan @JvmOverloads constructor(override var attributes: AztecAttributes = AztecAttributes()) : SuperscriptSpan(), AztecInlineSpan {
 
-    private var TAG: String = "sup"
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    @JvmOverloads
-    constructor(attributes: AztecAttributes = AztecAttributes()) : super() {
-        this.attributes = attributes
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
+    override val TAG = "sup"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTypefaceSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTypefaceSpan.kt
@@ -3,25 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.style.TypefaceSpan
 import org.wordpress.aztec.AztecAttributes
 
-open class AztecTypefaceSpan : TypefaceSpan, AztecInlineSpan {
+open class AztecTypefaceSpan @JvmOverloads constructor(tag: String, family: String, override var attributes: AztecAttributes = AztecAttributes()) : TypefaceSpan(family), AztecInlineSpan {
 
-    var tag: String
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    @JvmOverloads
-    constructor(tag: String, family: String, attributes: AztecAttributes = AztecAttributes()) : super(family) {
-        this.tag = tag
-        this.attributes = attributes
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return tag
-        }
-        return tag + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return tag
-    }
+    override val TAG = tag
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -25,7 +25,7 @@ import org.wordpress.aztec.formatting.LinkFormatter
 
 class AztecURLSpan : URLSpan, AztecInlineSpan {
 
-    private val TAG: String = "a"
+    override val TAG = "a"
 
     private var linkColor = 0
     private var linkUnderline = true
@@ -59,16 +59,5 @@ class AztecURLSpan : URLSpan, AztecInlineSpan {
     override fun updateDrawState(ds: TextPaint) {
         ds.color = if (linkColor != 0) linkColor else ds.linkColor
         ds.isUnderlineText = linkUnderline
-    }
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnderlineSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnderlineSpan.kt
@@ -5,16 +5,5 @@ import org.wordpress.aztec.AztecAttributes
 
 class AztecUnderlineSpan(override var attributes: AztecAttributes = AztecAttributes()) : UnderlineSpan(), AztecInlineSpan {
 
-    private val TAG = "u"
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
+    override val TAG = "u"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -30,19 +30,7 @@ class AztecUnorderedListSpan(
         var listStyle: BlockFormatter.ListStyle = BlockFormatter.ListStyle(0, 0, 0, 0, 0)
     ) : AztecListSpan(nestingLevel, listStyle.verticalPadding) {
 
-    private val TAG = "ul"
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
-
+    override val TAG = "ul"
 
     override fun getLeadingMargin(first: Boolean): Int {
         return listStyle.indicatorMargin + 2 * listStyle.indicatorWidth + listStyle.indicatorPadding

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/CommentSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/CommentSpan.kt
@@ -3,9 +3,8 @@ package org.wordpress.aztec.spans
 import android.text.TextPaint
 import android.text.style.CharacterStyle
 
-class CommentSpan : CharacterStyle() { // AztecContentSpan
+class CommentSpan : CharacterStyle() {
 
     override fun updateDrawState(tp: TextPaint) {
-
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/EndOfParagraphMarker.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/EndOfParagraphMarker.kt
@@ -5,7 +5,7 @@ import android.text.Spanned
 import android.text.style.LineHeightSpan
 import android.text.style.UpdateLayout
 
-//Used to mark newline at the end of calypso paragraphs.We
+// Used to mark newline at the end of calypso paragraphs
 class EndOfParagraphMarker(var verticalPadding: Int = 0) : LineHeightSpan, UpdateLayout {
 
     override fun chooseHeight(text: CharSequence?, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
@@ -3,7 +3,6 @@ package org.wordpress.aztec.spans
 import android.text.TextPaint
 import android.text.style.CharacterStyle
 import org.wordpress.aztec.AztecAttributes
-import org.xml.sax.Attributes
 
 class FontSpan(override var attributes: AztecAttributes = AztecAttributes()) : CharacterStyle(), AztecInlineSpan {
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/FontSpan.kt
@@ -5,26 +5,10 @@ import android.text.style.CharacterStyle
 import org.wordpress.aztec.AztecAttributes
 import org.xml.sax.Attributes
 
-class FontSpan(attrs: Attributes) : CharacterStyle(), AztecInlineSpan {
+class FontSpan(override var attributes: AztecAttributes = AztecAttributes()) : CharacterStyle(), AztecInlineSpan {
 
-    private var TAG: String = "font"
-    override var attributes: AztecAttributes = AztecAttributes()
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
+    override var TAG = "font"
 
     override fun updateDrawState(tp: TextPaint?) {
-    }
-
-    init {
-        this.attributes = AztecAttributes(attrs)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
@@ -8,19 +8,8 @@ class ParagraphSpan(
         override var attributes: AztecAttributes = AztecAttributes()
     ) : ParagraphStyle, AztecBlockSpan {
 
+    override var TAG: String = "p"
+
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
-
-    private var TAG: String = "p"
-
-    override fun getStartTag(): String {
-        if (attributes.isEmpty()) {
-            return TAG
-        }
-        return TAG + " " + attributes
-    }
-
-    override fun getEndTag(): String {
-        return TAG
-    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
@@ -2,7 +2,6 @@ package org.wordpress.aztec.spans
 
 import android.content.Context
 import android.text.style.ImageSpan
-import android.view.View
 
 class UnknownHtmlSpan(
         override var nestingLevel: Int,


### PR DESCRIPTION
After I started working on the plugin refactoring I noticed a lot of repetitive code when implementing the `AztecSpan` methods of `getStartTag()` and `getEndTag()`. I was able simplify most of the spans by adding default methods to the interface. I've decided to submit this PR separately to keep the it simpler.