### PR TITLE
Issue/342 image uploading scroll

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -197,7 +197,7 @@ class MainActivity : AppCompatActivity(),
         attrs.setValue("id", id)
         attrs.setValue("uploading", "true")
 
-        aztec.insertMedia(BitmapDrawable(resources, bitmap), attrs)
+        val mediaSpan = aztec.insertMedia(BitmapDrawable(resources, bitmap), attrs)
 
         val predicate = object : AztecText.AttributePredicate {
             override fun matches(attrs: Attributes): Boolean {
@@ -221,7 +221,7 @@ class MainActivity : AppCompatActivity(),
         val runnable: Runnable = Runnable {
             aztec.setOverlayLevel(predicate, 1, progress)
             aztec.updateElementAttributes(predicate, attrs)
-            aztec.refreshText()
+            aztec.updateMediaSpan(mediaSpan)
             progress += 2000
 
             if (progress >= 10000) {

--- a/app/src/main/res/layout-v17/activity_main.xml
+++ b/app/src/main/res/layout-v17/activity_main.xml
@@ -21,9 +21,7 @@
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:focusableInTouchMode="true" >
+            android:layout_height="wrap_content" >
 
             <org.wordpress.aztec.AztecText
                 android:id="@+id/aztec"

--- a/app/src/main/res/layout-v17/activity_main.xml
+++ b/app/src/main/res/layout-v17/activity_main.xml
@@ -21,7 +21,9 @@
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:focusableInTouchMode="true" >
 
             <org.wordpress.aztec.AztecText
                 android:id="@+id/aztec"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,9 +21,7 @@
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:focusableInTouchMode="true" >
+            android:layout_height="wrap_content" >
 
             <org.wordpress.aztec.AztecText
                 android:id="@+id/aztec"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,7 +21,9 @@
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:focusableInTouchMode="true" >
 
             <org.wordpress.aztec.AztecText
                 android:id="@+id/aztec"

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1022,8 +1022,8 @@ class AztecText : android.support.v7.widget.AppCompatEditText, TextWatcher, Unkn
         }
     }
 
-    fun insertMedia(drawable: Drawable?, attributes: Attributes) {
-        lineBlockFormatter.insertMedia(drawable, attributes, onMediaTappedListener)
+    fun insertMedia(drawable: Drawable?, attributes: Attributes): AztecMediaSpan {
+        return lineBlockFormatter.insertMedia(drawable, attributes, onMediaTappedListener)
     }
 
     fun removeMedia(attributePredicate: AttributePredicate) {
@@ -1057,6 +1057,10 @@ class AztecText : android.support.v7.widget.AppCompatEditText, TextWatcher, Unkn
                     attributePredicate.matches(it.attributes)
                 }
                 .firstOrNull()?.attributes = attrs
+    }
+
+    fun updateMediaSpan(mediaSpan: AztecMediaSpan) {
+        editableText.setSpan(mediaSpan, text.getSpanStart(mediaSpan), text.getSpanEnd(mediaSpan), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
     }
 
     fun setOverlayLevel(attributePredicate: AttributePredicate, index: Int, level: Int) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -778,10 +778,19 @@ class AztecText : android.support.v7.widget.AppCompatEditText, TextWatcher, Unkn
         disableTextChangedListener()
         val selStart = selectionStart
         val selEnd = selectionEnd
-        clearFocus()
+        setFocusOnParentView()
         text = editableText
         setSelection(selStart, selEnd)
         enableTextChangedListener()
+    }
+
+    fun setFocusOnParentView() {
+        if (parent is View) {
+            val parentView = parent as View
+            parentView.isFocusable = true
+            parentView.isFocusableInTouchMode = true
+            parentView.requestFocus()
+        }
     }
 
     fun removeInlineStylesFromRange(start: Int, end: Int) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -118,7 +118,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
                 if (selectionEnd < EndOfBufferMarkerAdder.safeLength(editor)) selectionEnd + 1 else selectionEnd)
     }
 
-    fun insertMedia(drawable: Drawable?, attributes: Attributes, onMediaTappedListener: OnMediaTappedListener?) {
+    fun insertMedia(drawable: Drawable?, attributes: Attributes, onMediaTappedListener: OnMediaTappedListener?): AztecMediaSpan {
         val span = AztecMediaSpan(editor.context, drawable, AztecAttributes(attributes), onMediaTappedListener, editor)
 
         val spanBeforeMedia = editableText.getSpans(selectionStart, selectionEnd, AztecBlockSpan::class.java)
@@ -164,5 +164,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
 
         editor.setSelection(mediaEndIndex)
         editor.isMediaAdded = true
+
+        return span
     }
 }


### PR DESCRIPTION
### Fix
View remains at scrolled position when uploading images as described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/313 and https://github.com/wordpress-mobile/AztecEditor-Android/issues/342.  The `clearFocus()` change in https://github.com/wordpress-mobile/AztecEditor-Android/pull/340 *does* clear the focus from the `AztecText` view, but the first focusable view (i.e. `AztecText` before this change) regains focus when the system returns from the media chooser.  By allowing the parent view to be focusable, the `AztecText` view is not focused when the activity is resumed and the view is not scrolled when the image uploading overlay is updated.

### Test
1. Place cursor near bottom of view.
2. Tap ***Media*** format button.
3. Choose image to insert.
4. Scroll to top of view.
5. Notice view does not scroll.
6. Place cursor near top of view.
7. Tap ***Media*** format button.
8. Choose image to insert.
9. Scroll to bottom of view.
10. Notice view does not scroll.