### PR TITLE
Make sure to use the correct loading drawable for Images and Video

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -733,7 +733,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 }
 
                 override fun onImageLoading(drawable: Drawable?) {
-                    replaceImage(ContextCompat.getDrawable(context, drawableLoading))
+                    replaceImage(drawable ?: ContextCompat.getDrawable(context, drawableLoading))
                 }
 
                 private fun replaceImage(drawable: Drawable?) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -766,7 +766,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 }
 
                 override fun onThumbnailLoading(drawable: Drawable?) {
-                    replaceImage(ContextCompat.getDrawable(context, drawableLoading))
+                    replaceImage(drawable ?: ContextCompat.getDrawable(context, drawableLoading))
                 }
 
                 private fun replaceImage(drawable: Drawable?) {


### PR DESCRIPTION
Fix #438 by checking that passed custom loading indicator is not null, and using it. Use default value otherwise.