### PR TITLE
Issue/366 remove excluded features

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -377,7 +377,8 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                     TextFormat.FORMAT_HEADING_4 -> headingMenu?.menu?.getItem(4)?.isChecked = true
                     TextFormat.FORMAT_HEADING_5 -> headingMenu?.menu?.getItem(5)?.isChecked = true
                     TextFormat.FORMAT_HEADING_6 -> headingMenu?.menu?.getItem(6)?.isChecked = true
-                    TextFormat.FORMAT_PREFORMAT -> headingMenu?.menu?.getItem(7)?.isChecked = true
+//                    TODO: Uncomment when Preformat is to be added back as a feature
+//                    TextFormat.FORMAT_PREFORMAT -> headingMenu?.menu?.getItem(7)?.isChecked = true
                     else -> {
                         // Select TextFormat.FORMAT_PARAGRAPH by default.
                         headingMenu?.menu?.getItem(0)?.isChecked = true
@@ -407,7 +408,8 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         else if (headingMenu?.menu?.getItem(4)?.isChecked!!) return TextFormat.FORMAT_HEADING_4
         else if (headingMenu?.menu?.getItem(5)?.isChecked!!) return TextFormat.FORMAT_HEADING_5
         else if (headingMenu?.menu?.getItem(6)?.isChecked!!) return TextFormat.FORMAT_HEADING_6
-        else if (headingMenu?.menu?.getItem(7)?.isChecked!!) return TextFormat.FORMAT_PREFORMAT
+//        TODO: Uncomment when Preformat is to be added back as a feature
+//        else if (headingMenu?.menu?.getItem(7)?.isChecked!!) return TextFormat.FORMAT_PREFORMAT
         return null
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -219,10 +219,11 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                 editor?.toggleFormatting(TextFormat.FORMAT_HEADING_6)
                 return true
             }
-            R.id.preformat -> {
-                editor?.toggleFormatting(TextFormat.FORMAT_PREFORMAT)
-                return true
-            }
+//            TODO: Uncomment when Preformat is to be added back as a feature
+//            R.id.preformat -> {
+//                editor?.toggleFormatting(TextFormat.FORMAT_PREFORMAT)
+//                return true
+//            }
             else -> return false
         }
     }

--- a/aztec/src/main/res/layout/aztec_format_bar.xml
+++ b/aztec/src/main/res/layout/aztec_format_bar.xml
@@ -139,12 +139,14 @@
                     style="@style/FormatBarButton" >
                 </org.wordpress.aztec.toolbar.RippleToggleButton>
 
+                <!--TODO: Remove android:visibility="gone" when Page Break is to be added back as a feature-->
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_page"
                     android:background="@drawable/format_bar_button_page_selector"
                     android:contentDescription="@string/format_bar_description_page"
                     android:layout_height="fill_parent"
                     android:layout_width="wrap_content"
+                    android:visibility="gone"
                     style="@style/FormatBarButton" >
                 </org.wordpress.aztec.toolbar.RippleToggleButton>
 

--- a/aztec/src/main/res/menu/heading.xml
+++ b/aztec/src/main/res/menu/heading.xml
@@ -40,10 +40,11 @@
             android:title="@string/heading_6" >
         </item>
 
-        <item
-            android:id="@+id/preformat"
-            android:title="@string/preformat" >
-        </item>
+        <!--TODO: Uncomment when Preformat is to be added back as a feature-->
+        <!--<item-->
+            <!--android:id="@+id/preformat"-->
+            <!--android:title="@string/preformat" >-->
+        <!--</item>-->
 
     </group>
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
@@ -31,7 +31,8 @@ class HeadingTest {
     lateinit var menuHeading1: MenuItem
     lateinit var menuHeading2: MenuItem
     lateinit var menuParagraph: MenuItem
-    lateinit var menuPreformat: MenuItem
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    lateinit var menuPreformat: MenuItem
 
     /**
      * Initialize variables.
@@ -50,7 +51,8 @@ class HeadingTest {
         menuHeading1 = menuHeading.menu.getItem(1)
         menuHeading2 = menuHeading.menu.getItem(2)
         menuParagraph = menuHeading.menu.getItem(0)
-        menuPreformat = menuHeading.menu.getItem(7)
+//        TODO: Uncomment when Preformat is to be added back as a feature
+//        menuPreformat = menuHeading.menu.getItem(7)
         activity.setContentView(editText)
     }
 
@@ -63,14 +65,15 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun applyPreformatToSingleLine() {
-        safeAppend(editText, "Preformat")
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<pre>Preformat</pre>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun applyPreformatToSingleLine() {
+//        safeAppend(editText, "Preformat")
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<pre>Preformat</pre>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -82,15 +85,16 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun applyPreformatToPartiallySelectedText() {
-        safeAppend(editText, "Preformat")
-        editText.setSelection(1, editText.length() - 2)
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<pre>Preformat</pre>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun applyPreformatToPartiallySelectedText() {
+//        safeAppend(editText, "Preformat")
+//        editText.setSelection(1, editText.length() - 2)
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<pre>Preformat</pre>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -104,17 +108,18 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun applyPreformatToSelectedMultilineText() {
-        safeAppend(editText, "First line")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "Second line")
-        editText.setSelection(3, editText.length() - 3)
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<pre>First line<br>Second line</pre>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun applyPreformatToSelectedMultilineText() {
+//        safeAppend(editText, "First line")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "Second line")
+//        editText.setSelection(3, editText.length() - 3)
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<pre>First line<br>Second line</pre>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -126,15 +131,16 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun prependTextToPreformat() {
-        safeAppend(editText, "Preformat")
-        toolbar.onMenuItemClick(menuPreformat)
-        editText.text.insert(0, "inserted")
-        Assert.assertEquals("<pre>insertedPreformat</pre>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun prependTextToPreformat() {
+//        safeAppend(editText, "Preformat")
+//        toolbar.onMenuItemClick(menuPreformat)
+//        editText.text.insert(0, "inserted")
+//        Assert.assertEquals("<pre>insertedPreformat</pre>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -243,15 +249,16 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_2, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun changeHeadingToPreformatOfSingleLine() {
-        editText.fromHtml("<h1 foo=\"bar\">Text</h1>")
-        toolbar.onMenuItemClick(menuHeading1)
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<pre foo=\"bar\">Text</pre>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun changeHeadingToPreformatOfSingleLine() {
+//        editText.fromHtml("<h1 foo=\"bar\">Text</h1>")
+//        toolbar.onMenuItemClick(menuHeading1)
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<pre foo=\"bar\">Text</pre>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -263,18 +270,19 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_2, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun changeHeadingToParagraphToPreformatOfSelectedMultilineText() {
-        editText.fromHtml("<h1 foo=\"bar\">Heading 1</h1><pre>Preformat</pre>")
-        editText.setSelection(0, safeLength(editText))
-        toolbar.onMenuItemClick(menuParagraph)
-        Assert.assertEquals("Heading 1<br>Preformat", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<pre>Heading 1<br>Preformat</pre>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun changeHeadingToParagraphToPreformatOfSelectedMultilineText() {
+//        editText.fromHtml("<h1 foo=\"bar\">Heading 1</h1><pre>Preformat</pre>")
+//        editText.setSelection(0, safeLength(editText))
+//        toolbar.onMenuItemClick(menuParagraph)
+//        Assert.assertEquals("Heading 1<br>Preformat", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<pre>Heading 1<br>Preformat</pre>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -295,14 +303,15 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun applyPreformatToTextInsideQuote() {
-        editText.fromHtml("<blockquote>Quote</blockquote>")
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<blockquote><pre>Quote</pre></blockquote>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun applyPreformatToTextInsideQuote() {
+//        editText.fromHtml("<blockquote>Quote</blockquote>")
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<blockquote><pre>Quote</pre></blockquote>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -329,14 +338,15 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun applyPreformatToQuote() {
-        editText.fromHtml("<blockquote>Quote</blockquote>")
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<blockquote><pre>Quote</pre></blockquote>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun applyPreformatToQuote() {
+//        editText.fromHtml("<blockquote>Quote</blockquote>")
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<blockquote><pre>Quote</pre></blockquote>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -349,19 +359,20 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun applyPreformatToTextSurroundedByLists() {
-        editText.fromHtml("<ol><li>Ordered</li></ol>Preformat<ol><li>Ordered</li></ol>")
-        val mark = editText.text.indexOf("format")
-        editText.setSelection(mark)
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<ol><li>Ordered</li></ol><pre>Preformat</pre><ol><li>Ordered</li></ol>", editText.toHtml())
-//        TODO: Correct heading menu selection.  This is incorrect.  Preformat should be selected.
-//        https://github.com/wordpress-mobile/AztecEditor-Android/issues/317
-//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun applyPreformatToTextSurroundedByLists() {
+//        editText.fromHtml("<ol><li>Ordered</li></ol>Preformat<ol><li>Ordered</li></ol>")
+//        val mark = editText.text.indexOf("format")
+//        editText.setSelection(mark)
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<ol><li>Ordered</li></ol><pre>Preformat</pre><ol><li>Ordered</li></ol>", editText.toHtml())
+////        TODO: Correct heading menu selection.  This is incorrect.  Preformat should be selected.
+////        https://github.com/wordpress-mobile/AztecEditor-Android/issues/317
+////        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//        Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -374,16 +385,17 @@ class HeadingTest {
         Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun applyPreformatToTextSurroundedByQuotes() {
-        editText.fromHtml("<blockquote>Quote</blockquote>Preformat<blockquote>Quote</blockquote>")
-        val mark = editText.text.indexOf("format")
-        editText.setSelection(mark)
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<blockquote>Quote</blockquote><pre>Preformat</pre><blockquote>Quote</blockquote>", editText.toHtml())
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
-    }
+//    TODO: Uncomment when Preformat is to be added back as a feature
+//    @Test
+//    @Throws(Exception::class)
+//    fun applyPreformatToTextSurroundedByQuotes() {
+//        editText.fromHtml("<blockquote>Quote</blockquote>Preformat<blockquote>Quote</blockquote>")
+//        val mark = editText.text.indexOf("format")
+//        editText.setSelection(mark)
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<blockquote>Quote</blockquote><pre>Preformat</pre><blockquote>Quote</blockquote>", editText.toHtml())
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//    }
 
     @Test
     @Throws(Exception::class)
@@ -487,9 +499,10 @@ class HeadingTest {
         editText.setSelection(cursor)
         Assert.assertEquals(TextFormat.FORMAT_PARAGRAPH, toolbar.getSelectedHeadingMenuItem())
 
-        cursor = editText.text.indexOf("format")
-        editText.setSelection(cursor)
-        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
+//        TODO: Uncomment when Preformat is to be added back as a feature
+//        cursor = editText.text.indexOf("format")
+//        editText.setSelection(cursor)
+//        Assert.assertEquals(TextFormat.FORMAT_PREFORMAT, toolbar.getSelectedHeadingMenuItem())
     }
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
@@ -1,384 +1,368 @@
 package org.wordpress.aztec
 
-import android.app.Activity
-import android.view.MenuItem
-import android.widget.PopupMenu
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import org.wordpress.aztec.TestUtils.safeAppend
-import org.wordpress.aztec.TestUtils.safeEmpty
-import org.wordpress.aztec.TestUtils.safeLength
-import org.wordpress.aztec.source.SourceViewEditText
-import org.wordpress.aztec.toolbar.AztecToolbar
-
-/**
- * Testing preformat behavior.
- */
-@RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
-class PreformatTest {
-
-    val tag = "pre"
-
-    lateinit var editText: AztecText
-    lateinit var sourceText: SourceViewEditText
-    lateinit var toolbar: AztecToolbar
-    lateinit var menuHeading: PopupMenu
-    lateinit var menuParagraph: MenuItem
-    lateinit var menuPreformat: MenuItem
-
-    /**
-     * Initialize variables.
-     */
-    @Before
-    fun init() {
-        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
-        editText = AztecText(activity)
-        sourceText = SourceViewEditText(activity)
-        toolbar = AztecToolbar(activity)
-        toolbar.setEditor(editText, sourceText)
-        menuHeading = toolbar.getHeadingMenu() as PopupMenu
-        menuParagraph = menuHeading.menu.getItem(0)
-        menuPreformat = menuHeading.menu.getItem(7)
-        activity.setContentView(editText)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun closePreformatWithText() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun closePreformatWithoutText() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "\n")
-        Assert.assertEquals("", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun styleSingleItem() {
-        safeAppend(editText, "first item")
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<$tag>first item</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun styleMultipleSelectedItems() {
-        safeEmpty(editText)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "third item")
-        editText.setSelection(0, safeLength(editText))
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<$tag>first item\n\nsecond item\n\nthird item</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun stylePartiallySelectedMultipleItems() {
-        safeEmpty(editText)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "third item")
-        editText.setSelection(4, 15) // partially select first and second item
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<$tag>first item\n\nsecond item</$tag>\n\nthird item", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun styleSurroundedItem() {
-        safeEmpty(editText)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "third item")
-        editText.setSelection(14)
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("first item\n<$tag>second item</$tag>\n\nthird item", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun styleSingleEnteredItem() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        Assert.assertEquals("<$tag>first item</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun styleMultipleEnteredItems() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        Assert.assertEquals("<$tag>first item\nsecond item</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun extendingPreformatBySplittingItems() {
-        toolbar.onMenuItemClick(menuPreformat)
-        editText.append("firstitem")
-        editText.text.insert(5, "\n")
-        Assert.assertEquals("<$tag>first\nitem</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun splitTwoPreformatsWithNewline() {
-        editText.fromHtml("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>")
-        val mark = editText.text.indexOf("Preformat 2") - 1
-        editText.text.insert(mark, "\n")
-        Assert.assertEquals("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun switchHeadingToPreformat() {
-        editText.fromHtml("<h3>First<br>Second<br>Third</h3>")
-        editText.setSelection(editText.text.indexOf("ond"))
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<$tag>First\nSecond\nThird</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun switchPreformatToHeading() {
-        editText.fromHtml("<$tag>First<br>Second<br>Third</$tag>")
-        editText.setSelection(editText.text.indexOf("ond"))
-        val menuHeading3 = menuHeading.menu.getItem(3) // Heading 3, i.e. <h3>
-        toolbar.onMenuItemClick(menuHeading3)
-        val tagHeading = "h3"
-        Assert.assertEquals("<$tagHeading>First\nSecond\nThird</$tagHeading>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun newlineAtStartOfPreformat() {
-        editText.fromHtml("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>")
-        val mark = editText.text.indexOf("Preformat 2")
-        editText.text.insert(mark, "\n")
-        Assert.assertEquals("<$tag>Preformat 1</$tag><$tag>\nPreformat 2</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun removeStyleFromEmptyPreformat() {
-        toolbar.onMenuItemClick(menuPreformat)
-        Assert.assertEquals("<$tag></$tag>", editText.toHtml())
-        toolbar.onMenuItemClick(menuParagraph)
-        Assert.assertEquals("", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun removeStyleFromNonEmptyPreformat() {
-        editText.fromHtml("<$tag>first item</$tag>")
-        editText.setSelection(1)
-        toolbar.onMenuItemClick(menuParagraph)
-        Assert.assertEquals("first item", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun removePreformatStylingForPartialSelection() {
-        editText.fromHtml("<$tag>first item</$tag>")
-        editText.setSelection(2, 4)
-        toolbar.onMenuItemClick(menuParagraph)
-        Assert.assertEquals("first item", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun emptyPreformatSurroundedBytItems() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        val firstMark = safeLength(editText)
-        safeAppend(editText, "second item")
-        safeAppend(editText, "\n")
-        val secondMark = safeLength(editText)
-        safeAppend(editText, "third item")
-        editText.text.delete(firstMark, secondMark - 1)
-        Assert.assertEquals("<$tag>first item\n\nthird item</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun trailingEmptyLine() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "third item")
-        safeAppend(editText, "\n")
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
-        safeAppend(editText, "\n")
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
-        safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun openPreformatByAddingNewline() {
-        editText.fromHtml("<$tag>first item<br>second item</$tag>not preformat")
-        val mark = editText.text.indexOf("second item") + "second item".length
-        editText.text.insert(mark, "\n")
-        editText.text.insert(mark + 1, "third item")
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun openPreformatByAppendingTextToTheEnd() {
-        editText.fromHtml("<$tag>first item<br>second item</$tag>not preformat")
-        editText.setSelection(safeLength(editText))
-        editText.text.insert(editText.text.indexOf("\nnot preformat"), " (appended)")
-        Assert.assertEquals("<$tag>first item\nsecond item (appended)</$tag>not preformat", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun openPreformatByMovingOutsideTextInsideIt() {
-        editText.fromHtml("<$tag>first item<br>second item</$tag>")
-        safeAppend(editText, "not preformat")
-        editText.text.delete(editText.text.indexOf("not preformat"), editText.text.indexOf("not preformat"))
-        Assert.assertEquals("<$tag>first item\nsecond itemnot preformat</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun remainClosedWhenLastCharacterIsDeleted() {
-        editText.fromHtml("<$tag>first item<br>second item</$tag>not preformat")
-        editText.setSelection(safeLength(editText))
-        val mark = editText.text.indexOf("second item") + "second item".length
-        //delete last character from "second item"
-        editText.text.delete(mark - 1, mark)
-        Assert.assertEquals("<$tag>first item\nsecond ite</$tag>not preformat", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun openingAndReopeningOfPreformat() {
-        editText.fromHtml("<$tag>first item<br>second item</$tag>")
-        editText.setSelection(safeLength(editText))
-        safeAppend(editText, "\n")
-        safeAppend(editText, "third item")
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
-        safeAppend(editText, "\n")
-        safeAppend(editText, "\n")
-        val mark = safeLength(editText) - 1
-        safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
-        safeAppend(editText, "\n")
-        safeAppend(editText, "foo")
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat\n\nfoo", editText.toHtml())
-        editText.text.delete(mark, mark + 1)
-        Assert.assertEquals("<$tag>first item\nsecond item\nthird itemnot preformat</$tag>\n\nfoo", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun handlePreformatReopeningAfterLastElementDeletion() {
-        editText.fromHtml("<$tag>first item<br>second item<br>third item</$tag>")
-        editText.setSelection(safeLength(editText))
-        editText.text.delete(editText.text.indexOf("third item", 0), safeLength(editText))
-        safeAppend(editText, "\n")
-        safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
-        editText.text.insert(editText.text.indexOf("not preformat") - 1, " addition")
-        Assert.assertEquals("<$tag>first item\nsecond item addition</$tag>not preformat", editText.toHtml())
-        editText.text.insert(editText.text.indexOf("not preformat") - 1, "\n")
-        editText.text.insert(editText.text.indexOf("not preformat") - 1, "third item")
-        Assert.assertEquals("first item\nsecond item addition\nthird item\nnot preformat", editText.text.toString())
-        Assert.assertEquals("<$tag>first item\nsecond item addition\nthird item</$tag>not preformat", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun additionToClosedPreformat() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        val mark = safeLength(editText)
-        safeAppend(editText, "\n")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "not preformat")
-        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
-        editText.text.insert(mark, " (addition)")
-        Assert.assertEquals("<$tag>first item\nsecond item (addition)</$tag>not preformat", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun appendToPreformatFromTopAtFirstLine() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        editText.setSelection(0)
-        editText.text.insert(0, "addition ")
-        Assert.assertEquals("<$tag>addition first item\nsecond item</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun appendToPreformatFromTop() {
-        safeAppend(editText, "not preformat")
-        safeAppend(editText, "\n")
-        toolbar.onMenuItemClick(menuPreformat)
-        val mark = editText.length() - 1
-        safeAppend(editText, "first item")
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        editText.setSelection(mark)
-        editText.text.insert(mark, "addition ")
-        Assert.assertEquals("not preformat\n<$tag>addition first item\nsecond item</$tag>", editText.toHtml())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun deleteFirstItemWithKeyboard() {
-        toolbar.onMenuItemClick(menuPreformat)
-        safeAppend(editText, "first item")
-        val firstMark = safeLength(editText)
-        safeAppend(editText, "\n")
-        safeAppend(editText, "second item")
-        val secondMark = safeLength(editText)
-        safeAppend(editText, "\n")
-        safeAppend(editText, "third item")
-        editText.setSelection(0)
-        Assert.assertEquals("first item\nsecond item\nthird item", editText.text.toString())
-        editText.text.delete(firstMark + 1, secondMark)
-        Assert.assertEquals("first item\n\nthird item", editText.text.toString())
-        Assert.assertEquals("<$tag>first item\n\nthird item</$tag>", editText.toHtml())
-        editText.text.delete(0, firstMark)
-        Assert.assertEquals("<$tag>\n\nthird item</$tag>", editText.toHtml())
-    }
-}
+//TODO: Uncomment when Preformat is to be added back as a feature
+///**
+// * Testing preformat behavior.
+// */
+//@RunWith(RobolectricTestRunner::class)
+//@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+//class PreformatTest {
+//    val tag = "pre"
+//
+//    lateinit var editText: AztecText
+//    lateinit var sourceText: SourceViewEditText
+//    lateinit var toolbar: AztecToolbar
+//    lateinit var menuHeading: PopupMenu
+//    lateinit var menuParagraph: MenuItem
+//    lateinit var menuPreformat: MenuItem
+//
+//    /**
+//     * Initialize variables.
+//     */
+//    @Before
+//    fun init() {
+//        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+//        editText = AztecText(activity)
+//        sourceText = SourceViewEditText(activity)
+//        toolbar = AztecToolbar(activity)
+//        toolbar.setEditor(editText, sourceText)
+//        menuHeading = toolbar.getHeadingMenu() as PopupMenu
+//        menuParagraph = menuHeading.menu.getItem(0)
+//        menuPreformat = menuHeading.menu.getItem(7)
+//        activity.setContentView(editText)
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun closePreformatWithText() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "not preformat")
+//        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun closePreformatWithoutText() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "\n")
+//        Assert.assertEquals("", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun styleSingleItem() {
+//        safeAppend(editText, "first item")
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<$tag>first item</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun styleMultipleSelectedItems() {
+//        safeEmpty(editText)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "third item")
+//        editText.setSelection(0, safeLength(editText))
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<$tag>first item\n\nsecond item\n\nthird item</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun stylePartiallySelectedMultipleItems() {
+//        safeEmpty(editText)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "third item")
+//        editText.setSelection(4, 15) // partially select first and second item
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<$tag>first item\n\nsecond item</$tag>\n\nthird item", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun styleSurroundedItem() {
+//        safeEmpty(editText)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "third item")
+//        editText.setSelection(14)
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("first item\n<$tag>second item</$tag>\n\nthird item", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun styleSingleEnteredItem() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        Assert.assertEquals("<$tag>first item</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun styleMultipleEnteredItems() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        Assert.assertEquals("<$tag>first item\nsecond item</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun extendingPreformatBySplittingItems() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        editText.append("firstitem")
+//        editText.text.insert(5, "\n")
+//        Assert.assertEquals("<$tag>first\nitem</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun splitTwoPreformatsWithNewline() {
+//        editText.fromHtml("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>")
+//        val mark = editText.text.indexOf("Preformat 2") - 1
+//        editText.text.insert(mark, "\n")
+//        Assert.assertEquals("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun switchHeadingToPreformat() {
+//        editText.fromHtml("<h3>First<br>Second<br>Third</h3>")
+//        editText.setSelection(editText.text.indexOf("ond"))
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<$tag>First\nSecond\nThird</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun switchPreformatToHeading() {
+//        editText.fromHtml("<$tag>First<br>Second<br>Third</$tag>")
+//        editText.setSelection(editText.text.indexOf("ond"))
+//        val menuHeading3 = menuHeading.menu.getItem(3) // Heading 3, i.e. <h3>
+//        toolbar.onMenuItemClick(menuHeading3)
+//        val tagHeading = "h3"
+//        Assert.assertEquals("<$tagHeading>First\nSecond\nThird</$tagHeading>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun newlineAtStartOfPreformat() {
+//        editText.fromHtml("<$tag>Preformat 1</$tag><$tag>Preformat 2</$tag>")
+//        val mark = editText.text.indexOf("Preformat 2")
+//        editText.text.insert(mark, "\n")
+//        Assert.assertEquals("<$tag>Preformat 1</$tag><$tag>\nPreformat 2</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun removeStyleFromEmptyPreformat() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        Assert.assertEquals("<$tag></$tag>", editText.toHtml())
+//        toolbar.onMenuItemClick(menuParagraph)
+//        Assert.assertEquals("", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun removeStyleFromNonEmptyPreformat() {
+//        editText.fromHtml("<$tag>first item</$tag>")
+//        editText.setSelection(1)
+//        toolbar.onMenuItemClick(menuParagraph)
+//        Assert.assertEquals("first item", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun removePreformatStylingForPartialSelection() {
+//        editText.fromHtml("<$tag>first item</$tag>")
+//        editText.setSelection(2, 4)
+//        toolbar.onMenuItemClick(menuParagraph)
+//        Assert.assertEquals("first item", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun emptyPreformatSurroundedBytItems() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        val firstMark = safeLength(editText)
+//        safeAppend(editText, "second item")
+//        safeAppend(editText, "\n")
+//        val secondMark = safeLength(editText)
+//        safeAppend(editText, "third item")
+//        editText.text.delete(firstMark, secondMark - 1)
+//        Assert.assertEquals("<$tag>first item\n\nthird item</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun trailingEmptyLine() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "third item")
+//        safeAppend(editText, "\n")
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
+//        safeAppend(editText, "\n")
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
+//        safeAppend(editText, "not preformat")
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun openPreformatByAddingNewline() {
+//        editText.fromHtml("<$tag>first item<br>second item</$tag>not preformat")
+//        val mark = editText.text.indexOf("second item") + "second item".length
+//        editText.text.insert(mark, "\n")
+//        editText.text.insert(mark + 1, "third item")
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun openPreformatByAppendingTextToTheEnd() {
+//        editText.fromHtml("<$tag>first item<br>second item</$tag>not preformat")
+//        editText.setSelection(safeLength(editText))
+//        editText.text.insert(editText.text.indexOf("\nnot preformat"), " (appended)")
+//        Assert.assertEquals("<$tag>first item\nsecond item (appended)</$tag>not preformat", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun openPreformatByMovingOutsideTextInsideIt() {
+//        editText.fromHtml("<$tag>first item<br>second item</$tag>")
+//        safeAppend(editText, "not preformat")
+//        editText.text.delete(editText.text.indexOf("not preformat"), editText.text.indexOf("not preformat"))
+//        Assert.assertEquals("<$tag>first item\nsecond itemnot preformat</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun remainClosedWhenLastCharacterIsDeleted() {
+//        editText.fromHtml("<$tag>first item<br>second item</$tag>not preformat")
+//        editText.setSelection(safeLength(editText))
+//        val mark = editText.text.indexOf("second item") + "second item".length
+//        //delete last character from "second item"
+//        editText.text.delete(mark - 1, mark)
+//        Assert.assertEquals("<$tag>first item\nsecond ite</$tag>not preformat", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun openingAndReopeningOfPreformat() {
+//        editText.fromHtml("<$tag>first item<br>second item</$tag>")
+//        editText.setSelection(safeLength(editText))
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "third item")
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>", editText.toHtml())
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "\n")
+//        val mark = safeLength(editText) - 1
+//        safeAppend(editText, "not preformat")
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat", editText.toHtml())
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "foo")
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird item</$tag>not preformat\n\nfoo", editText.toHtml())
+//        editText.text.delete(mark, mark + 1)
+//        Assert.assertEquals("<$tag>first item\nsecond item\nthird itemnot preformat</$tag>\n\nfoo", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun handlePreformatReopeningAfterLastElementDeletion() {
+//        editText.fromHtml("<$tag>first item<br>second item<br>third item</$tag>")
+//        editText.setSelection(safeLength(editText))
+//        editText.text.delete(editText.text.indexOf("third item", 0), safeLength(editText))
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "not preformat")
+//        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
+//        editText.text.insert(editText.text.indexOf("not preformat") - 1, " addition")
+//        Assert.assertEquals("<$tag>first item\nsecond item addition</$tag>not preformat", editText.toHtml())
+//        editText.text.insert(editText.text.indexOf("not preformat") - 1, "\n")
+//        editText.text.insert(editText.text.indexOf("not preformat") - 1, "third item")
+//        Assert.assertEquals("first item\nsecond item addition\nthird item\nnot preformat", editText.text.toString())
+//        Assert.assertEquals("<$tag>first item\nsecond item addition\nthird item</$tag>not preformat", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun additionToClosedPreformat() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        val mark = safeLength(editText)
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "not preformat")
+//        Assert.assertEquals("<$tag>first item\nsecond item</$tag>not preformat", editText.toHtml())
+//        editText.text.insert(mark, " (addition)")
+//        Assert.assertEquals("<$tag>first item\nsecond item (addition)</$tag>not preformat", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun appendToPreformatFromTopAtFirstLine() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        editText.setSelection(0)
+//        editText.text.insert(0, "addition ")
+//        Assert.assertEquals("<$tag>addition first item\nsecond item</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun appendToPreformatFromTop() {
+//        safeAppend(editText, "not preformat")
+//        safeAppend(editText, "\n")
+//        toolbar.onMenuItemClick(menuPreformat)
+//        val mark = editText.length() - 1
+//        safeAppend(editText, "first item")
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        editText.setSelection(mark)
+//        editText.text.insert(mark, "addition ")
+//        Assert.assertEquals("not preformat\n<$tag>addition first item\nsecond item</$tag>", editText.toHtml())
+//    }
+//
+//    @Test
+//    @Throws(Exception::class)
+//    fun deleteFirstItemWithKeyboard() {
+//        toolbar.onMenuItemClick(menuPreformat)
+//        safeAppend(editText, "first item")
+//        val firstMark = safeLength(editText)
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "second item")
+//        val secondMark = safeLength(editText)
+//        safeAppend(editText, "\n")
+//        safeAppend(editText, "third item")
+//        editText.setSelection(0)
+//        Assert.assertEquals("first item\nsecond item\nthird item", editText.text.toString())
+//        editText.text.delete(firstMark + 1, secondMark)
+//        Assert.assertEquals("first item\n\nthird item", editText.text.toString())
+//        Assert.assertEquals("<$tag>first item\n\nthird item</$tag>", editText.toHtml())
+//        editText.text.delete(0, firstMark)
+//        Assert.assertEquals("<$tag>\n\nthird item</$tag>", editText.toHtml())
+//    }
+//}


### PR DESCRIPTION
### Fix
Remove ***Preformat*** and ***Page Break*** from heading menu and format toolbar, respectively, as described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/366.

### Test
1. Run demonstration app.
2. Tap ***Heading*** format button.
3. Notice ***Preformat*** is not in popup menu.
4. Tap away from popup menu.
5. Scroll format toolbar to the left.
6. Notice ***Page Break*** is not in format toolbar.