### PR TITLE
Use default WordPress video shortcode for quick testing

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -225,6 +225,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         reader.setContentHandler(this);
         try {
             reader.setProperty(Parser.lexicalHandlerProperty, this);
+            source = source.replaceAll("\\[video([^\\]]*)\\]", "<video$1/>");
             reader.parse(new InputSource(new StringReader(source)));
         } catch (IOException e) {
             // We are reading from a string. There should not be IO problems.

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -88,7 +88,7 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
         canvas.restore()
     }
 
-    fun getHtml(): String {
+    open fun getHtml(): String {
         val sb = StringBuilder()
         sb.append("<")
         sb.append(TAG)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -13,28 +13,22 @@ class AztecVideoSpan(context: Context, drawable: Drawable?, override var nesting
                      editor: AztecText? = null) :
         AztecMediaSpan(context, drawable, attributes, editor), IAztecFullWidthImageSpan, IAztecSpan {
 
-    override val TAG: String = "a"
+    override val TAG: String = "video"
 
     init {
         setOverlay(0, ContextCompat.getDrawable(context, android.R.drawable.ic_media_play), Gravity.CENTER)
     }
 
     override fun getHtml(): String {
-        val linkText = attributes.getValue("href") ?: ""
-
         val sb = StringBuilder()
-        sb.append("<")
+        sb.append(" [")
         sb.append(TAG)
         sb.append(' ')
 
         attributes.removeAttribute("aztec_id")
 
         sb.append(attributes)
-        sb.append(">")
-        sb.append(linkText)
-        sb.append("</")
-        sb.append(TAG)
-        sb.append(">")
+        sb.append("] ")
         return sb.toString()
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -19,7 +19,6 @@ class AztecVideoSpan(context: Context, drawable: Drawable?, override var nesting
         setOverlay(0, ContextCompat.getDrawable(context, android.R.drawable.ic_media_play), Gravity.CENTER)
     }
 
-    
     override fun onClick() {
         onVideoTappedListener?.onVideoTapped(attributes)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -19,6 +19,7 @@ class AztecVideoSpan(context: Context, drawable: Drawable?, override var nesting
         setOverlay(0, ContextCompat.getDrawable(context, android.R.drawable.ic_media_play), Gravity.CENTER)
     }
 
+    
     override fun onClick() {
         onVideoTappedListener?.onVideoTapped(attributes)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -13,7 +13,7 @@ class AztecVideoSpan(context: Context, drawable: Drawable?, override var nesting
                      editor: AztecText? = null) :
         AztecMediaSpan(context, drawable, attributes, editor), IAztecFullWidthImageSpan, IAztecSpan {
 
-    override val TAG: String = "video"
+    override val TAG: String = "link"
 
     init {
         setOverlay(0, ContextCompat.getDrawable(context, android.R.drawable.ic_media_play), Gravity.CENTER)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -13,10 +13,29 @@ class AztecVideoSpan(context: Context, drawable: Drawable?, override var nesting
                      editor: AztecText? = null) :
         AztecMediaSpan(context, drawable, attributes, editor), IAztecFullWidthImageSpan, IAztecSpan {
 
-    override val TAG: String = "link"
+    override val TAG: String = "a"
 
     init {
         setOverlay(0, ContextCompat.getDrawable(context, android.R.drawable.ic_media_play), Gravity.CENTER)
+    }
+
+    override fun getHtml(): String {
+        val linkText = attributes.getValue("href") ?: ""
+
+        val sb = StringBuilder()
+        sb.append("<")
+        sb.append(TAG)
+        sb.append(' ')
+
+        attributes.removeAttribute("aztec_id")
+
+        sb.append(attributes)
+        sb.append(">")
+        sb.append(linkText)
+        sb.append("</")
+        sb.append(TAG)
+        sb.append(">")
+        return sb.toString()
     }
 
     override fun onClick() {


### PR DESCRIPTION
This PR basically changes the HTML produced by `AztecVideoSpan`, and prints out the `[video]` default WP shortcode Ref: https://codex.wordpress.org/Video_Shortcode instead of the HTML `video` tag.

This is a quick fix to make video upload working in wp-android, to be used until a full shortcode support is completed in Aztec.