### PR TITLE
[Not ready to be merged] Possible fix for OOM issues with pictures

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -172,7 +172,7 @@ class MainActivity : AppCompatActivity(),
                     options.inDensity = DisplayMetrics.DENSITY_DEFAULT
                     bitmap = BitmapFactory.decodeFile(mediaPath, options)
 
-                    insertImageAndSimulateUpload(bitmap, mediaPath)
+                    insertImageAndSimulateUpload(mediaPath)
                 }
                 REQUEST_MEDIA_PHOTO -> {
                     mediaPath = data?.data.toString()
@@ -183,7 +183,7 @@ class MainActivity : AppCompatActivity(),
                     options.inDensity = DisplayMetrics.DENSITY_DEFAULT
                     bitmap = BitmapFactory.decodeStream(stream, null, options)
 
-                    insertImageAndSimulateUpload(bitmap, mediaPath)
+                    insertImageAndSimulateUpload(mediaPath)
                 }
                 REQUEST_MEDIA_CAMERA_VIDEO -> {
                     mediaPath = data?.data.toString()
@@ -202,7 +202,7 @@ class MainActivity : AppCompatActivity(),
                             drawable.setBounds(0, 0, canvas.width, canvas.height)
                             drawable.draw(canvas)
 
-                            insertVideoAndSimulateUpload(bitmap, mediaPath)
+                            insertVideoAndSimulateUpload(mediaPath)
                         }
 
                         override fun onThumbnailLoading(drawable: Drawable?) {
@@ -216,15 +216,15 @@ class MainActivity : AppCompatActivity(),
         super.onActivityResult(requestCode, resultCode, data)
     }
 
-    fun insertImageAndSimulateUpload(bitmap: Bitmap?, mediaPath: String) {
+    fun insertImageAndSimulateUpload(imagePath: String) {
         val (id, attrs) = generateAttributesForMedia(mediaPath, isVideo = false)
-        aztec.visualEditor.insertImage(BitmapDrawable(resources, bitmap), attrs)
+        aztec.visualEditor.insertImage(imagePath, attrs)
         insertMediaAndSimulateUpload(id, attrs)
     }
 
-    fun insertVideoAndSimulateUpload(bitmap: Bitmap?, mediaPath: String) {
+    fun insertVideoAndSimulateUpload(imagePath: String) {
         val (id, attrs) = generateAttributesForMedia(mediaPath, isVideo = true)
-        aztec.visualEditor.insertVideo(BitmapDrawable(resources, bitmap), attrs)
+        aztec.visualEditor.insertVideo(imagePath, attrs)
         insertMediaAndSimulateUpload(id, attrs)
     }
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
     compile 'org.jsoup:jsoup:1.10.2'
+    compile 'org.wordpress:utils:1.16.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.3.2'

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -97,7 +97,7 @@ class AztecTagHandler : Html.TagHandler {
             LINE -> {
                 if (opening) {
                     // Add an extra newline above the line to prevent weird typing on the line above
-                    start(output, AztecHorizontalRuleSpan(context, ContextCompat.getDrawable(context, R.drawable.img_hr), nestingLevel))
+                    start(output, AztecHorizontalRuleSpan(context, R.drawable.img_hr, nestingLevel))
 
                     output.append(Constants.MAGIC_CHAR)
                 } else {
@@ -121,17 +121,21 @@ class AztecTagHandler : Html.TagHandler {
 
     private fun createImageSpan(attributes: AztecAttributes, context: Context) : AztecMediaSpan {
         val styles = context.obtainStyledAttributes(R.styleable.AztecText)
-        val loadingDrawable = ContextCompat.getDrawable(context, styles.getResourceId(R.styleable.AztecText_drawableLoading, R.drawable.ic_image_loading))
+        val image =  AztecImageSpan(context, null, styles.getResourceId(R.styleable.AztecText_drawableLoading, R.drawable.ic_image_loading), attributes)
         styles.recycle()
-        return AztecImageSpan(context, loadingDrawable, attributes)
+        return image
     }
 
     private fun createVideoSpan(attributes: AztecAttributes,
                                 context: Context, nestingLevel: Int) : AztecMediaSpan {
         val styles = context.obtainStyledAttributes(R.styleable.AztecText)
-        val loadingDrawable = ContextCompat.getDrawable(context, styles.getResourceId(R.styleable.AztecText_drawableLoading, R.drawable.ic_image_loading))
+        val video =  AztecVideoSpan(context,
+                null, styles.getResourceId(R.styleable.AztecText_drawableLoading, R.drawable.ic_image_loading),
+                nestingLevel,
+                attributes
+        )
         styles.recycle()
-        return AztecVideoSpan(context, loadingDrawable, nestingLevel, attributes)
+        return video
     }
 
     private fun handleElement(output: Editable, opening: Boolean, span: Any) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -722,12 +722,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
     private fun loadImages() {
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
         spans.forEach {
-            it.drawable = drawable
-                    post {
-                        refreshText()
-                    }
-
-
+            it.imageGetter = imageGetter
             val callbacks = object : Html.ImageGetter.Callbacks {
 
                 override fun onImageFailed() {
@@ -743,17 +738,14 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 }
 
                 private fun replaceImage(drawable: Drawable?) {
-                    /*it.drawable = drawable
                     post {
                         refreshText()
-                    }*/
+                    }
                 }
             }
-
-            // maxidth set to the biggest of screen width/height to cater for device rotation
-            val maxWidth = Math.max(context.resources.displayMetrics.widthPixels,
-                    context.resources.displayMetrics.heightPixels)
-            imageGetter?.loadImage(it.getSource(), callbacks, maxWidth)
+            it.imageURI = it.getSource()
+            it.imageGetterCallbacks = callbacks
+            it.getDrawable() // To start downloading the picture
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -722,10 +722,16 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
     private fun loadImages() {
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
         spans.forEach {
+            it.drawable = drawable
+                    post {
+                        refreshText()
+                    }
+
+
             val callbacks = object : Html.ImageGetter.Callbacks {
 
                 override fun onImageFailed() {
-                    replaceImage(ContextCompat.getDrawable(context, drawableFailed))
+                   replaceImage(ContextCompat.getDrawable(context, drawableFailed))
                 }
 
                 override fun onImageLoaded(drawable: Drawable?) {
@@ -737,10 +743,10 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 }
 
                 private fun replaceImage(drawable: Drawable?) {
-                    it.drawable = drawable
+                    /*it.drawable = drawable
                     post {
                         refreshText()
-                    }
+                    }*/
                 }
             }
 
@@ -758,22 +764,22 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
             val callbacks = object : Html.VideoThumbnailGetter.Callbacks {
 
                 override fun onThumbnailFailed() {
-                    replaceImage(ContextCompat.getDrawable(context, drawableFailed))
+                    //replaceImage(ContextCompat.getDrawable(context, drawableFailed))
                 }
 
                 override fun onThumbnailLoaded(drawable: Drawable?) {
-                    replaceImage(drawable)
+                    //replaceImage(drawable)
                 }
 
                 override fun onThumbnailLoading(drawable: Drawable?) {
-                    replaceImage(ContextCompat.getDrawable(context, drawableLoading))
+                    //replaceImage(ContextCompat.getDrawable(context, drawableLoading))
                 }
 
                 private fun replaceImage(drawable: Drawable?) {
-                    it.drawable = drawable
+                    /*it.drawable = drawable
                     post {
                         refreshText()
-                    }
+                    }*/
                 }
             }
 
@@ -1139,12 +1145,12 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         }
     }
 
-    fun insertImage(drawable: Drawable?, attributes: Attributes) {
-        lineBlockFormatter.insertImage(drawable, attributes, onImageTappedListener)
+    fun insertImage(imagePath : String, attributes: Attributes) {
+        lineBlockFormatter.insertImage(imagePath, attributes, onImageTappedListener)
     }
 
-    fun insertVideo(drawable: Drawable?, attributes: Attributes) {
-        lineBlockFormatter.insertVideo(drawable, attributes, onVideoTappedListener)
+    fun insertVideo(imagePath : String, attributes: Attributes) {
+        lineBlockFormatter.insertVideo(imagePath, attributes, onVideoTappedListener)
     }
 
     fun removeMedia(attributePredicate: AttributePredicate) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -92,7 +92,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
 
         val span = AztecHorizontalRuleSpan(
                 editor.context,
-                ContextCompat.getDrawable(editor.context, R.drawable.img_hr),
+                R.drawable.img_hr,
                 nestingLevel,
                 editor
         )
@@ -111,14 +111,14 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         )
     }
 
-    fun insertVideo(drawable: Drawable?, attributes: Attributes, onVideoTappedListener: OnVideoTappedListener?) {
+    fun insertVideo(imageURI : String, attributes: Attributes, onVideoTappedListener: OnVideoTappedListener?) {
         val nestingLevel = IAztecNestable.getNestingLevelAt(editableText, selectionStart)
-        val span = AztecVideoSpan(editor.context, drawable, nestingLevel, AztecAttributes(attributes), onVideoTappedListener, editor)
+        val span = AztecVideoSpan(editor.context, imageURI, null, nestingLevel, AztecAttributes(attributes), onVideoTappedListener, editor)
         insertMedia(span)
     }
 
-    fun insertImage(drawable: Drawable?, attributes: Attributes, onImageTappedListener: OnImageTappedListener?) {
-        val span = AztecImageSpan(editor.context, drawable, AztecAttributes(attributes), onImageTappedListener, editor)
+    fun insertImage(imageURI : String, attributes: Attributes, onImageTappedListener: OnImageTappedListener?) {
+        val span = AztecImageSpan(editor.context, imageURI, null, AztecAttributes(attributes), onImageTappedListener, editor)
         insertMedia(span)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
@@ -2,12 +2,15 @@ package org.wordpress.aztec.spans
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.support.annotation.DrawableRes
+import android.support.v4.content.ContextCompat
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.R
 
-class AztecHorizontalRuleSpan(context: Context, drawable: Drawable, override var nestingLevel: Int,
+class AztecHorizontalRuleSpan(context: Context, resId : Int, override var nestingLevel: Int,
                               editor: AztecText? = null, override var attributes: AztecAttributes = AztecAttributes()) :
-        AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecDynamicImageSpan(context, null, resId), IAztecFullWidthImageSpan, IAztecSpan {
 
     init {
         textView = editor

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
@@ -5,14 +5,14 @@ import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 
-class AztecImageSpan(context: Context, drawable: Drawable?, attributes: AztecAttributes = AztecAttributes(),
+class AztecImageSpan(context: Context, imageURI: String?, resId : Int?, attributes: AztecAttributes = AztecAttributes(),
                      var onImageTappedListener: AztecText.OnImageTappedListener? = null,
                      editor: AztecText? = null) :
-        AztecMediaSpan(context, drawable, attributes, editor) {
+        AztecMediaSpan(context, imageURI, resId, attributes, editor) {
 
     override val TAG: String = "img"
 
     override fun onClick() {
-        onImageTappedListener?.onImageTapped(attributes, getWidth(getDrawable()), getHeight(getDrawable()))
+        onImageTappedListener?.onImageTapped(attributes, getWidth(drawable), getHeight(drawable))
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -22,16 +22,6 @@ abstract class AztecMediaSpan(context: Context, imageURI: String?, resId : Int?,
         textView = editor
     }
 
-    fun setDrawablePath(newDrawable: Drawable?) {
-        drawableRef = WeakReference<Drawable>(newDrawable)
-
-        originalBounds = Rect(getDrawable()?.bounds ?: Rect(0, 0, 0, 0))
-
-        setInitBounds(newDrawable)
-
-        computeAspectRatio(newDrawable)
-    }
-
     fun setOverlay(index: Int, newDrawable: Drawable?, gravity: Int) {
         if (overlays.lastIndex >= index) {
             overlays.removeAt(index)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -11,8 +11,8 @@ import org.wordpress.aztec.AztecText
 import java.lang.ref.WeakReference
 import java.util.*
 
-abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
-                              editor: AztecText? = null) : AztecDynamicImageSpan(context, drawable), IAztecAttributedSpan {
+abstract class AztecMediaSpan(context: Context, imageURI: String?, resId : Int?, override var attributes: AztecAttributes = AztecAttributes(),
+                              editor: AztecText? = null) : AztecDynamicImageSpan(context, imageURI, resId), IAztecAttributedSpan {
 
     abstract val TAG: String
 
@@ -22,7 +22,7 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
         textView = editor
     }
 
-    fun setDrawable(newDrawable: Drawable?) {
+    fun setDrawablePath(newDrawable: Drawable?) {
         drawableRef = WeakReference<Drawable>(newDrawable)
 
         originalBounds = Rect(getDrawable()?.bounds ?: Rect(0, 0, 0, 0))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -78,7 +78,7 @@ abstract class AztecMediaSpan(context: Context, imageURI: String?, resId : Int?,
         canvas.restore()
     }
 
-    fun getHtml(): String {
+    open fun getHtml(): String {
         val sb = StringBuilder()
         sb.append("<")
         sb.append(TAG)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -7,11 +7,11 @@ import android.view.Gravity
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 
-class AztecVideoSpan(context: Context, drawable: Drawable?, override var nestingLevel: Int,
+class AztecVideoSpan(context: Context, imageURI: String?, resId : Int?, override var nestingLevel: Int,
                      attributes: AztecAttributes = AztecAttributes(),
                      var onVideoTappedListener: AztecText.OnVideoTappedListener? = null,
                      editor: AztecText? = null) :
-        AztecMediaSpan(context, drawable, attributes, editor), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecMediaSpan(context, imageURI, resId, attributes, editor), IAztecFullWidthImageSpan, IAztecSpan {
 
     override val TAG: String = "video"
 

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
@@ -41,7 +41,8 @@ class WordPressCommentsPlugin(val visualEditor: AztecText) : IInlineSpanHandler,
                     WordPressCommentSpan(
                             text,
                             visualEditor.context,
-                            ContextCompat.getDrawable(visualEditor.context, R.drawable.img_more),
+                            null,
+                            R.drawable.img_more,
                             nestingLevel
                     ),
                     spanStart,
@@ -57,7 +58,8 @@ class WordPressCommentsPlugin(val visualEditor: AztecText) : IInlineSpanHandler,
                     WordPressCommentSpan(
                             text,
                             visualEditor.context,
-                            ContextCompat.getDrawable(visualEditor.context, R.drawable.img_page),
+                            null,
+                            R.drawable.img_page,
                             nestingLevel
                     ),
                     spanStart,

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/WordPressCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/WordPressCommentSpan.kt
@@ -6,8 +6,8 @@ import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecDynamicImageSpan
 import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
 
-class WordPressCommentSpan @JvmOverloads constructor(val commentText: String, context: Context, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
-        AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan {
+class WordPressCommentSpan @JvmOverloads constructor(val commentText: String, context: Context, imageURI: String?, resId : Int?, override var nestingLevel: Int, editor: AztecText? = null) :
+        AztecDynamicImageSpan(context, imageURI, resId), IAztecFullWidthImageSpan {
 
     init {
         textView = editor

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -29,7 +29,8 @@ class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
         val span = WordPressCommentSpan(
                 WordPressCommentSpan.Comment.MORE.html,
                 visualEditor.context,
-                ContextCompat.getDrawable(visualEditor.context, R.drawable.img_more),
+                null,
+                R.drawable.img_more,
                 nestingLevel,
                 visualEditor
         )

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
@@ -29,7 +29,8 @@ class PageToolbarButton(val visualEditor: AztecText) : IToolbarButton {
         val span = WordPressCommentSpan(
                 WordPressCommentSpan.Comment.PAGE.html,
                 visualEditor.context,
-                ContextCompat.getDrawable(visualEditor.context, R.drawable.img_page),
+                null,
+                R.drawable.img_page,
                 nestingLevel,
                 visualEditor
         )


### PR DESCRIPTION
This is just a preliminary test on removing any hard reference to the Bitmaps drawn on the screen, and use path instead.  Ref: #420 

Basically <del>`wp-android`</del> the main app will not add Bitmap/BitmapDrawable to the editor, but will just pass a `resID` or a `String` with the path to the image on disk or on the Internet. The editor should be ready to load the correct picture by itself, and dispose the object if thery're not on the screen anymore. Since we have the Path of each pictures we can re-create them when needed.

Unfortunately this PR changes a lot of files though, but the main changes are here https://github.com/wordpress-mobile/AztecEditor-Android/compare/issue/420-danilo-testing--fix-oom-with-media?expand=1#diff-1254219b4f1ac2f85c98f60b1440f70bR194
and here: https://github.com/wordpress-mobile/AztecEditor-Android/compare/issue/420-danilo-testing--fix-oom-with-media?expand=1#diff-7ca71cd1f009ab8438e0901205001b14R722

Still need to add the code for videos.


