### PR TITLE
Issue/394 reset media span by attributes

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -268,7 +268,7 @@ class MainActivity : AppCompatActivity(),
         val runnable: Runnable = Runnable {
             aztec.setOverlayLevel(predicate, 1, progress)
             aztec.updateElementAttributes(predicate, attrs)
-            aztec.resetAttributedSpan(predicate)
+            aztec.resetAttributeMediaSpan(predicate)
             progress += 2000
 
             if (progress >= 10000) {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -268,7 +268,7 @@ class MainActivity : AppCompatActivity(),
         val runnable: Runnable = Runnable {
             aztec.setOverlayLevel(predicate, 1, progress)
             aztec.updateElementAttributes(predicate, attrs)
-            aztec.resetAttributeMediaSpan(predicate)
+            aztec.resetAttributedMediaSpan(predicate)
             progress += 2000
 
             if (progress >= 10000) {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -37,7 +37,6 @@ import org.wordpress.aztec.Html
 import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader
 import org.wordpress.aztec.picassoloader.PicassoImageLoader
 import org.wordpress.aztec.source.SourceViewEditText
-import org.wordpress.aztec.spans.AztecMediaSpan
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.AztecToolbarClickListener
 import org.xml.sax.Attributes
@@ -127,7 +126,7 @@ class MainActivity : AppCompatActivity(),
                 LONG_TEXT +
                 VIDEO
 
-        private val isRunningTest : Boolean by lazy {
+        private val isRunningTest: Boolean by lazy {
             try {
                 Class.forName("android.support.test.espresso.Espresso")
                 true
@@ -221,14 +220,14 @@ class MainActivity : AppCompatActivity(),
 
     fun insertImageAndSimulateUpload(bitmap: Bitmap?, mediaPath: String) {
         val (id, attrs) = generateAttributesForMedia(mediaPath, isVideo = false)
-        val mediaSpan = aztec.insertImage(BitmapDrawable(resources, bitmap), attrs)
-        insertMediaAndSimulateUpload(id, attrs, mediaSpan)
+        aztec.insertImage(BitmapDrawable(resources, bitmap), attrs)
+        insertMediaAndSimulateUpload(id, attrs)
     }
 
     fun insertVideoAndSimulateUpload(bitmap: Bitmap?, mediaPath: String) {
         val (id, attrs) = generateAttributesForMedia(mediaPath, isVideo = true)
-        val mediaSpan = aztec.insertVideo(BitmapDrawable(resources, bitmap), attrs)
-        insertMediaAndSimulateUpload(id, attrs, mediaSpan)
+        aztec.insertVideo(BitmapDrawable(resources, bitmap), attrs)
+        insertMediaAndSimulateUpload(id, attrs)
     }
 
     private fun generateAttributesForMedia(mediaPath: String, isVideo: Boolean): Pair<String, AztecAttributes> {
@@ -246,7 +245,7 @@ class MainActivity : AppCompatActivity(),
         return Pair(id, attrs)
     }
 
-    private fun insertMediaAndSimulateUpload(id: String, attrs: AztecAttributes, mediaSpan: AztecMediaSpan) {
+    private fun insertMediaAndSimulateUpload(id: String, attrs: AztecAttributes) {
         val predicate = object : AztecText.AttributePredicate {
             override fun matches(attrs: Attributes): Boolean {
                 return attrs.getValue("id") == id
@@ -269,7 +268,7 @@ class MainActivity : AppCompatActivity(),
         val runnable: Runnable = Runnable {
             aztec.setOverlayLevel(predicate, 1, progress)
             aztec.updateElementAttributes(predicate, attrs)
-            aztec.updateMediaSpan(mediaSpan)
+            aztec.resetAttributedSpan(predicate)
             progress += 2000
 
             if (progress >= 10000) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1111,7 +1111,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 .firstOrNull()?.attributes = attrs
     }
 
-    fun resetAttributeMediaSpan(attributePredicate: AttributePredicate) {
+    fun resetAttributedMediaSpan(attributePredicate: AttributePredicate) {
         text.getSpans(0, text.length, AztecMediaSpan::class.java)
                 .filter {
                     attributePredicate.matches(it.attributes) && text.getSpanStart(it) != -1 && text.getSpanEnd(it) != -1

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1111,7 +1111,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 .firstOrNull()?.attributes = attrs
     }
 
-    fun resetAttributedSpan(attributePredicate: AttributePredicate) {
+    fun resetAttributeMediaSpan(attributePredicate: AttributePredicate) {
         text.getSpans(0, text.length, AztecMediaSpan::class.java)
                 .filter {
                     attributePredicate.matches(it.attributes) && text.getSpanStart(it) != -1 && text.getSpanEnd(it) != -1

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1070,12 +1070,12 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         }
     }
 
-    fun insertImage(drawable: Drawable?, attributes: Attributes): AztecMediaSpan {
-        return lineBlockFormatter.insertImage(drawable, attributes, onImageTappedListener)
+    fun insertImage(drawable: Drawable?, attributes: Attributes) {
+        lineBlockFormatter.insertImage(drawable, attributes, onImageTappedListener)
     }
 
-    fun insertVideo(drawable: Drawable?, attributes: Attributes): AztecMediaSpan {
-        return lineBlockFormatter.insertVideo(drawable, attributes, onVideoTappedListener)
+    fun insertVideo(drawable: Drawable?, attributes: Attributes) {
+        lineBlockFormatter.insertVideo(drawable, attributes, onVideoTappedListener)
     }
 
     fun removeMedia(attributePredicate: AttributePredicate) {
@@ -1111,10 +1111,14 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 .firstOrNull()?.attributes = attrs
     }
 
-    fun updateMediaSpan(mediaSpan: AztecMediaSpan) {
-        if (text.getSpanStart(mediaSpan) != -1 && text.getSpanEnd(mediaSpan) != -1) {
-            editableText.setSpan(mediaSpan, text.getSpanStart(mediaSpan), text.getSpanEnd(mediaSpan), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
+    fun resetAttributedSpan(attributePredicate: AttributePredicate) {
+        text.getSpans(0, text.length, AztecMediaSpan::class.java)
+                .filter {
+                    attributePredicate.matches(it.attributes) && text.getSpanStart(it) != -1 && text.getSpanEnd(it) != -1
+                }
+                .forEach {
+                    editableText.setSpan(it, text.getSpanStart(it), text.getSpanEnd(it), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+                }
     }
 
     fun setOverlayLevel(attributePredicate: AttributePredicate, index: Int, level: Int) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -125,10 +125,10 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         val nestingLevel = AztecNestable.getNestingLevelAt(editableText, selectionStart)
 
         val span = AztecHorizontalRuleSpan(
-            editor.context,
-            ContextCompat.getDrawable(editor.context, R.drawable.img_hr),
-            nestingLevel,
-            editor
+                editor.context,
+                ContextCompat.getDrawable(editor.context, R.drawable.img_hr),
+                nestingLevel,
+                editor
         )
 
         val builder = SpannableStringBuilder(Constants.MAGIC_STRING)
@@ -137,26 +137,26 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         editableText.replace(selectionStart, selectionEnd, builder)
 
         editor.setSelection(
-            if (selectionEnd < EndOfBufferMarkerAdder.safeLength(editor)) {
-                selectionEnd + 1
-            } else {
-                selectionEnd
-            }
+                if (selectionEnd < EndOfBufferMarkerAdder.safeLength(editor)) {
+                    selectionEnd + 1
+                } else {
+                    selectionEnd
+                }
         )
     }
 
-    fun insertVideo(drawable: Drawable?, attributes: Attributes, onVideoTappedListener: OnVideoTappedListener?): AztecMediaSpan {
+    fun insertVideo(drawable: Drawable?, attributes: Attributes, onVideoTappedListener: OnVideoTappedListener?) {
         val nestingLevel = AztecNestable.getNestingLevelAt(editableText, selectionStart)
         val span = AztecVideoSpan(editor.context, drawable, nestingLevel, AztecAttributes(attributes), onVideoTappedListener, editor)
-        return insertMedia(span)
+        insertMedia(span)
     }
 
-    fun insertImage(drawable: Drawable?, attributes: Attributes, onImageTappedListener: OnImageTappedListener?): AztecMediaSpan {
+    fun insertImage(drawable: Drawable?, attributes: Attributes, onImageTappedListener: OnImageTappedListener?) {
         val span = AztecImageSpan(editor.context, drawable, AztecAttributes(attributes), onImageTappedListener, editor)
-        return insertMedia(span)
+        insertMedia(span)
     }
 
-    private fun insertMedia(span: AztecMediaSpan): AztecMediaSpan {
+    private fun insertMedia(span: AztecMediaSpan) {
         val spanBeforeMedia = editableText.getSpans(selectionStart, selectionEnd, AztecBlockSpan::class.java)
                 .firstOrNull {
                     selectionStart == editableText.getSpanEnd(it)
@@ -198,7 +198,5 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         editor.setSelection(
                 if (selectionEnd < EndOfBufferMarkerAdder.safeLength(editor)) selectionEnd + 1 else selectionEnd)
         editor.isMediaAdded = true
-
-        return span
     }
 }


### PR DESCRIPTION
### Aztec side fix for #394

When updating the progress of uploading media spans, instead of exposing inserted spans we are going to use `AttributePredicate`, that is available at client side to locate and reset them.


### Test
1. Open demo app.
2. Add image to the editor.
3. While the image is being uploaded make sure that cursor is not moving.

On client side instead of calling `refreshText()` during media upload events, we will call `resetAttributeMediaSpan()`.