### PR TITLE
Issue/237 inline style stop

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -27,6 +27,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AlertDialog
+import android.support.v7.widget.AppCompatAutoCompleteTextView
 import android.text.*
 import android.text.style.ParagraphStyle
 import android.text.style.SuggestionSpan
@@ -54,7 +55,7 @@ import org.xml.sax.Attributes
 import java.util.*
 
 @Suppress("UNUSED_PARAMETER")
-class AztecText : android.support.v7.widget.AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListener {
+class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListener {
 
     companion object {
         val BLOCK_EDITOR_HTML_KEY = "RETAINED_BLOCK_HTML_KEY"

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -69,7 +69,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle) : AztecFormat
                 val spanStart = editableText.getSpanStart(it)
                 val spanEnd = editableText.getSpanEnd(it)
 
-                if ((spanStart == start || spanEnd == count + start) && spanEnd < after) {
+                if ((spanStart == start || spanEnd == count + start) && (spanEnd - spanStart) < after) {
                     editableText.removeSpan(it)
                     carryOverSpans.add(CarryOverSpan(it, spanStart, spanEnd))
                 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -249,6 +249,126 @@ class AztecToolbarTest {
     }
 
     /**
+     * Test inline style when applying and removing styles while typing.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun testInlineStyleWhileTyping() {
+        // Clear text
+        editText.setText("")
+
+        // Bold
+        boldButton.performClick()
+        editText.append("Bo")
+        boldButton.performClick()
+        editText.append("ld")
+        Assert.assertEquals("<b>Bo</b>ld", editText.toHtml())
+
+        // Italic
+        italicButton.performClick()
+        editText.append("Ita")
+        italicButton.performClick()
+        editText.append("lic")
+        Assert.assertEquals("<b>Bo</b>ld<i>Ita</i>lic", editText.toHtml())
+
+        // Strike
+        strikeThroughButton.performClick()
+        editText.append("Str")
+        strikeThroughButton.performClick()
+        editText.append("ike")
+        Assert.assertEquals("<b>Bo</b>ld<i>Ita</i>lic<del>Str</del>ike", editText.toHtml())
+
+        // Underline
+        underlineButton.performClick()
+        editText.append("Under")
+        underlineButton.performClick()
+        editText.append("line")
+        Assert.assertEquals("<b>Bo</b>ld<i>Ita</i>lic<del>Str</del>ike<u>Under</u>line", editText.toHtml())
+
+        // Clear text
+        editText.setText("")
+
+        // Bold
+        editText.append("Bo")
+        boldButton.performClick()
+        editText.append("ld")
+        boldButton.performClick()
+        Assert.assertEquals("Bo<b>ld</b>", editText.toHtml())
+
+        // Italic
+        editText.append("Ita")
+        italicButton.performClick()
+        editText.append("lic")
+        italicButton.performClick()
+        Assert.assertEquals("Bo<b>ld</b>Ita<i>lic</i>", editText.toHtml())
+
+        // Strike
+        editText.append("Str")
+        strikeThroughButton.performClick()
+        editText.append("ike")
+        strikeThroughButton.performClick()
+        Assert.assertEquals("Bo<b>ld</b>Ita<i>lic</i>Str<del>ike</del>", editText.toHtml())
+
+        // Underline
+        editText.append("Under")
+        underlineButton.performClick()
+        editText.append("line")
+        underlineButton.performClick()
+        Assert.assertEquals("Bo<b>ld</b>Ita<i>lic</i>Str<del>ike</del>Under<u>line</u>", editText.toHtml())
+    }
+
+    /**
+     * Test inline style when applying and removing styles while typing with spaces.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun testInlineStyleWhileTypingWithSpaces() {
+        // Space
+        editText.setText(" ")
+
+        // Bold
+        boldButton.performClick()
+        editText.append("Bo")
+        boldButton.performClick()
+        editText.append("ld")
+        Assert.assertEquals(" <b>Bo</b>ld", editText.toHtml())
+
+        // Space
+        editText.append(" ")
+
+        // Italic
+        italicButton.performClick()
+        editText.append("Ita")
+        italicButton.performClick()
+        editText.append("lic")
+        Assert.assertEquals(" <b>Bo</b>ld <i>Ita</i>lic", editText.toHtml())
+
+        // Space
+        editText.append(" ")
+
+        // Strike
+        strikeThroughButton.performClick()
+        editText.append("Str")
+        strikeThroughButton.performClick()
+        editText.append("ike")
+        Assert.assertEquals(" <b>Bo</b>ld <i>Ita</i>lic <del>Str</del>ike", editText.toHtml())
+
+        // Space
+        editText.append(" ")
+
+        // Underline
+        underlineButton.performClick()
+        editText.append("Under")
+        underlineButton.performClick()
+        editText.append("line")
+        Assert.assertEquals(" <b>Bo</b>ld <i>Ita</i>lic <del>Str</del>ike <u>Under</u>line", editText.toHtml())
+    }
+
+    /**
      * Select parts of text and apply formatting to it.
      *
      * @throws Exception


### PR DESCRIPTION
### Fix
Allow inline style to be removed in the middle of text as described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/237.

### Test
1. Type "H" letter.
2. Type "e" letter.
3. Type "l" letter.
4. Type "l" letter.
5. Type "o" letter.
6. Type "," character.
7. Tap ***Space*** key.
8. Tap ***Italic*** format button.
9. Type "W" letter.
10. Type "o" letter.
11. Type "r" letter.
12. Type "l" letter.
13. Type "d" letter.
14. Tap ***Italic*** format button.
15. Type "!" character.
16. Tap ***Space*** key.
17. Tap ***Space*** key.
18. Tap ***Strikethrough*** format button.
19. Type "I" letter.
20. Type "n" letter.
21. Tap ***Strikethrough*** format button.
22. Type "l" letter.
23. Type "i" letter.
24. Type "n" letter.
25. Type "e" letter.
26. Tap ***Space*** key.
27. Type "s" letter.
28. Type "t" letter.
29. Type "y" letter.
30. Type "l" letter.
31. Type "e" letter.
32. Tap ***Space*** key.
33. Tap ***Bold*** format button.
34. Tap ***Italic*** format button.
35. Type "w" letter.
36. Type "o" letter.
37. Type "r" letter.
38. Type "k" letter.
39. Type "s" letter.
40. Tap ***Bold*** format button.
41. Tap ***Italic*** format button.
42. Type "!" character.
43. Type "?" character.
44. Tap ***HTML*** format button.
45. Notice following HTML.
```
Hello, <i>World</i>!  <del>In</del>line style <b><i>works</i></b>!?
```