### PR TITLE
Try to reduce memory usage with images

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -12,7 +12,7 @@ import android.view.View
 import org.wordpress.aztec.AztecText
 import java.lang.ref.WeakReference
 
-abstract class AztecDynamicImageSpan(val context: Context, private var imageDrawable: Drawable?) : DynamicDrawableSpan() {
+abstract class AztecDynamicImageSpan(val context: Context, protected var imageDrawable: Drawable?) : DynamicDrawableSpan() {
 
     var textView: AztecText? = null
     var originalBounds = Rect(imageDrawable?.bounds ?: Rect(0, 0, 0, 0))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -12,7 +12,7 @@ import android.view.View
 import org.wordpress.aztec.AztecText
 import java.lang.ref.WeakReference
 
-abstract class AztecDynamicImageSpan(val context: Context, protected var imageDrawable: Drawable?) : DynamicDrawableSpan() {
+abstract class AztecDynamicImageSpan(val context: Context, private var imageDrawable: Drawable?) : DynamicDrawableSpan() {
 
     var textView: AztecText? = null
     var originalBounds = Rect(imageDrawable?.bounds ?: Rect(0, 0, 0, 0))
@@ -20,7 +20,7 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
 
     private var measuring = false
 
-    private var mDrawableRef: WeakReference<Drawable>? = WeakReference<Drawable>(imageDrawable)
+    protected var mDrawableRef: WeakReference<Drawable>? = WeakReference<Drawable>(imageDrawable)
 
     companion object {
         @JvmStatic protected fun setInitBounds(drawable: Drawable?) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -20,7 +20,7 @@ abstract class AztecDynamicImageSpan(val context: Context, imageDrawable: Drawab
 
     private var measuring = false
 
-    protected var mDrawableRef: WeakReference<Drawable>? = WeakReference<Drawable>(imageDrawable)
+    protected var drawableRef: WeakReference<Drawable>? = WeakReference<Drawable>(imageDrawable)
 
     companion object {
         @JvmStatic protected fun setInitBounds(drawable: Drawable?) {
@@ -59,9 +59,9 @@ abstract class AztecDynamicImageSpan(val context: Context, imageDrawable: Drawab
     }
 
     init {
-        computeAspectRatio(mDrawableRef?.get())
+        computeAspectRatio(drawableRef?.get())
 
-        setInitBounds(mDrawableRef?.get())
+        setInitBounds(drawableRef?.get())
     }
 
     fun computeAspectRatio(drawable: Drawable?) {
@@ -89,7 +89,7 @@ abstract class AztecDynamicImageSpan(val context: Context, imageDrawable: Drawab
     }
 
     fun adjustBounds(start: Int): Rect {
-        var drawable: Drawable? = mDrawableRef?.get()
+        var drawable: Drawable? = drawableRef?.get()
 
         if (textView == null || textView?.widthMeasureSpec == 0) {
             return Rect(drawable?.bounds ?: Rect(0, 0, 0, 0))
@@ -174,7 +174,7 @@ abstract class AztecDynamicImageSpan(val context: Context, imageDrawable: Drawab
     }
 
     override fun getDrawable(): Drawable? {
-        return mDrawableRef?.get()
+        return drawableRef?.get()
     }
 
     override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -12,7 +12,7 @@ import android.view.View
 import org.wordpress.aztec.AztecText
 import java.lang.ref.WeakReference
 
-abstract class AztecDynamicImageSpan(val context: Context, protected var imageDrawable: Drawable?) : DynamicDrawableSpan() {
+abstract class AztecDynamicImageSpan(val context: Context, imageDrawable: Drawable?) : DynamicDrawableSpan() {
 
     var textView: AztecText? = null
     var originalBounds = Rect(imageDrawable?.bounds ?: Rect(0, 0, 0, 0))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
@@ -13,6 +13,6 @@ class AztecImageSpan(context: Context, drawable: Drawable?, attributes: AztecAtt
     override val TAG: String = "img"
 
     override fun onClick() {
-        onImageTappedListener?.onImageTapped(attributes, getWidth(imageDrawable), getHeight(imageDrawable))
+        onImageTappedListener?.onImageTapped(attributes, getWidth(getDrawable()), getHeight(getDrawable()))
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -23,7 +23,7 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     }
 
     fun setDrawable(newDrawable: Drawable?) {
-        mDrawableRef = WeakReference<Drawable>(newDrawable)
+        drawableRef = WeakReference<Drawable>(newDrawable)
 
         originalBounds = Rect(getDrawable()?.bounds ?: Rect(0, 0, 0, 0))
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable
 import android.view.Gravity
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
+import java.lang.ref.WeakReference
 import java.util.*
 
 abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
@@ -22,9 +23,9 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     }
 
     fun setDrawable(newDrawable: Drawable?) {
-        imageDrawable = newDrawable
+        mDrawableRef = WeakReference<Drawable>(newDrawable)
 
-        originalBounds = Rect(imageDrawable?.bounds ?: Rect(0, 0, 0, 0))
+        originalBounds = Rect(getDrawable()?.bounds ?: Rect(0, 0, 0, 0))
 
         setInitBounds(newDrawable)
 
@@ -53,8 +54,8 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     }
 
     private fun applyOverlayGravity(overlay: Drawable?, gravity: Int) {
-        if (imageDrawable != null && overlay != null) {
-            val rect = Rect(0, 0, imageDrawable!!.bounds.width(), imageDrawable!!.bounds.height())
+        if (getDrawable() != null && overlay != null) {
+            val rect = Rect(0, 0, getDrawable()!!.bounds.width(), getDrawable()!!.bounds.height())
             val outRect = Rect()
 
             Gravity.apply(gravity, overlay.bounds.width(), overlay.bounds.height(), rect, outRect)
@@ -66,14 +67,14 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
         canvas.save()
 
-        if (imageDrawable != null) {
+        if (getDrawable() != null) {
             var transY = top
             if (mVerticalAlignment == ALIGN_BASELINE) {
                 transY -= paint.fontMetricsInt.descent
             }
 
             canvas.translate(x, transY.toFloat())
-            imageDrawable!!.draw(canvas)
+            getDrawable()!!.draw(canvas)
         }
 
         overlays.forEach {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -28,7 +28,7 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
 
         setInitBounds(newDrawable)
 
-        computeAspectRatio()
+        computeAspectRatio(newDrawable)
     }
 
     fun setOverlay(index: Int, newDrawable: Drawable?, gravity: Int) {


### PR DESCRIPTION
### Fix #420 
by using weak references to images added to the editor.  The ticket has better description about the issue, and why we're trying this way of retaining drawables.

### Test
1. Add a lot of pictures to the editor.
2. Scroll up and down, add other pictures.
3. Do not close the app, but exit the editor. 
4. Repeat steps above and check that the app doesn't crash.


There is a wp-android branch that use this - https://github.com/wordpress-mobile/WordPress-Android/tree/danilo/aztec-media-testing

