### PR TITLE
Issue/317 fixing block elements selection range

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -398,7 +398,7 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
             }
 
             applyBlock(spanToApply, startOfBlock, endOfBlock)
-            editor.onSelectionChanged(startOfLine, endOfLine)
+            editor.onSelectionChanged(editor.selectionStart, editor.selectionEnd)
         }
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
@@ -557,12 +557,7 @@ class HeadingTest {
 
         toolbar.onMenuItemClick(menuHeading2)
         Assert.assertEquals("<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3>", editText.toHtml())
-//        TODO: Correct heading menu selection.  This is incorrect.  Heading 2 should be selected.
-//        AztecToolbar.highlightAppliedStyles returns Heading 1, Heading 2, and Heading 3 so then
-//        AztecToolbar.selectHeaderMenu selects the first format.  See this issue for details.
-//        https://github.com/wordpress-mobile/AztecEditor-Android/issues/317
-//        Assert.assertEquals(TextFormat.FORMAT_HEADING_2, toolbar.getSelectedHeadingMenuItem())
-        Assert.assertEquals(TextFormat.FORMAT_HEADING_1, toolbar.getSelectedHeadingMenuItem())
+        Assert.assertEquals(TextFormat.FORMAT_HEADING_2, toolbar.getSelectedHeadingMenuItem())
     }
 
     @Test


### PR DESCRIPTION
This partially fixes #317, and closed as duplicate #380
"Horizontal Row" part of the #317 is not technically related (and looks like way more involved), so I'll address it later.

### Test 1
1. Load demo app.
2. Place cursor in Heading 2
3. Open Heading menu and select Default
4. Open Heading menu and select Heading 2
4. Open Heading menu and confirm that Heading 2 is selected.

### Test 2
1. Launch demonstration app.
2. Move cursor anywhere in "Bold" text.
3. Tap Ordered List or Unordered List format button.
4. Tap Heading format button.
5. Notice Default paragraph is selected.
