### PR TITLE
Add UI Tests for Simple Text Formatting

### DIFF
--- a/app/src/androidTest/java/org/wordpress/aztec/demo/BetterClickAction.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/BetterClickAction.java
@@ -1,0 +1,120 @@
+package org.wordpress.aztec.demo;
+
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
+import static org.hamcrest.Matchers.allOf;
+
+import android.support.test.espresso.core.deps.guava.base.Optional;
+import android.support.test.espresso.PerformException;
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.action.CoordinatesProvider;
+import android.support.test.espresso.action.PrecisionDescriber;
+import android.support.test.espresso.action.Tap;
+import android.support.test.espresso.action.Tapper;
+import android.support.test.espresso.util.HumanReadables;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.webkit.WebView;
+import org.hamcrest.Matcher;
+
+/**
+ * Enables clicking on views with 65% or greater displaying.
+ */
+public final class BetterClickAction implements ViewAction {
+    private final CoordinatesProvider coordinatesProvider;
+    private final Tapper tapper;
+    private final PrecisionDescriber precisionDescriber;
+    private final Optional<ViewAction> rollbackAction;
+    public BetterClickAction(Tapper tapper, CoordinatesProvider coordinatesProvider,
+                              PrecisionDescriber precisionDescriber) {
+        this(tapper, coordinatesProvider, precisionDescriber, null);
+    }
+    public BetterClickAction(Tapper tapper, CoordinatesProvider coordinatesProvider,
+                              PrecisionDescriber precisionDescriber, ViewAction rollbackAction) {
+        this.coordinatesProvider = coordinatesProvider;
+        this.tapper = tapper;
+        this.precisionDescriber = precisionDescriber;
+        this.rollbackAction = Optional.fromNullable(rollbackAction);
+    }
+    @Override
+    @SuppressWarnings("unchecked")
+    public Matcher<View> getConstraints() {
+        Matcher<View> standardConstraint = isDisplayingAtLeast(65);
+        if (rollbackAction.isPresent()) {
+            return allOf(standardConstraint, rollbackAction.get().getConstraints());
+        } else {
+            return standardConstraint;
+        }
+    }
+    @Override
+    public void perform(UiController uiController, View view) {
+        float[] coordinates = coordinatesProvider.calculateCoordinates(view);
+        float[] precision = precisionDescriber.describePrecision();
+        Tapper.Status status = Tapper.Status.FAILURE;
+        int loopCount = 0;
+        // Native event injection is quite a tricky process. A tap is actually 2
+        // seperate motion events which need to get injected into the system. Injection
+        // makes an RPC call from our app under test to the Android system server, the
+        // system server decides which window layer to deliver the event to, the system
+        // server makes an RPC to that window layer, that window layer delivers the event
+        // to the correct UI element, activity, or window object. Now we need to repeat
+        // that 2x. for a simple down and up. Oh and the down event triggers timers to
+        // detect whether or not the event is a long vs. short press. The timers are
+        // removed the moment the up event is received (NOTE: the possibility of eventTime
+        // being in the future is totally ignored by most motion event processors).
+        //
+        // Phew.
+        //
+        // The net result of this is sometimes we'll want to do a regular tap, and for
+        // whatever reason the up event (last half) of the tap is delivered after long
+        // press timeout (depending on system load) and the long press behaviour is
+        // displayed (EG: show a context menu). There is no way to avoid or handle this more
+        // gracefully. Also the longpress behavour is app/widget specific. So if you have
+        // a seperate long press behaviour from your short press, you can pass in a
+        // 'RollBack' ViewAction which when executed will undo the effects of long press.
+        while (status != Tapper.Status.SUCCESS && loopCount < 3) {
+            try {
+                status = tapper.sendTap(uiController, coordinates, precision);
+            } catch (RuntimeException re) {
+                throw new PerformException.Builder()
+                        .withActionDescription(this.getDescription())
+                        .withViewDescription(HumanReadables.describe(view))
+                        .withCause(re)
+                        .build();
+            }
+            int duration = ViewConfiguration.getPressedStateDuration();
+            // ensures that all work enqueued to process the tap has been run.
+            if (duration > 0) {
+                uiController.loopMainThreadForAtLeast(duration);
+            }
+            if (status == Tapper.Status.WARNING) {
+                if (rollbackAction.isPresent()) {
+                    rollbackAction.get().perform(uiController, view);
+                } else {
+                    break;
+                }
+            }
+            loopCount++;
+        }
+        if (status == Tapper.Status.FAILURE) {
+            throw new PerformException.Builder()
+                    .withActionDescription(this.getDescription())
+                    .withViewDescription(HumanReadables.describe(view))
+                    .withCause(new RuntimeException(String.format("Couldn't "
+                                    + "click at: %s,%s precision: %s, %s . Tapper: %s coordinate provider: %s precision " +
+                                    "describer: %s. Tried %s times. With Rollback? %s", coordinates[0], coordinates[1],
+                            precision[0], precision[1], tapper, coordinatesProvider, precisionDescriber, loopCount,
+                            rollbackAction.isPresent())))
+                    .build();
+        }
+        if (tapper == Tap.SINGLE && view instanceof WebView) {
+            // WebViews will not process click events until double tap
+            // timeout. Not the best place for this - but good for now.
+            uiController.loopMainThreadForAtLeast(ViewConfiguration.getDoubleTapTimeout());
+        }
+    }
+    @Override
+    public String getDescription() {
+        return tapper.toString().toLowerCase() + " click";
+    }
+}

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/BetterClickAction.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/BetterClickAction.java
@@ -39,6 +39,7 @@ public final class BetterClickAction implements ViewAction {
     @Override
     @SuppressWarnings("unchecked")
     public Matcher<View> getConstraints() {
+        // Check that at least 65% of the element is displayed (instead of default 90%)
         Matcher<View> standardConstraint = isDisplayingAtLeast(65);
         if (rollbackAction.isPresent()) {
             return allOf(standardConstraint, rollbackAction.get().getConstraints());

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/BetterScrollToAction.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/BetterScrollToAction.java
@@ -36,6 +36,7 @@ public final class BetterScrollToAction implements ViewAction {
 
     @Override
     public void perform(UiController uiController, View view) {
+        // Check that at least 65% of the element is displayed (instead of default 90%)
         if (isDisplayingAtLeast(65).matches(view)) {
             Log.i(TAG, "View is already displayed. Returning.");
             return;
@@ -46,6 +47,7 @@ public final class BetterScrollToAction implements ViewAction {
             Log.w(TAG, "Scrolling to view was requested, but none of the parents scrolled.");
         }
         uiController.loopMainThreadUntilIdle();
+        // Check that at least 65% of the element is displayed (instead of default 90%)
         if (!isDisplayingAtLeast(65).matches(view)) {
             throw new PerformException.Builder()
                     .withActionDescription(this.getDescription())

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/BetterScrollToAction.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/BetterScrollToAction.java
@@ -1,0 +1,63 @@
+package org.wordpress.aztec.demo;
+
+import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
+import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+
+import android.support.test.espresso.PerformException;
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.matcher.ViewMatchers.Visibility;
+import android.support.test.espresso.util.HumanReadables;
+
+import android.graphics.Rect;
+import android.util.Log;
+import android.view.View;
+import android.widget.HorizontalScrollView;
+import android.widget.ScrollView;
+
+import org.hamcrest.Matcher;
+
+/**
+ * Enables scrolling to the given view with 65% or greater displaying. View must be a descendant of a ScrollView.
+ */
+public final class BetterScrollToAction implements ViewAction {
+    private static final String TAG = BetterScrollToAction.class.getSimpleName();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Matcher<View> getConstraints() {
+        return allOf(withEffectiveVisibility(Visibility.VISIBLE), isDescendantOfA(anyOf(
+                isAssignableFrom(ScrollView.class), isAssignableFrom(HorizontalScrollView.class))));
+    }
+
+    @Override
+    public void perform(UiController uiController, View view) {
+        if (isDisplayingAtLeast(65).matches(view)) {
+            Log.i(TAG, "View is already displayed. Returning.");
+            return;
+        }
+        Rect rect = new Rect();
+        view.getDrawingRect(rect);
+        if (!view.requestRectangleOnScreen(rect, true /* immediate */)) {
+            Log.w(TAG, "Scrolling to view was requested, but none of the parents scrolled.");
+        }
+        uiController.loopMainThreadUntilIdle();
+        if (!isDisplayingAtLeast(65).matches(view)) {
+            throw new PerformException.Builder()
+                    .withActionDescription(this.getDescription())
+                    .withViewDescription(HumanReadables.describe(view))
+                    .withCause(new RuntimeException(
+                            "Scrolling to view was attempted, but the view is not displayed"))
+                    .build();
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "scroll to";
+    }
+}

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -1,0 +1,49 @@
+package org.wordpress.aztec.demo;
+
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class SimpleTextFormattingTests {
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
+
+    @Test
+    public void testSimpleBoldFormatting() {
+        // Focus on visual editor
+        ViewInteraction aztecText = onView(withId(R.id.aztec));
+        aztecText.perform(click());
+
+        // Enable bold formatting
+        ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
+        boldButton.perform(click());
+
+        // Type bold text
+        aztecText.perform(typeText("hello world"), closeSoftKeyboard());
+
+        // Switch to HTML view
+        ViewInteraction htmlButton = onView(withId(R.id.format_bar_button_html));
+        htmlButton.perform(click());
+
+        // Assert that text has bold tags
+        ViewInteraction sourceText = onView(allOf(withId(R.id.source), isDisplayed()));
+        sourceText.check(matches(withText("<b>hello world</b>")));
+    }
+}

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -135,18 +135,38 @@ public class SimpleTextFormattingTests {
         sourceText.check(matches(withText(unformattedText + "\n<ol>\n\t<li>" + formattedText + "</li>\n</ol>")));
     }
 
-    @Test
-    public void testSimpleLinkFormatting() {
+    /*
+    * This test is disabled because Espresso does not click in the correct position for the link dialog's OK button.
+    * See replacement test below.
+     */
+    //@Test
+    //public void testSimpleLinkFormatting() {
         // Enter text in visual editor with formatting
-        aztecText.perform(typeText(unformattedText));
-        linkButton.perform(scrollTo(), click());
-        linkURLField.perform(typeTextIntoFocusedView(linkURLText));
-        linkTextField.perform(typeText(formattedText));
-        linkOKButton.perform(click());
+        //aztecText.perform(typeText(unformattedText));
+        //linkButton.perform(scrollTo(), click());
+        //linkURLField.perform(replaceText(linkURLText));
+        //linkTextField.perform(replaceText(formattedText));
+        //linkOKButton.perform(click());
 
         // Check that HTML formatting tags were correctly added
+        //toggleHTMLView();
+        //sourceText.check(matches(withText(unformattedText + "<a href='" + linkURLText + "'>" + formattedText + "</a>")));
+    //}
+
+    /*
+    * This test enters link HTML and then checks the link dialog values.
+     */
+    @Test
+    public void testSimpleLinkFormatting() {
+        // Enter link HTML
         toggleHTMLView();
-        sourceText.check(matches(withText(unformattedText + "<a href='" + linkURLText + "'>" + formattedText + "</a>")));
+        sourceText.perform(typeText("<a href='" + linkURLText + "'>" + formattedText + "</a>"));
+
+        // Check that link dialog contains the correct values
+        toggleHTMLView();
+        linkButton.perform(scrollTo(), click());
+        linkURLField.check(matches(withText(linkURLText)));
+        linkTextField.check(matches(withText(formattedText)));
     }
 
     @Test

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -10,13 +10,10 @@ import org.junit.runner.RunWith;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.Matchers.allOf;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -27,23 +24,19 @@ public class SimpleTextFormattingTests {
 
     @Test
     public void testSimpleBoldFormatting() {
-        // Focus on visual editor
-        ViewInteraction aztecText = onView(withId(R.id.aztec));
-        aztecText.perform(click());
-
-        // Enable bold formatting
-        ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
-        boldButton.perform(click());
-
-        // Type bold text
-        aztecText.perform(typeText("hello world"), closeSoftKeyboard());
-
         // Switch to HTML view
         ViewInteraction htmlButton = onView(withId(R.id.format_bar_button_html));
         htmlButton.perform(click());
 
-        // Assert that text has bold tags
-        ViewInteraction sourceText = onView(allOf(withId(R.id.source), isDisplayed()));
-        sourceText.check(matches(withText("<b>hello world</b>")));
+        // Type text with bold tags
+        ViewInteraction htmlViewEditText = onView(withId(R.id.source));
+        htmlViewEditText.perform(typeText("<b>hello world</b>"));
+
+        // Switch back to visual view
+        htmlButton.perform(click());
+
+        // Assert that bold button is enabled
+        ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
+        boldButton.check(matches(isEnabled()));
     }
 }

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -15,6 +15,8 @@ import static android.support.test.espresso.action.ViewActions.typeTextIntoFocus
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.wordpress.aztec.demo.TestUtils.aztecText;
+import static org.wordpress.aztec.demo.TestUtils.betterClick;
+import static org.wordpress.aztec.demo.TestUtils.betterScrollTo;
 import static org.wordpress.aztec.demo.TestUtils.boldButton;
 import static org.wordpress.aztec.demo.TestUtils.formattedText;
 import static org.wordpress.aztec.demo.TestUtils.headingButton;
@@ -163,12 +165,12 @@ public class SimpleTextFormattingTests {
     public void testSimplePageBreakFormatting() {
         // Enter text in visual editor with page break in between
         aztecText.perform(typeText(unformattedText));
-        pageButton.perform(scrollTo(), click());
+        pageButton.perform(betterScrollTo(), betterClick());
         aztecText.perform(typeTextIntoFocusedView(unformattedText));
 
         // Check that page break was correctly added
         toggleHTMLView();
-        sourceText.check(matches(withText(unformattedText + "\n\n<!--pagebreak-->\n\n" + unformattedText)));
+        sourceText.check(matches(withText(unformattedText + "\n\n<!--nextpage-->\n\n" + unformattedText)));
     }
 
     @Test

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -1,19 +1,46 @@
 package org.wordpress.aztec.demo;
 
-import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.action.ViewActions.typeTextIntoFocusedView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
-import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static org.wordpress.aztec.demo.TestUtils.enterHTML;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.wordpress.aztec.demo.TestUtils.aztecText;
+import static org.wordpress.aztec.demo.TestUtils.boldButton;
+import static org.wordpress.aztec.demo.TestUtils.formattedText;
+import static org.wordpress.aztec.demo.TestUtils.headingButton;
+import static org.wordpress.aztec.demo.TestUtils.headingFiveSelector;
+import static org.wordpress.aztec.demo.TestUtils.headingFourSelector;
+import static org.wordpress.aztec.demo.TestUtils.headingOneSelector;
+import static org.wordpress.aztec.demo.TestUtils.headingSixSelector;
+import static org.wordpress.aztec.demo.TestUtils.headingThreeSelector;
+import static org.wordpress.aztec.demo.TestUtils.headingTwoSelector;
+import static org.wordpress.aztec.demo.TestUtils.italicButton;
+import static org.wordpress.aztec.demo.TestUtils.linkButton;
+import static org.wordpress.aztec.demo.TestUtils.linkOKButton;
+import static org.wordpress.aztec.demo.TestUtils.linkTextField;
+import static org.wordpress.aztec.demo.TestUtils.linkURLField;
+import static org.wordpress.aztec.demo.TestUtils.linkURLText;
+import static org.wordpress.aztec.demo.TestUtils.moreButton;
+import static org.wordpress.aztec.demo.TestUtils.orderedListButton;
+import static org.wordpress.aztec.demo.TestUtils.pageButton;
+import static org.wordpress.aztec.demo.TestUtils.preSelector;
+import static org.wordpress.aztec.demo.TestUtils.quoteButton;
+import static org.wordpress.aztec.demo.TestUtils.sourceText;
+import static org.wordpress.aztec.demo.TestUtils.strikethroughButton;
+import static org.wordpress.aztec.demo.TestUtils.toggleHTMLView;
+import static org.wordpress.aztec.demo.TestUtils.underlineButton;
+import static org.wordpress.aztec.demo.TestUtils.unformattedText;
+import static org.wordpress.aztec.demo.TestUtils.unorderedListButton;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -24,11 +51,214 @@ public class SimpleTextFormattingTests {
 
     @Test
     public void testSimpleBoldFormatting() {
-        ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
-        boldButton.check(matches(isNotChecked()));
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText));
+        boldButton.perform(click());
+        aztecText.perform(typeText(formattedText));
 
-        enterHTML("<b>hello world</b>");
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "<b>" + formattedText + "</b>")));
+    }
 
-        boldButton.check(matches(isChecked()));
+    @Test
+    public void testSimpleItalicFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText));
+        italicButton.perform(click());
+        aztecText.perform(typeText(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "<i>" + formattedText + "</i>")));
+    }
+
+    @Test
+    public void testSimpleStrikethroughFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText));
+        strikethroughButton.perform(click());
+        aztecText.perform(typeText(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "<del>" + formattedText + "</del>")));
+    }
+
+    @Test
+    public void testSimpleUnderlineFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText));
+        underlineButton.perform(click());
+        aztecText.perform(typeText(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "<u>" + formattedText + "</u>")));
+    }
+
+    @Test
+    public void testSimpleQuoteFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        quoteButton.perform(click());
+        aztecText.perform(typeText(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<blockquote>" + formattedText + "</blockquote>")));
+    }
+
+    @Test
+    public void testSimpleUnorderedListFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        unorderedListButton.perform(scrollTo(), click());
+        aztecText.perform(typeText(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<ul>\n\t<li>" + formattedText + "</li>\n</ul>")));
+    }
+
+    @Test
+    public void testSimpleOrderedListFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        orderedListButton.perform(scrollTo(), click());
+        aztecText.perform(typeText(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<ol>\n\t<li>" + formattedText + "</li>\n</ol>")));
+    }
+
+    @Test
+    public void testSimpleLinkFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText));
+        linkButton.perform(scrollTo(), click());
+        linkURLField.perform(typeTextIntoFocusedView(linkURLText));
+        linkTextField.perform(typeText(formattedText));
+        linkOKButton.perform(click());
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "<a href='" + linkURLText + "'>" + formattedText + "</a>")));
+    }
+
+    @Test
+    public void testSimpleMoreTagFormatting() {
+        // Enter text in visual editor more tag in between
+        aztecText.perform(typeText(unformattedText));
+        moreButton.perform(scrollTo(), click());
+        aztecText.perform(typeTextIntoFocusedView(unformattedText));
+
+        // Check that more tag was correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n\n<!--more-->\n\n" + unformattedText)));
+    }
+
+    @Test
+    public void testSimplePageBreakFormatting() {
+        // Enter text in visual editor with page break in between
+        aztecText.perform(typeText(unformattedText));
+        pageButton.perform(scrollTo(), click());
+        aztecText.perform(typeTextIntoFocusedView(unformattedText));
+
+        // Check that page break was correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n\n<!--pagebreak-->\n\n" + unformattedText)));
+    }
+
+    @Test
+    public void testSimpleHeadingOneFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        headingButton.perform(click());
+        headingOneSelector.perform(click());
+        aztecText.perform(typeTextIntoFocusedView(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<h1>" + formattedText + "</h1>")));
+    }
+
+    @Test
+    public void testSimpleHeadingTwoFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        headingButton.perform(click());
+        headingTwoSelector.perform(click());
+        aztecText.perform(typeTextIntoFocusedView(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<h2>" + formattedText + "</h2>")));
+    }
+
+    @Test
+    public void testSimpleHeadingThreeFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        headingButton.perform(click());
+        headingThreeSelector.perform(click());
+        aztecText.perform(typeTextIntoFocusedView(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<h3>" + formattedText + "</h3>")));
+    }
+
+    @Test
+    public void testSimpleHeadingFourFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        headingButton.perform(click());
+        headingFourSelector.perform(click());
+        aztecText.perform(typeTextIntoFocusedView(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<h4>" + formattedText + "</h4>")));
+    }
+
+    @Test
+    public void testSimpleHeadingFiveFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        headingButton.perform(click());
+        headingFiveSelector.perform(click());
+        aztecText.perform(typeTextIntoFocusedView(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<h5>" + formattedText + "</h5>")));
+    }
+
+    @Test
+    public void testSimpleHeadingSixFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        headingButton.perform(click());
+        headingSixSelector.perform(click());
+        aztecText.perform(typeTextIntoFocusedView(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<h6>" + formattedText + "</h6>")));
+    }
+
+    @Test
+    public void testSimplePreformattedTextFormatting() {
+        // Enter text in visual editor with formatting
+        aztecText.perform(typeText(unformattedText + "\n"));
+        headingButton.perform(click());
+        preSelector.perform(click());
+        aztecText.perform(typeTextIntoFocusedView(formattedText));
+
+        // Check that HTML formatting tags were correctly added
+        toggleHTMLView();
+        sourceText.check(matches(withText(unformattedText + "\n<pre>" + formattedText + "</pre>")));
     }
 }

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -24,9 +24,11 @@ public class SimpleTextFormattingTests {
 
     @Test
     public void testSimpleBoldFormatting() {
+        ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
+        boldButton.check(matches(isNotChecked()));
+
         enterHTML("<b>hello world</b>");
 
-        ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
         boldButton.check(matches(isChecked()));
     }
 }

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -9,11 +9,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.wordpress.aztec.demo.TestUtils.enterHTML;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -24,19 +24,9 @@ public class SimpleTextFormattingTests {
 
     @Test
     public void testSimpleBoldFormatting() {
-        // Switch to HTML view
-        ViewInteraction htmlButton = onView(withId(R.id.format_bar_button_html));
-        htmlButton.perform(click());
+        enterHTML("<b>hello world</b>");
 
-        // Type text with bold tags
-        ViewInteraction htmlViewEditText = onView(withId(R.id.source));
-        htmlViewEditText.perform(typeText("<b>hello world</b>"));
-
-        // Switch back to visual view
-        htmlButton.perform(click());
-
-        // Assert that bold button is enabled
         ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
-        boldButton.check(matches(isEnabled()));
+        boldButton.check(matches(isChecked()));
     }
 }

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/SimpleTextFormattingTests.java
@@ -136,25 +136,9 @@ public class SimpleTextFormattingTests {
     }
 
     /*
-    * This test is disabled because Espresso does not click in the correct position for the link dialog's OK button.
-    * See replacement test below.
-     */
-    //@Test
-    //public void testSimpleLinkFormatting() {
-        // Enter text in visual editor with formatting
-        //aztecText.perform(typeText(unformattedText));
-        //linkButton.perform(scrollTo(), click());
-        //linkURLField.perform(replaceText(linkURLText));
-        //linkTextField.perform(replaceText(formattedText));
-        //linkOKButton.perform(click());
-
-        // Check that HTML formatting tags were correctly added
-        //toggleHTMLView();
-        //sourceText.check(matches(withText(unformattedText + "<a href='" + linkURLText + "'>" + formattedText + "</a>")));
-    //}
-
-    /*
     * This test enters link HTML and then checks the link dialog values.
+    * This is opposite of the steps in the other tests (which enter rich text and check the HTML),
+    * because Espresso does not click in the correct position for the link dialog's OK button.
      */
     @Test
     public void testSimpleLinkFormatting() {

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
@@ -1,13 +1,15 @@
 package org.wordpress.aztec.demo;
 
+import android.support.test.espresso.DataInteraction;
 import android.support.test.espresso.ViewInteraction;
 
+import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasToString;
 
 /**
  * Test utilities to be used with instrumentation tests.
@@ -37,13 +39,13 @@ public class TestUtils {
     public static ViewInteraction unorderedListButton = onView(withId(R.id.format_bar_button_ul));
 
     // Heading/Paragraph Format Selectors
-    public static ViewInteraction headingOneSelector = onView(allOf(withId(android.R.id.title), withText("Heading 1")));
-    public static ViewInteraction headingTwoSelector = onView(withText("Heading 2"));
-    public static ViewInteraction headingThreeSelector = onView(withText("Heading 3"));
-    public static ViewInteraction headingFourSelector = onView(withText("Heading 4"));
-    public static ViewInteraction headingFiveSelector = onView(withText("Heading 5"));
-    public static ViewInteraction headingSixSelector = onView(withText("Heading 6"));
-    public static ViewInteraction preSelector = onView(withText("Heading 6"));
+    public static DataInteraction headingOneSelector = onData(hasToString("Heading 1"));
+    public static DataInteraction headingTwoSelector = onData(hasToString("Heading 2"));
+    public static DataInteraction headingThreeSelector = onData(hasToString("Heading 3"));
+    public static DataInteraction headingFourSelector = onData(hasToString("Heading 4"));
+    public static DataInteraction headingFiveSelector = onData(hasToString("Heading 5"));
+    public static DataInteraction headingSixSelector = onData(hasToString("Heading 6"));
+    public static DataInteraction preSelector = onData(hasToString("Preformat"));
 
     // Link Modal
     public static ViewInteraction linkOKButton = onView(withId(android.R.id.button1));

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
@@ -1,0 +1,27 @@
+package org.wordpress.aztec.demo;
+
+import android.support.test.espresso.ViewInteraction;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+/**
+ * Test utilities to be used with instrumentation tests.
+ */
+public class TestUtils {
+    public static void toggleHTMLView() {
+        ViewInteraction htmlButton = onView(withId(R.id.format_bar_button_html));
+        htmlButton.perform(click());
+    }
+
+    public static void enterHTML(String text) {
+        toggleHTMLView();
+
+        ViewInteraction htmlViewEditText = onView(withId(R.id.source));
+        htmlViewEditText.perform(typeText(text));
+
+        toggleHTMLView();
+    }
+}

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
@@ -4,24 +4,54 @@ import android.support.test.espresso.ViewInteraction;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
 
 /**
  * Test utilities to be used with instrumentation tests.
  */
 public class TestUtils {
+
+    // Strings
+    public static String unformattedText = "hello";
+    public static String formattedText = "world";
+    public static String linkURLText = "https://github.com/wordpress-mobile/AztecEditor-Android";
+
+    // Editor Views
+    public static ViewInteraction aztecText = onView(withId(R.id.aztec));
+    public static ViewInteraction sourceText = onView(allOf(withId(R.id.source), isDisplayed()));
+
+    // Format Toolbar Buttons
+    public static ViewInteraction boldButton = onView(withId(R.id.format_bar_button_bold));
+    public static ViewInteraction headingButton = onView(withId(R.id.format_bar_button_heading));
+    public static ViewInteraction italicButton = onView(withId(R.id.format_bar_button_italic));
+    public static ViewInteraction linkButton = onView(withId(R.id.format_bar_button_link));
+    public static ViewInteraction moreButton = onView(withId(R.id.format_bar_button_more));
+    public static ViewInteraction orderedListButton = onView(withId(R.id.format_bar_button_ol));
+    public static ViewInteraction pageButton = onView(withId(R.id.format_bar_button_page));
+    public static ViewInteraction quoteButton = onView(withId(R.id.format_bar_button_quote));
+    public static ViewInteraction strikethroughButton = onView(withId(R.id.format_bar_button_strikethrough));
+    public static ViewInteraction underlineButton = onView(withId(R.id.format_bar_button_underline));
+    public static ViewInteraction unorderedListButton = onView(withId(R.id.format_bar_button_ul));
+
+    // Heading/Paragraph Format Selectors
+    public static ViewInteraction headingOneSelector = onView(allOf(withId(android.R.id.title), withText("Heading 1")));
+    public static ViewInteraction headingTwoSelector = onView(withText("Heading 2"));
+    public static ViewInteraction headingThreeSelector = onView(withText("Heading 3"));
+    public static ViewInteraction headingFourSelector = onView(withText("Heading 4"));
+    public static ViewInteraction headingFiveSelector = onView(withText("Heading 5"));
+    public static ViewInteraction headingSixSelector = onView(withText("Heading 6"));
+    public static ViewInteraction preSelector = onView(withText("Heading 6"));
+
+    // Link Modal
+    public static ViewInteraction linkOKButton = onView(withId(android.R.id.button1));
+    public static ViewInteraction linkTextField = onView(withId(R.id.linkText));
+    public static ViewInteraction linkURLField = onView(withId(R.id.linkURL));
+
     public static void toggleHTMLView() {
         ViewInteraction htmlButton = onView(withId(R.id.format_bar_button_html));
         htmlButton.perform(click());
-    }
-
-    public static void enterHTML(String text) {
-        toggleHTMLView();
-
-        ViewInteraction htmlViewEditText = onView(withId(R.id.source));
-        htmlViewEditText.perform(typeText(text));
-
-        toggleHTMLView();
     }
 }

--- a/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
+++ b/app/src/androidTest/java/org/wordpress/aztec/demo/TestUtils.java
@@ -1,7 +1,12 @@
 package org.wordpress.aztec.demo;
 
 import android.support.test.espresso.DataInteraction;
+import android.support.test.espresso.ViewAction;
 import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.action.GeneralLocation;
+import android.support.test.espresso.action.Press;
+import android.support.test.espresso.action.Tap;
+import android.support.test.espresso.action.ViewActions;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
@@ -52,8 +57,19 @@ public class TestUtils {
     public static ViewInteraction linkTextField = onView(withId(R.id.linkText));
     public static ViewInteraction linkURLField = onView(withId(R.id.linkURL));
 
+    // Switch to HTML view
     public static void toggleHTMLView() {
         ViewInteraction htmlButton = onView(withId(R.id.format_bar_button_html));
         htmlButton.perform(click());
+    }
+
+    // Better scrolling action for last toolbar item (<90% of item displayed)
+    public static ViewAction betterScrollTo() {
+        return ViewActions.actionWithAssertions(new BetterScrollToAction());
+    }
+
+    // Better click action for last toolbar item (<90% of item displayed)
+    public static ViewAction betterClick() {
+        return new BetterClickAction(Tap.SINGLE, GeneralLocation.CENTER, Press.FINGER);
     }
 }


### PR DESCRIPTION
This PR adds a suite of UI tests for simple text formatting in the Aztec demo app, using the Android Espresso testing framework.

## Before running the tests

Espresso [advises](https://google.github.io/android-testing-support-library/docs/espresso/setup/#setup-your-test-environment) disabling system animations on devices used for testing:

> On your device, under Settings->Developer options disable the following 3 settings:
> 
> - Window animation scale
> - Transition animation scale
> - Animator duration scale

One additional setup step is also required to handle an Espresso issue with clicks (see the caveats below):

On your device, under Settings -> Accessibility -> Touch & hold delay, set the delay to `Long`.

## Test Details

Each test performs the following steps:

1. Enter text (unformatted).
2. Select a formatting button in the toolbar.
3. Enter more text (with formatting).
4. Verify the correct HTML appears in HTML mode for the unformatted and formatted text.

A couple caveats:

- The Espresso framework sometimes performs a long click instead of a single click (see the [Espresso code](https://android.googlesource.com/platform/frameworks/testing/+/android-support-test/espresso/core/src/main/java/android/support/test/espresso/action/GeneralClickAction.java#75) for an explanation). In the Aztec toolbar, this displays a hint instead of selecting the formatting button and causes the test to fail.
- Espresso also has trouble with the editor's link dialog. Although it can identify the fields and buttons in the dialog (and TalkBack works with the dialog as expected) it clicks in the wrong position. This seems to be a bug with the coordinates select for the click action for a custom `AlertDialog` and so I reversed the link formatting test. (It enters the link HTML and then verifies that the link dialog displays the expected values.)

cc @catehstn @lancewillett @hoverduck 