### PR TITLE
Issue/344 button long press

### DIFF
--- a/aztec/src/main/res/drawable/format_bar_button_bold_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_bold_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_bold_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_bold_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_bold_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_bold_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_bold" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_heading_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_selector.xml
@@ -4,7 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/format_bar_button_heading_disabled" android:state_enabled="false" />
-    <item android:drawable="@drawable/format_bar_button_heading_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_heading_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_heading" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_html_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_html_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_html_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_html_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_html_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_html_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_html" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_italic_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_italic_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_italic_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_italic_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_italic_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_italic_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_italic" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_link_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_link_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_link_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_link_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_link_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_link_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_link" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_media_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_media" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_more_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_more_selector.xml
@@ -4,7 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/format_bar_button_more_disabled" android:state_enabled="false" />
-    <item android:drawable="@drawable/format_bar_button_more_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_more_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_more" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_ol_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ol_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_ol_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_ol" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_page_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_page_selector.xml
@@ -4,7 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/format_bar_button_page_disabled" android:state_enabled="false" />
-    <item android:drawable="@drawable/format_bar_button_page_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_page_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_page" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_quote_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_quote_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_quote_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_quote_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_quote_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_quote_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_quote" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_strikethrough_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_strikethrough_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_strikethrough_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_strikethrough_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_strikethrough" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_ul_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ul_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_ul_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_ul" />
 

--- a/aztec/src/main/res/drawable/format_bar_button_underline_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_underline_selector.xml
@@ -5,7 +5,6 @@
 
     <item android:drawable="@drawable/format_bar_button_underline_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_underline_highlighted" android:state_checked="true" />
-    <item android:drawable="@drawable/format_bar_button_underline_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_underline_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_underline" />
 


### PR DESCRIPTION
### Fix
Remove the pressed state color from format toolbar buttons as described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/344#issuecomment-301846859.

### Test
1. Launch demonstration app.
2. Long-press any format toolbar button.
3. Notice color remains unchanged.
4. Notice ripple effect.