### PR TITLE
Ability to add paragraph to the first line of editor.

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfParagraphMarkerAdder.kt
@@ -25,7 +25,7 @@ class EndOfParagraphMarkerAdder(aztecText: AztecText, val verticalParagraphMargi
         textChangedEventDetails.start = start
         textChangedEventDetails.initialize()
 
-        if (!textChangedEventDetails.isNewLineButNotAtTheBeginning()) return
+        if (!textChangedEventDetails.isNewLine()) return
 
         val aztecText = aztecTextRef.get()
         if (aztecText != null && !aztecText.isTextChangedListenerDisabled() && aztecText.isInCalypsoMode) {


### PR DESCRIPTION
### Fix #350 

Adds ability to add a paragraph to the previous line when pressing enter at 0 index.

### Test
1. Load empty editor and type some text.
2. Place cursor at the beginning of editor and press enter.
3. Notice that the first line in editor is a paragraph (has vertical padding)