### PR TITLE
Issue/337 disappearing paragraph text

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
@@ -50,7 +50,11 @@ class EndOfParagraphMarkerAdder(aztecText: AztecText, val verticalParagraphMargi
         }
     }
 
-    override fun afterTextChanged(text: Editable) {}
+    override fun afterTextChanged(text: Editable) {
+        text.getSpans(0, text.length, EndOfParagraphMarker::class.java).forEach {
+            text.setSpan(it, text.getSpanStart(it), text.getSpanEnd(it), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
 
     companion object {
         fun install(editText: AztecText, verticalParagraphMargin: Int) {


### PR DESCRIPTION
### Fix
Displays characters/lines as expected when deleting paragraphs as described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/337.

### Test
1. Enter following text manually (i.e. do not copy/paste) in visual view.
```
Aztec
is
the
best
editor.
```
2. Place cursor after "." in "editor." text.
3. Tap backspace key until all text is deleted.
4. Notice each character/line is deleted as expected.