### PR TITLE
Improving hit detection of clickable span.

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -45,7 +45,8 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val clickedOnSpanToTheLeftOfCursor = x in charPrevX..charX
             val clickedOnSpanToTheRightOfCursor = x in charX..charNextX
 
-            val clickedOnSpan = clickedWithinLineHeight && (clickedOnSpanToTheLeftOfCursor || clickedOnSpanToTheRightOfCursor)
+            val clickedOnSpan = clickedWithinLineHeight &&
+                    (clickedOnSpanToTheLeftOfCursor || clickedOnSpanToTheRightOfCursor)
 
             val clickedSpanBordersAnotherOne = (text.getSpans(off, off, ClickableSpan::class.java).size == 1 &&
                     text.getSpans(off + 1, off + 1, ClickableSpan::class.java).isNotEmpty())
@@ -54,7 +55,6 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
 
             val failedToPinpointClickedSpan = (isClickedSpanAmbiguous || clickedSpanBordersAnotherOne)
                     && !clickedOnSpanToTheLeftOfCursor && !clickedOnSpanToTheRightOfCursor
-
 
             var link: ClickableSpan? = null
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -26,14 +26,11 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             x += widget.scrollX
             y += widget.scrollY
 
+            if(x < 0) return true
+
             val layout = widget.layout
             val line = layout.getLineForVertical(y)
             val off = layout.getOffsetForHorizontal(line, x.toFloat())
-
-            val clickedSpanBordersAnotherOne = (text.getSpans(off, off, AztecMediaClickableSpan::class.java).size == 1 &&
-                    text.getSpans(off + 1, off + 1, AztecMediaClickableSpan::class.java).isNotEmpty())
-
-            val isClickedSpanAmbiguous = text.getSpans(off, off, AztecMediaClickableSpan::class.java).size > 1
 
             // get the character's position. This may be the left or the right edge of the character so, find the
             //  other edge by inspecting nearby characters (if they exist)
@@ -49,6 +46,11 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val clickedOnSpanToTheRightOfCursor = x in charX..charNextX
 
             val clickedOnSpan = clickedWithinLineHeight && (clickedOnSpanToTheLeftOfCursor || clickedOnSpanToTheRightOfCursor)
+
+            val clickedSpanBordersAnotherOne = (text.getSpans(off, off, ClickableSpan::class.java).size == 1 &&
+                    text.getSpans(off + 1, off + 1, ClickableSpan::class.java).isNotEmpty())
+
+            val isClickedSpanAmbiguous = text.getSpans(off, off, ClickableSpan::class.java).size > 1
 
             val failedToPinpointClickedSpan = (isClickedSpanAmbiguous || clickedSpanBordersAnotherOne)
                     && !clickedOnSpanToTheLeftOfCursor && !clickedOnSpanToTheRightOfCursor


### PR DESCRIPTION
Fixes #396 (again).
This PR also improves the hit detection for clickable spans.

### Test
1. Load editor.
2. Insert a couple of images right after another without any character between them.
3. Click on them and make sure that click events are properly fired.
