### PR TITLE
Issue/322 keep whitespaces inside pre tags

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -182,6 +182,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
 
     public int unknownTagLevel = 0;
     public Unknown unknown;
+    private boolean insidePreTag = false;
 
     private String mSource;
     private UnknownHtmlSpan.OnUnknownHtmlClickListener onUnknownHtmlClickListener;
@@ -293,6 +294,9 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
             start(spannableStringBuilder, TextFormat.FORMAT_CODE, attributes);
         } else {
             if (tagHandler != null) {
+                if(tag.equalsIgnoreCase("pre")){
+                    insidePreTag = true;
+                }
                 boolean tagHandled = tagHandler.handleTag(true, tag, spannableStringBuilder, onMediaTappedListener,
                         context, attributes, nestingLevel);
                 if (tagHandled) {
@@ -367,6 +371,9 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         } else if (tag.equalsIgnoreCase("code")) {
             end(spannableStringBuilder, TextFormat.FORMAT_CODE);
         } else if (tagHandler != null) {
+            if(tag.equalsIgnoreCase("pre")){
+                insidePreTag = false;
+            }
             tagHandler.handleTag(false, tag, spannableStringBuilder, onMediaTappedListener, context, new AztecAttributes(),
                     nestingLevel);
         }
@@ -597,14 +604,14 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         StringBuilder sb = new StringBuilder();
 
         /*
-         * Ignore whitespace that immediately follows other whitespace;
+         * Ignore whitespace that immediately follows other whitespace, unless in pre tag;
          * newlines count as spaces.
          */
 
         for (int i = 0; i < length; i++) {
             char c = ch[i + start];
 
-            if (c == ' ' || c == '\n') {
+            if (!insidePreTag &&  c == ' ' || c == '\n') {
                 char pred;
                 int len = sb.length();
 

--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -90,8 +90,11 @@ public class Html {
 
         interface Callbacks {
             void onUseDefaultImage();
+
             void onImageFailed();
+
             void onImageLoaded(Drawable drawable);
+
             void onImageLoading(Drawable drawable);
         }
     }
@@ -106,7 +109,7 @@ public class Html {
          * a tag that it does not know how to interpret.
          */
         boolean handleTag(boolean opening, String tag, Editable output, OnMediaTappedListener onMediaTappedListener,
-                Context context, Attributes attributes, int nestingLevel);
+                          Context context, Attributes attributes, int nestingLevel);
     }
 
     private Html() {
@@ -183,6 +186,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
     public int unknownTagLevel = 0;
     public Unknown unknown;
     private boolean insidePreTag = false;
+    private boolean insideCodeTag = false;
 
     private String mSource;
     private UnknownHtmlSpan.OnUnknownHtmlClickListener onUnknownHtmlClickListener;
@@ -291,12 +295,14 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         } else if (tag.equalsIgnoreCase("sub")) {
             start(spannableStringBuilder, TextFormat.FORMAT_SUBSCRIPT, attributes);
         } else if (tag.equalsIgnoreCase("code")) {
+            insideCodeTag = true;
             start(spannableStringBuilder, TextFormat.FORMAT_CODE, attributes);
         } else {
             if (tagHandler != null) {
-                if(tag.equalsIgnoreCase("pre")){
+                if (tag.equalsIgnoreCase("pre")) {
                     insidePreTag = true;
                 }
+
                 boolean tagHandled = tagHandler.handleTag(true, tag, spannableStringBuilder, onMediaTappedListener,
                         context, attributes, nestingLevel);
                 if (tagHandled) {
@@ -369,9 +375,10 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         } else if (tag.equalsIgnoreCase("sub")) {
             end(spannableStringBuilder, TextFormat.FORMAT_SUBSCRIPT);
         } else if (tag.equalsIgnoreCase("code")) {
+            insideCodeTag = false;
             end(spannableStringBuilder, TextFormat.FORMAT_CODE);
         } else if (tagHandler != null) {
-            if(tag.equalsIgnoreCase("pre")){
+            if (tag.equalsIgnoreCase("pre")) {
                 insidePreTag = false;
             }
             tagHandler.handleTag(false, tag, spannableStringBuilder, onMediaTappedListener, context, new AztecAttributes(),
@@ -611,7 +618,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         for (int i = 0; i < length; i++) {
             char c = ch[i + start];
 
-            if (!insidePreTag &&  c == ' ' || c == '\n') {
+            if (!insidePreTag && !insideCodeTag && c == ' ' || c == '\n') {
                 char pred;
                 int len = sb.length();
 

--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -611,7 +611,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         StringBuilder sb = new StringBuilder();
 
         /*
-         * Ignore whitespace that immediately follows other whitespace, unless in pre tag;
+         * Ignore whitespace that immediately follows other whitespace, unless in pre or comment tags;
          * newlines count as spaces.
          */
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
@@ -49,8 +49,7 @@ class EndOfParagraphMarkerAdder(aztecText: AztecText, val verticalParagraphMargi
         val isInsideCode = text.getSpans(inputStart, inputEnd, AztecCodeSpan::class.java).isNotEmpty()
         var insideHeading = text.getSpans(inputStart, inputEnd, AztecHeadingSpan::class.java).isNotEmpty()
 
-        if (insideHeading && (text.length > inputEnd
-                && text[inputEnd] == '\n')) {
+        if (insideHeading && (text.length > inputEnd && text[inputEnd] == '\n')) {
             insideHeading = false
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
@@ -6,6 +6,7 @@ import android.text.TextWatcher
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecHeadingSpan
 import org.wordpress.aztec.spans.AztecListItemSpan
+import org.wordpress.aztec.spans.AztecPreformatSpan
 import org.wordpress.aztec.spans.EndOfParagraphMarker
 import java.lang.ref.WeakReference
 
@@ -36,6 +37,7 @@ class EndOfParagraphMarkerAdder(aztecText: AztecText, val verticalParagraphMargi
             val inputEnd = textChangedEventDetails.inputEnd
 
             val isInsideList = aztecText.text.getSpans(inputStart, inputEnd, AztecListItemSpan::class.java).isNotEmpty()
+            val isInsidePre = aztecText.text.getSpans(inputStart, inputEnd, AztecPreformatSpan::class.java).isNotEmpty()
             var insideHeading = aztecText.text.getSpans(inputStart, inputEnd, AztecHeadingSpan::class.java).isNotEmpty()
 
             if (insideHeading && (aztecText.text.length > inputEnd
@@ -43,7 +45,7 @@ class EndOfParagraphMarkerAdder(aztecText: AztecText, val verticalParagraphMargi
                 insideHeading = false
             }
 
-            if (!isInsideList && !insideHeading) {
+            if (!isInsideList && !insideHeading && !isInsidePre) {
                 aztecText.text.setSpan(EndOfParagraphMarker(verticalParagraphMargin), inputStart, inputEnd,
                         Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
@@ -4,10 +4,7 @@ import android.text.Editable
 import android.text.Spanned
 import android.text.TextWatcher
 import org.wordpress.aztec.AztecText
-import org.wordpress.aztec.spans.AztecHeadingSpan
-import org.wordpress.aztec.spans.AztecListItemSpan
-import org.wordpress.aztec.spans.AztecPreformatSpan
-import org.wordpress.aztec.spans.EndOfParagraphMarker
+import org.wordpress.aztec.spans.*
 import java.lang.ref.WeakReference
 
 
@@ -36,20 +33,28 @@ class EndOfParagraphMarkerAdder(aztecText: AztecText, val verticalParagraphMargi
             val inputStart = textChangedEventDetails.inputStart
             val inputEnd = textChangedEventDetails.inputEnd
 
-            val isInsideList = aztecText.text.getSpans(inputStart, inputEnd, AztecListItemSpan::class.java).isNotEmpty()
-            val isInsidePre = aztecText.text.getSpans(inputStart, inputEnd, AztecPreformatSpan::class.java).isNotEmpty()
-            var insideHeading = aztecText.text.getSpans(inputStart, inputEnd, AztecHeadingSpan::class.java).isNotEmpty()
-
-            if (insideHeading && (aztecText.text.length > inputEnd
-                    && aztecText.text[inputEnd] == '\n')) {
-                insideHeading = false
-            }
-
-            if (!isInsideList && !insideHeading && !isInsidePre) {
+            if (paragraphMarkerCanBeApplied(aztecText.text)) {
                 aztecText.text.setSpan(EndOfParagraphMarker(verticalParagraphMargin), inputStart, inputEnd,
                         Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
         }
+    }
+
+    fun paragraphMarkerCanBeApplied(text: Editable): Boolean {
+        val inputStart = textChangedEventDetails.inputStart
+        val inputEnd = textChangedEventDetails.inputEnd
+
+        val isInsideList = text.getSpans(inputStart, inputEnd, AztecListItemSpan::class.java).isNotEmpty()
+        val isInsidePre = text.getSpans(inputStart, inputEnd, AztecPreformatSpan::class.java).isNotEmpty()
+        val isInsideCode = text.getSpans(inputStart, inputEnd, AztecCodeSpan::class.java).isNotEmpty()
+        var insideHeading = text.getSpans(inputStart, inputEnd, AztecHeadingSpan::class.java).isNotEmpty()
+
+        if (insideHeading && (text.length > inputEnd
+                && text[inputEnd] == '\n')) {
+            insideHeading = false
+        }
+
+        return !isInsideList && !insideHeading && !isInsidePre && !isInsideCode
     }
 
     override fun afterTextChanged(text: Editable) {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
@@ -58,7 +58,7 @@ class PreformatTest {
         safeAppend(editText, "\n")
         safeAppend(editText, "\n")
         safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\n\nsecond item</$tag>\n\nnot preformat", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
     }
 
     @Test
@@ -134,7 +134,7 @@ class PreformatTest {
         safeAppend(editText, "first item")
         safeAppend(editText, "\n")
         safeAppend(editText, "second item")
-        Assert.assertEquals("<$tag>first item\n\nsecond item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item</$tag>", editText.toHtml())
     }
 
     @Test
@@ -143,7 +143,7 @@ class PreformatTest {
         toolbar.onMenuItemClick(menuPreformat)
         editText.append("firstitem")
         editText.text.insert(5, "\n")
-        Assert.assertEquals("<$tag>first\n\nitem</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>first\nitem</$tag>", editText.toHtml())
     }
 
     @Test
@@ -152,7 +152,7 @@ class PreformatTest {
         editText.fromHtml("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>")
         val mark = editText.text.indexOf("Preformat 2") - 1
         editText.text.insert(mark, "\n")
-        Assert.assertEquals("<$tag>Preformat 1</$tag>\n<$tag>Preformat 2</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>", editText.toHtml())
     }
 
     @Test
@@ -181,7 +181,7 @@ class PreformatTest {
         editText.fromHtml("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>")
         val mark = editText.text.indexOf("Preformat 2")
         editText.text.insert(mark, "\n")
-        Assert.assertEquals("<$tag>Preformat 1</$tag><$tag>\n\nPreformat 2</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>Preformat 1</$tag><$tag>\nPreformat 2</$tag>", editText.toHtml())
     }
 
     @Test
@@ -223,7 +223,7 @@ class PreformatTest {
         val secondMark = safeLength(editText)
         safeAppend(editText, "third item")
         editText.text.delete(firstMark, secondMark - 1)
-        Assert.assertEquals("<$tag>first item\n\n\n\nthird item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\n\nthird item</$tag>", editText.toHtml())
     }
 
     @Test
@@ -236,11 +236,11 @@ class PreformatTest {
         safeAppend(editText, "\n")
         safeAppend(editText, "third item")
         safeAppend(editText, "\n")
-        Assert.assertEquals("<$tag>first item\n\nsecond item\n\nthird item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
         safeAppend(editText, "\n")
-        Assert.assertEquals("<$tag>first item\n\nsecond item\n\nthird item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
         safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\n\nsecond item\n\nthird item</$tag>\n\nnot preformat", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
     }
 
     @Test
@@ -250,7 +250,7 @@ class PreformatTest {
         val mark = editText.text.indexOf("second item") + "second item".length
         editText.text.insert(mark, "\n")
         editText.text.insert(mark + 1, "third item")
-        Assert.assertEquals("<$tag>first item\nsecond item\n\nthird item</$tag>not preformat", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
     }
 
     @Test
@@ -289,17 +289,17 @@ class PreformatTest {
         editText.setSelection(safeLength(editText))
         safeAppend(editText, "\n")
         safeAppend(editText, "third item")
-        Assert.assertEquals("<$tag>first item\nsecond item\n\nthird item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
         safeAppend(editText, "\n")
         safeAppend(editText, "\n")
         val mark = safeLength(editText) - 1
         safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\nsecond item\n\nthird item</$tag>\n\nnot preformat", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
         safeAppend(editText, "\n")
         safeAppend(editText, "foo")
-        Assert.assertEquals("<$tag>first item\nsecond item\n\nthird item</$tag>\n\nnot preformat\n\nfoo", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat\n\nfoo", editText.toHtml())
         editText.text.delete(mark, mark + 1)
-        Assert.assertEquals("<$tag>first item\nsecond item\n\nthird itemnot preformat</$tag>\n\nfoo", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item\nthird itemnot preformat</$tag>\n\nfoo", editText.toHtml())
     }
 
     @Test
@@ -316,7 +316,7 @@ class PreformatTest {
         editText.text.insert(editText.text.indexOf("not preformat") - 1, "\n")
         editText.text.insert(editText.text.indexOf("not preformat") - 1, "third item")
         Assert.assertEquals("first item\nsecond item addition\nthird item\nnot preformat", editText.text.toString())
-        Assert.assertEquals("<$tag>first item\nsecond item addition\n\nthird item</$tag>not preformat", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item addition\nthird item</$tag>not preformat", editText.toHtml())
     }
 
     @Test
@@ -330,9 +330,9 @@ class PreformatTest {
         safeAppend(editText, "\n")
         safeAppend(editText, "\n")
         safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\n\nsecond item</$tag>\n\nnot preformat", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
         editText.text.insert(mark, " (addition)")
-        Assert.assertEquals("<$tag>first item\n\nsecond item (addition)</$tag>\n\nnot preformat", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\nsecond item (addition)</$tag>not preformat", editText.toHtml())
     }
 
     @Test
@@ -344,7 +344,7 @@ class PreformatTest {
         safeAppend(editText, "second item")
         editText.setSelection(0)
         editText.text.insert(0, "addition ")
-        Assert.assertEquals("<$tag>addition first item\n\nsecond item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>addition first item\nsecond item</$tag>", editText.toHtml())
     }
 
     @Test
@@ -359,7 +359,7 @@ class PreformatTest {
         safeAppend(editText, "second item")
         editText.setSelection(mark)
         editText.text.insert(mark, "addition ")
-        Assert.assertEquals("not preformat\n<$tag>addition first item\n\nsecond item</$tag>", editText.toHtml())
+        Assert.assertEquals("not preformat\n<$tag>addition first item\nsecond item</$tag>", editText.toHtml())
     }
 
     @Test
@@ -377,8 +377,8 @@ class PreformatTest {
         Assert.assertEquals("first item\nsecond item\nthird item", editText.text.toString())
         editText.text.delete(firstMark + 1, secondMark)
         Assert.assertEquals("first item\n\nthird item", editText.text.toString())
-        Assert.assertEquals("<$tag>first item\n\n\n\nthird item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>first item\n\nthird item</$tag>", editText.toHtml())
         editText.text.delete(0, firstMark)
-        Assert.assertEquals("<$tag>\n\n\n\nthird item</$tag>", editText.toHtml())
+        Assert.assertEquals("<$tag>\n\nthird item</$tag>", editText.toHtml())
     }
 }


### PR DESCRIPTION
### Fixes #322 

This PR preserves spaces and newlines in `<pre>` and `<code>` tags.
In addition, instead of adding a paragraph on the press of enter key, it adds a regular newline.

The problem of preserving spaces inside blockquotes is more related to #338, so I will try to address it there.

To test:
Try to add spaces or newlines to content inside `<pre>` or `<code>` tags.
Switch to HTML and back, notice that newlines and spaces are preserved.