### PR TITLE
Issue/396 fixing image click detection

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -1,7 +1,6 @@
 package org.wordpress.aztec
 
 import android.graphics.Rect
-import android.text.Selection
 import android.text.Spannable
 import android.text.method.ArrowKeyMovementMethod
 import android.text.style.ClickableSpan
@@ -52,11 +51,7 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
                 if (link != null && (link is AztecMediaClickableSpan || link is UnknownClickableSpan)) {
                     if (action == MotionEvent.ACTION_UP) {
                         link.onClick(widget)
-                    } else {
-                        if (link is UnknownClickableSpan)
-                            Selection.setSelection(text, text.getSpanStart(link), text.getSpanEnd(link))
                     }
-
                     return true
                 }
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -29,7 +29,7 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
 
             val layout = widget.layout
             val line = layout.getLineForVertical(y)
-            val off = layout.getOffsetForHorizontal(line, x.toFloat())
+            val off = layout.getOffsetForHorizontal(line, x.toFloat()) +1
 
             // get the character's position. This may be the left or the right edge of the character so, find the
             //  other edge by inspecting nearby characters (if they exist)
@@ -40,7 +40,7 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val lineRect = Rect()
             layout.getLineBounds(line, lineRect)
 
-            if (((x >= charPrevX && x <= charX) || (x >= charX && x <= charNextX))
+            if (((x in charPrevX..charX) || (x in charX..charNextX))
                     && y >= lineRect.top && y <= lineRect.bottom) {
                 val link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull()
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -29,7 +29,11 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
 
             val layout = widget.layout
             val line = layout.getLineForVertical(y)
-            val off = layout.getOffsetForHorizontal(line, x.toFloat()) +1
+            var off = layout.getOffsetForHorizontal(line, x.toFloat())
+
+            if (text.length > off) {
+                off++
+            }
 
             // get the character's position. This may be the left or the right edge of the character so, find the
             //  other edge by inspecting nearby characters (if they exist)
@@ -49,7 +53,8 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
                     if (action == MotionEvent.ACTION_UP) {
                         link.onClick(widget)
                     } else {
-                        Selection.setSelection(text, text.getSpanStart(link), text.getSpanEnd(link))
+                        if (link is UnknownClickableSpan)
+                            Selection.setSelection(text, text.getSpanStart(link), text.getSpanEnd(link))
                     }
 
                     return true


### PR DESCRIPTION
### Fixes #396 

Improves hit detection for images without spacing between them.

To test:

1. Load empty editor.
2. Add image.
3. Add another image, that is big enough to render below the first image, like this:
<img width="485" alt="tworobots" src="https://user-images.githubusercontent.com/728822/27937169-17fdab52-626a-11e7-8568-77838319acf3.png">
4. Make sure both images are clickable.
