### PR TITLE
Issue/format button media

### DIFF
--- a/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
@@ -4,7 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/format_bar_button_media_disabled" android:state_enabled="false" />
-    <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_checked="true" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_media" />


### PR DESCRIPTION
### Fix
Remove checked state from media format button to mimic behavior of other buttons which trigger popup menus (e.g. ***Heading***).

#### Before
![format_button_media_before](https://cloud.githubusercontent.com/assets/3827611/26022560/cccd3d70-3765-11e7-9acf-06355f350642.gif)

#### After
![format_button_media_after](https://cloud.githubusercontent.com/assets/3827611/26022561/d016e404-3765-11e7-8aa4-f3e93c710dfd.gif)

### Test
1. Tap ***Media*** format button.
2. Notice ***Media*** format button is not highlighted.
3. Tap ***Heading*** format button.
4. Notice ***Heading*** format button is not highlighted.