### PR TITLE
Issue/update advanced layout

### DIFF
--- a/aztec/src/main/res/layout/aztec_format_bar_advanced.xml
+++ b/aztec/src/main/res/layout/aztec_format_bar_advanced.xml
@@ -27,162 +27,175 @@
         android:paddingRight="@dimen/format_bar_right_margin"
         tools:ignore="RtlHardcoded,RtlSymmetry" >
 
-        <RelativeLayout
+        <LinearLayout
             android:layout_height="match_parent"
-            android:layout_width="wrap_content" >
+            android:layout_width="wrap_content"
+            android:orientation="horizontal" >
 
-            <LinearLayout
-                android:id="@+id/format_bar_button_layout_expanded"
+            <RelativeLayout
                 android:layout_height="match_parent"
-                android:layout_toRightOf="@+id/format_bar_button_layout_collapsed"
-                android:layout_width="wrap_content"
-                android:orientation="horizontal"
-                tools:visibility="gone" >
+                android:layout_width="wrap_content" >
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_link"
-                    android:background="@drawable/format_bar_button_link_selector"
-                    android:contentDescription="@string/format_bar_description_link"
-                    android:layout_height="fill_parent"
+                <LinearLayout
+                    android:id="@+id/format_bar_button_layout_expanded"
+                    android:layout_height="match_parent"
+                    android:layout_toRightOf="@+id/format_bar_button_layout_collapsed"
                     android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                    android:orientation="horizontal"
+                    tools:visibility="gone" >
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_underline"
-                    android:background="@drawable/format_bar_button_underline_selector"
-                    android:contentDescription="@string/format_bar_description_underline"
-                    android:layout_height="fill_parent"
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_link"
+                        android:background="@drawable/format_bar_button_link_selector"
+                        android:contentDescription="@string/format_bar_description_link"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_underline"
+                        android:background="@drawable/format_bar_button_underline_selector"
+                        android:contentDescription="@string/format_bar_description_underline"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_strikethrough"
+                        android:background="@drawable/format_bar_button_strikethrough_selector"
+                        android:contentDescription="@string/format_bar_description_strike"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_horizontal_rule"
+                        android:background="@drawable/format_bar_button_horizontal_rule_selector"
+                        android:contentDescription="@string/format_bar_description_horizontal_rule"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_more"
+                        android:background="@drawable/format_bar_button_more_selector"
+                        android:contentDescription="@string/format_bar_description_more"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                    <!--TODO: Remove android:visibility="gone" when Page Break is to be added back as a feature-->
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_page"
+                        android:background="@drawable/format_bar_button_page_selector"
+                        android:contentDescription="@string/format_bar_description_page"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        android:visibility="gone"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_html"
+                        android:background="@drawable/format_bar_button_html_selector"
+                        android:contentDescription="@string/format_bar_description_html"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/format_bar_button_layout_collapsed"
+                    android:background="@color/format_bar_background"
+                    android:layout_height="match_parent"
                     android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                    android:orientation="horizontal" >
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_strikethrough"
-                    android:background="@drawable/format_bar_button_strikethrough_selector"
-                    android:contentDescription="@string/format_bar_description_strike"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_media"
+                        android:background="@drawable/format_bar_button_media_selector"
+                        android:contentDescription="@string/format_bar_description_media"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_horizontal_rule"
-                    android:background="@drawable/format_bar_button_horizontal_rule_selector"
-                    android:contentDescription="@string/format_bar_description_horizontal_rule"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                    <View
+                        android:id="@+id/format_bar_vertical_divider"
+                        android:layout_height="fill_parent"
+                        android:layout_width="@dimen/format_bar_horizontal_divider_height"
+                        style="@style/DividerVertical" >
+                    </View>
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_more"
-                    android:background="@drawable/format_bar_button_more_selector"
-                    android:contentDescription="@string/format_bar_description_more"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_heading"
+                        android:background="@drawable/format_bar_button_heading_selector"
+                        android:contentDescription="@string/format_bar_description_heading"
+                        android:layout_height="fill_parent"
+                        android:layout_marginLeft="@dimen/format_bar_left_margin"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
 
-                <!--TODO: Remove android:visibility="gone" when Page Break is to be added back as a feature-->
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_page"
-                    android:background="@drawable/format_bar_button_page_selector"
-                    android:contentDescription="@string/format_bar_description_page"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    android:visibility="gone"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_list"
+                        android:background="@drawable/format_bar_button_ul_selector"
+                        android:contentDescription="@string/format_bar_description_list"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_html"
-                    android:background="@drawable/format_bar_button_html_selector"
-                    android:contentDescription="@string/format_bar_description_html"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_quote"
+                        android:background="@drawable/format_bar_button_quote_selector"
+                        android:contentDescription="@string/format_bar_description_quote"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
 
-            </LinearLayout>
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_bold"
+                        android:background="@drawable/format_bar_button_bold_selector"
+                        android:contentDescription="@string/format_bar_description_bold"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
 
-            <LinearLayout
-                android:id="@+id/format_bar_button_layout_collapsed"
-                android:background="@color/format_bar_background"
-                android:layout_height="match_parent"
-                android:layout_width="wrap_content"
-                android:orientation="horizontal" >
+                    <org.wordpress.aztec.toolbar.RippleToggleButton
+                        android:id="@+id/format_bar_button_italic"
+                        android:background="@drawable/format_bar_button_italic_selector"
+                        android:contentDescription="@string/format_bar_description_italic"
+                        android:layout_height="fill_parent"
+                        android:layout_width="wrap_content"
+                        style="@style/FormatBarButton" >
+                    </org.wordpress.aztec.toolbar.RippleToggleButton>
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_media"
-                    android:background="@drawable/format_bar_button_media_selector"
-                    android:contentDescription="@string/format_bar_description_media"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
+                </LinearLayout>
 
-                <View
-                    android:id="@+id/format_bar_vertical_divider"
-                    android:layout_height="fill_parent"
-                    android:layout_width="@dimen/format_bar_horizontal_divider_height"
-                    style="@style/DividerVertical" >
-                </View>
+            </RelativeLayout>
 
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_heading"
-                    android:background="@drawable/format_bar_button_heading_selector"
-                    android:contentDescription="@string/format_bar_description_heading"
-                    android:layout_height="fill_parent"
-                    android:layout_marginLeft="@dimen/format_bar_left_margin"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
-
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_list"
-                    android:background="@drawable/format_bar_button_ul_selector"
-                    android:contentDescription="@string/format_bar_description_list"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
-
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_quote"
-                    android:background="@drawable/format_bar_button_quote_selector"
-                    android:contentDescription="@string/format_bar_description_quote"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
-
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_bold"
-                    android:background="@drawable/format_bar_button_bold_selector"
-                    android:contentDescription="@string/format_bar_description_bold"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
-
-                <org.wordpress.aztec.toolbar.RippleToggleButton
-                    android:id="@+id/format_bar_button_italic"
-                    android:background="@drawable/format_bar_button_italic_selector"
-                    android:contentDescription="@string/format_bar_description_italic"
-                    android:layout_height="fill_parent"
-                    android:layout_width="wrap_content"
-                    style="@style/FormatBarButton" >
-                </org.wordpress.aztec.toolbar.RippleToggleButton>
-
-            </LinearLayout>
+            <!-- Hidden view used to force ellipsis icons to layout right/end -->
+            <View
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                android:layout_width="0dp"
+                android:visibility="invisible" >
+            </View>
 
             <org.wordpress.aztec.toolbar.RippleToggleButton
                 android:id="@+id/format_bar_button_ellipsis_expand"
                 android:background="@drawable/format_bar_button_ellipsis_horizontal_selector"
                 android:contentDescription="@string/format_bar_description_ellipsis_expand"
-                android:layout_alignParentRight="true"
-                android:layout_alignRight="@+id/format_bar_button_layout_expanded"
                 android:layout_height="fill_parent"
                 android:layout_width="wrap_content"
                 style="@style/FormatBarButton" >
@@ -193,13 +206,12 @@
                 android:background="@drawable/format_bar_button_ellipsis_vertical_selector"
                 android:contentDescription="@string/format_bar_description_ellipsis_collapse"
                 android:layout_height="fill_parent"
-                android:layout_toRightOf="@+id/format_bar_button_layout_expanded"
                 android:layout_width="wrap_content"
                 android:visibility="gone"
                 style="@style/FormatBarButton" >
             </org.wordpress.aztec.toolbar.RippleToggleButton>
 
-        </RelativeLayout>
+        </LinearLayout>
 
     </HorizontalScrollView>
 


### PR DESCRIPTION
### Fix
Update advanced toolbar layout to stick ellipsis buttons to the right side of the layout when toggling collapsed and expanded views.

***Before***
![before](https://user-images.githubusercontent.com/3827611/27456006-934c1b40-575c-11e7-8809-23fb845ea4c1.gif)

***After***
![after](https://user-images.githubusercontent.com/3827611/27456434-40f589ba-575e-11e7-840d-91cf8d9498d3.gif)

### Test
0. Add `aztec:advanced="true"` to [AztecToolbar](https://github.com/wordpress-mobile/AztecEditor-Android/blob/develop/app/src/main/res/layout-v17/activity_main.xml#L8-L13) view.
1. Launch demonstration app.
2. Tap ***Expand Toolbar*** button.
3. Notice ***Collapse Toolbar*** button remains on right.

#### Note
This is best tested using a device that is wider than 682dp.