### PR TITLE
Disable styling of multiline text with lingering/trailing newlines.

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
@@ -109,7 +109,12 @@ abstract class BlockHandler<SpanType : IAztecBlockSpan>(val clazz: Class<SpanTyp
 
     companion object {
         fun set(text: Spannable, block: IAztecBlockSpan, start: Int, end: Int) {
-            text.setSpan(block, start, end, Spanned.SPAN_PARAGRAPH)
+            //TODO Super temporary fix that disables styling multiline selection with trailing/leading newlines
+            try{
+                text.setSpan(block, start, end, Spanned.SPAN_PARAGRAPH)
+            }catch (e: RuntimeException){
+            }
+
         }
     }
 }


### PR DESCRIPTION
This is a temporary fix for #418 to prevent future crashes until the issue is properly resolved.

Allowing styling of empty lines resulted in series of crashes in scenarios where styling didn't work before.
This PR adds a temporary try/catch block so the interactions that didn't work before will continue not to work instead of crashing.

😭 

