### PR TITLE
Issue/313 image loading scroll

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -778,6 +778,7 @@ class AztecText : android.support.v7.widget.AppCompatEditText, TextWatcher, Unkn
         disableTextChangedListener()
         val selStart = selectionStart
         val selEnd = selectionEnd
+        clearFocus()
         text = editableText
         setSelection(selStart, selEnd)
         enableTextChangedListener()


### PR DESCRIPTION
### Fix
When first opening content containing images or toggling from HTML to visual view with images, remain at the scrolled position while images are loading as described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/313 and https://github.com/wordpress-mobile/WordPress-Android/issues/5184.  The content still moves when images load due to the difference in size between the placeholder and loaded images.  Since images can be loaded from an arbitrary URL, the image size cannot be determined before loading to compensate for the size difference and offset the content shift.

### Test
0. Clear ***AztecDemo*** app data.
1. Launch demonstration app.
2. Scroll down quickly.
3. Notice view doesn't scroll to top when image loads.
4. Tap ***HTML*** format button.
5. Select all text.
6. Paste text below.
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
<img src="http://goo.gl/i4Z69E">
<img src="http://goo.gl/dWbMtv">
Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
<img src="http://goo.gl/3urcsh">
<img src="http://goo.gl/8C4lZo">
Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
<img src="http://goo.gl/dL6tOu">
<img src="http://goo.gl/FJQ3yw">
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
<img src="http://goo.gl/9fNoiH">
<img src="http://goo.gl/AbW6tw">
Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```
7. Tap ***HTML*** format button.
8. Scroll down quickly.
9. Notice view doesn't scroll to top when images load.

#### Note
Using emulators to test may help simulate slow and/or poor network connections to make image loading more pronounced.