### PR TITLE
Fix drawables keep disappearing

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
@@ -13,6 +13,6 @@ class AztecImageSpan(context: Context, drawable: Drawable?, attributes: AztecAtt
     override val TAG: String = "img"
 
     override fun onClick() {
-        onImageTappedListener?.onImageTapped(attributes, getWidth(getDrawable()), getHeight(getDrawable()))
+        onImageTappedListener?.onImageTapped(attributes, getWidth(imageDrawable), getHeight(imageDrawable))
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -8,7 +8,6 @@ import android.graphics.drawable.Drawable
 import android.view.Gravity
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
-import java.lang.ref.WeakReference
 import java.util.*
 
 abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
@@ -23,13 +22,13 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     }
 
     fun setDrawable(newDrawable: Drawable?) {
-        drawableRef = WeakReference<Drawable>(newDrawable)
+        imageDrawable = newDrawable
 
-        originalBounds = Rect(getDrawable()?.bounds ?: Rect(0, 0, 0, 0))
+        originalBounds = Rect(imageDrawable?.bounds ?: Rect(0, 0, 0, 0))
 
         setInitBounds(newDrawable)
 
-        computeAspectRatio(newDrawable)
+        computeAspectRatio()
     }
 
     fun setOverlay(index: Int, newDrawable: Drawable?, gravity: Int) {
@@ -54,8 +53,8 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     }
 
     private fun applyOverlayGravity(overlay: Drawable?, gravity: Int) {
-        if (getDrawable() != null && overlay != null) {
-            val rect = Rect(0, 0, getDrawable()!!.bounds.width(), getDrawable()!!.bounds.height())
+        if (imageDrawable != null && overlay != null) {
+            val rect = Rect(0, 0, imageDrawable!!.bounds.width(), imageDrawable!!.bounds.height())
             val outRect = Rect()
 
             Gravity.apply(gravity, overlay.bounds.width(), overlay.bounds.height(), rect, outRect)
@@ -67,14 +66,14 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
         canvas.save()
 
-        if (getDrawable() != null) {
+        if (imageDrawable != null) {
             var transY = top
             if (mVerticalAlignment == ALIGN_BASELINE) {
                 transY -= paint.fontMetricsInt.descent
             }
 
             canvas.translate(x, transY.toFloat())
-            getDrawable()!!.draw(canvas)
+            imageDrawable!!.draw(canvas)
         }
 
         overlays.forEach {


### PR DESCRIPTION
Fix #431 by reverting wordpress-mobile/AztecEditor-Android#421

Didn't find an easy way to fix this, except on reverting #431.
We should probably not pass a drawable in the constructor of `AztecDynamicImageSpan`, but a reference instead, and create the drawable when it's required (image is on the screen). Dispose the drawable when it's in not on the screen. Re-create the drawable when needed.

See `DynamicDrawableSpan`.
