### PR TITLE
Issue/363 fixing quote parsing crash

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -180,7 +180,7 @@ class AztecParser {
             val spanEnd = spanned.getSpanEnd(it)
 
             // block spans include a newline at the end, we need to account for that
-            val newlineExpected = if (it is AztecBlockSpan) spanEnd - 1 else spanEnd
+            val newlineExpected = if (it is AztecBlockSpan && spanEnd > 0) spanEnd - 1 else spanEnd
 
             if (spanEnd == spanned.length) {
                 // no visual newline if at text end

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/TextDeleter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/TextDeleter.kt
@@ -21,14 +21,14 @@ class TextDeleter private constructor(aztecText: AztecText) : TextWatcher {
             return
         }
 
-        aztecTextRef.get()?.text?.let { text ->
-            text.getSpans(0, text.length, MarkForDeletion::class.java).forEach {
-                val start = text.getSpanStart(it)
-                val end = text.getSpanEnd(it)
+        text.getSpans(0, text.length, MarkForDeletion::class.java).forEach {
+            val start = text.getSpanStart(it)
+            val end = text.getSpanEnd(it)
 
-                if (start > -1 && end > -1) {
-                    text.delete(text.getSpanStart(it), text.getSpanEnd(it))
-                }
+            if (start > -1 && end > -1) {
+                aztecTextRef.get()?.disableTextChangedListener()
+                text.delete(start, end)
+                aztecTextRef.get()?.enableTextChangedListener()
             }
         }
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
@@ -92,4 +92,26 @@ class BlockElementsTest {
         Assert.assertTrue(safeEmpty(editText))
         Assert.assertEquals("", editText.toHtml())
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun testCollapsingEmptyQuoteAboveNewline() {
+        safeAppend(editText, "\n")
+        editText.setSelection(0)
+        editText.toggleFormatting(TextFormat.FORMAT_QUOTE)
+        editText.text.insert(0,"\n")
+
+        Assert.assertEquals("", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testCollapsingEmptyListAboveNewline() {
+        safeAppend(editText, "\n")
+        editText.setSelection(0)
+        editText.toggleFormatting(TextFormat.FORMAT_ORDERED_LIST)
+        editText.text.insert(0,"\n")
+
+        Assert.assertEquals("", editText.toHtml())
+    }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
@@ -101,7 +101,7 @@ class BlockElementsTest {
         editText.toggleFormatting(TextFormat.FORMAT_QUOTE)
         editText.text.insert(0,"\n")
 
-        Assert.assertEquals("", editText.toHtml())
+        Assert.assertEquals("<br>", editText.toHtml())
     }
 
     @Test
@@ -112,6 +112,6 @@ class BlockElementsTest {
         editText.toggleFormatting(TextFormat.FORMAT_ORDERED_LIST)
         editText.text.insert(0,"\n")
 
-        Assert.assertEquals("", editText.toHtml())
+        Assert.assertEquals("<br>", editText.toHtml())
     }
 }


### PR DESCRIPTION
### Fixes #363


### Test

1. Load empty editor.
2. Press enter.
3. Move cursor back to the first line.
4. Toggle Blockquote.
5. Press enter.
6. Notice that nothing has exploded and the quote has closed properly.
