### PR TITLE
Copy/paste Fix & Improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 - Image/video loading placeholder drawable usage
 - The missing hint bug if text is empty
+- Crash when copy/pasting lists
+- Copy/pasting of non-latin unicode characters
 
 ### Added
 - This changelog
@@ -14,6 +16,7 @@
 - Plugin interface for HTML preprocessor
 - Plugin interface for HTML postprocessor
 - Plugin module with `[video]`, `[audio]` and `[caption]` WordPress shrotcode support
+- Copy/pasting of block element styles
 
 ## [1.0-beta.6](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.6) - 2017-07-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 ### Fixed
 - Image/video loading placeholder drawable usage
 - The missing hint bug if text is empty
+- Crash in the URL dialog caused by the non plain text content of a clipboard
 - Crash when copy/pasting lists
 - Copy/pasting of non-latin unicode characters
-- Crash in the URL dialog caused by the non plain text content of a clipboard
 
 ### Added
 - This changelog
@@ -17,8 +17,10 @@
 - Plugin interface for HTML preprocessor
 - Plugin interface for HTML postprocessor
 - Plugin module with `[video]`, `[audio]` and `[caption]` WordPress shrotcode support
-- Copy/pasting of block element styles
 - OnMediaDeletedListener interface, detection and handling
+- Copy/pasting of block element styles
+- Copy/pasting of styled text and HTML from external sources
+
 
 ## [1.0-beta.6](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.6) - 2017-07-25
 ### Changed

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -313,6 +313,9 @@ class MainActivity : AppCompatActivity(),
         val sourceEditor = findViewById(R.id.source) as SourceViewEditText
         val toolbar = findViewById(R.id.formatting_toolbar) as AztecToolbar
 
+        visualEditor.setCalypsoMode(false)
+        sourceEditor.setCalypsoMode(false)
+
         aztec = Aztec.with(visualEditor, sourceEditor, toolbar, this)
             .setImageGetter(PicassoImageLoader(this, visualEditor))
             .setVideoThumbnailGetter(GlideVideoThumbnailLoader(this))

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -316,8 +316,6 @@ class MainActivity : AppCompatActivity(),
         val sourceEditor = findViewById(R.id.source) as SourceViewEditText
         val toolbar = findViewById(R.id.formatting_toolbar) as AztecToolbar
 
-        visualEditor.setCalypsoMode(false)
-        sourceEditor.setCalypsoMode(false)
 
         aztec = Aztec.with(visualEditor, sourceEditor, toolbar, this)
             .setImageGetter(PicassoImageLoader(this, visualEditor))

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -107,7 +107,7 @@ class MainActivity : AppCompatActivity(),
         private val CODE = "<code>if (value == 5) printf(value)</code><br>"
         private val IMG = "[caption align=\"alignright\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />Caption[/caption]"
         private val EMOJI = "&#x1F44D;"
-        private val HTML_NON_LATIN_TEXT = "测试一个"
+        private val NON_LATIN_TEXT = "测试一个"
         private val LONG_TEXT = "<br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
         private val VIDEO = "[video src=\"https://examplebloge.files.wordpress.com/2017/06/d7d88643-88e6-d9b5-11e6-92e03def4804.mp4\"]"
         private val AUDIO = "[audio src=\"https://upload.wikimedia.org/wikipedia/commons/9/94/H-Moll.ogg\"]"
@@ -132,7 +132,7 @@ class MainActivity : AppCompatActivity(),
                 CODE +
                 UNKNOWN +
                 EMOJI +
-                HTML_NON_LATIN_TEXT +
+                NON_LATIN_TEXT +
                 LONG_TEXT +
                 VIDEO +
                 AUDIO

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -106,6 +106,7 @@ class MainActivity : AppCompatActivity(),
         private val CODE = "<code>if (value == 5) printf(value)</code><br>"
         private val IMG = "[caption align=\"alignright\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />Caption[/caption]"
         private val EMOJI = "&#x1F44D;"
+        private val HTML_NON_LATIN_TEXT = "测试一个"
         private val LONG_TEXT = "<br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
         private val VIDEO = "[video src=\"https://examplebloge.files.wordpress.com/2017/06/d7d88643-88e6-d9b5-11e6-92e03def4804.mp4\"]"
         private val AUDIO = "[audio src=\"https://upload.wikimedia.org/wikipedia/commons/9/94/H-Moll.ogg\"]"
@@ -130,6 +131,7 @@ class MainActivity : AppCompatActivity(),
                 CODE +
                 UNKNOWN +
                 EMOJI +
+                HTML_NON_LATIN_TEXT +
                 LONG_TEXT +
                 VIDEO +
                 AUDIO

--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -297,6 +297,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
             }
         }
 
+        //noinspection StatementWithEmptyBody
         if (tag.equalsIgnoreCase("br")) {
             // We don't need to handle this. TagSoup will ensure that there's a </br> for each <br>
             // so we can safely emite the linebreaks when we handle the close tag.

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -546,7 +546,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
                 }
 
                 out.append(' ')
-            } else {
+            } else if (c != '\n') {
                 out.append(c)
             }
             i++

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -111,7 +111,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
             val parent = IAztecNestable.getParent(spanned, SpanWrapper(spanned, it))
 
             // a list item "repels" a child list so the list will appear in the next line
-            val repelling = (parent?.span is AztecListItemSpan) && (it is AztecListSpan)
+            val repelling = it is AztecListSpan && parent?.span is AztecListItemSpan
 
             val spanStart = spanned.getSpanStart(it)
 
@@ -137,8 +137,8 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
 
             // expand all same-start parents to include the new newline
             SpanWrapper.getSpans<IAztecNestable>(spanned, spanStart + 1, spanStart + 2)
-                    .filter { parent -> parent.span.nestingLevel < it.nestingLevel && parent.start == spanStart + 1 }
-                    .forEach { parent -> parent.start-- }
+                    .filter { subParent -> subParent.span.nestingLevel < it.nestingLevel && subParent.start == spanStart + 1 }
+                    .forEach { subParent -> subParent.start-- }
 
             markBlockElementLineBreak(spanned, spanStart)
         }
@@ -208,7 +208,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
             val parent = IAztecNestable.getParent(spanned, SpanWrapper(spanned, it))
 
             // a list item "repels" a child list so the list will appear in the next line
-            val repelling = (parent?.span is AztecListItemSpan) && (it is AztecListSpan)
+            val repelling = it is AztecListSpan && parent?.span is AztecListItemSpan
 
             val spanStart = spanned.getSpanStart(it)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -212,7 +212,11 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
 
             val spanStart = spanned.getSpanStart(it)
 
-            if (!repelling && spanStart < 1) {
+            if (spanStart < 1) {
+                return@forEach
+            }
+
+            if (!repelling) {
                 // no visual newline if at text start and not repelling so, return
                 return@forEach
             }
@@ -235,7 +239,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
                 return@forEach
             }
 
-            if (!repelling && spanned[spanStart - 2] == '\n') {
+            if (spanStart > 1 && !repelling && spanned[spanStart - 2] == '\n') {
                 // there's another newline before and we're not repelling a parent so, the adjacent one is not a visual one so, return
                 return@forEach
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -34,7 +34,6 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
     internal var closeMap: TreeMap<Int, HiddenHtmlSpan> = TreeMap()
     internal var openMap: TreeMap<Int, HiddenHtmlSpan> = TreeMap()
     internal var hiddenSpans: IntArray = IntArray(0)
-    internal var spanCursorPosition = -1
 
     fun fromHtml(source: String, context: Context): Spanned {
 
@@ -80,13 +79,11 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
         hiddenIndex = 0
         Arrays.sort(hiddenSpans)
 
-        if (withCursor) {
+        if (!withCursor) {
             val cursorSpan = data.getSpans(0, data.length, AztecCursorSpan::class.java).firstOrNull()
-            if (cursorSpan != null) { //there can be only one cursor
-                spanCursorPosition = data.getSpanStart(cursorSpan)
+            cursorSpan?.let {
+                data.removeSpan(cursorSpan)
             }
-        } else {
-            spanCursorPosition = -1
         }
 
         withinHtml(out, data)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -538,19 +538,6 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
                 out.append("&gt;")
             } else if (c == '&') {
                 out.append("&amp;")
-            } else if (c.toInt() in 0xD800..0xDFFF) {
-                if (c.toInt() < 0xDC00 && i + 1 < end) {
-                    val d = text[i + 1]
-                    if (d.toInt() in 0xDC00..0xDFFF) {
-                        i++
-                        val codepoint = 0x010000 or ((c.toInt() - 0xD800) shl 10) or (d.toInt() - 0xDC00)
-                        out.append("&#").append(codepoint).append(";")
-                    }
-                }
-            } else if (c.toInt() > 0x7E || c < ' ') {
-                if (c != '\n') {
-                    out.append("&#").append(c.toInt()).append(";")
-                }
             } else if (c == ' ') {
                 while (i + 1 < end && text[i + 1] == ' ') {
                     out.append("&nbsp;")
@@ -593,8 +580,8 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
 
     private fun tidy(html: String): String {
         return html
-                .replace("&#8203;", "")
-                .replace("&#65279;", "")
+                .replace(Constants.ZWJ_STRING, "")
+                .replace(Constants.MAGIC_STRING, "")
                 .replace("(</? ?br>)*((aztec_cursor)?)</blockquote>".toRegex(), "$2</blockquote>")
                 .replace("(</? ?br>)*((aztec_cursor)?)</li>".toRegex(), "$2</li>")
                 .replace("(</? ?br>)*((aztec_cursor)?)</p>".toRegex(), "$2</p>")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -565,13 +565,14 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
      *   input string.
      */
     private fun consumeCursorIfInInput(out: StringBuilder, text: CharSequence, position: Int) {
-        val cursorSpan = (text as SpannableStringBuilder).getSpans(position, position, AztecCursorSpan::class.java)
-                .firstOrNull()
-        if (cursorSpan != null) {
-            out.append(AztecCursorSpan.AZTEC_CURSOR_TAG)
+        if (text is SpannableStringBuilder) {
+            val cursorSpan = text.getSpans(position, position, AztecCursorSpan::class.java).firstOrNull()
+            if (cursorSpan != null) {
+                out.append(AztecCursorSpan.AZTEC_CURSOR_TAG)
 
-            // remove the cursor mark from the input string. It's work is finished.
-            text.removeSpan(cursorSpan)
+                // remove the cursor mark from the input string. It's work is finished.
+                text.removeSpan(cursorSpan)
+            }
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -212,12 +212,8 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
 
             val spanStart = spanned.getSpanStart(it)
 
-            if (spanStart < 1) {
-                return@forEach
-            }
-
-            if (!repelling) {
-                // no visual newline if at text start and not repelling so, return
+            // we're looking for newlines before the spans, no need to continue if span at the beginning
+            if (spanStart == 0) {
                 return@forEach
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1026,6 +1026,8 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste.toString())
 
                 fromHtml(newHtml)
+
+                inlineFormatter.joinStyleSpans(0, length())
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1044,7 +1044,9 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 val oldHtml = toPlainHtml()
                 val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste)
 
+                history.beforeTextChanged(toFormattedHtml())
                 fromHtml(newHtml)
+                history.handleHistory(this@AztecText)
 
                 inlineFormatter.joinStyleSpans(0, length())
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -724,7 +724,9 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
     fun fromHtml(source: String) {
         val builder = SpannableStringBuilder()
         val parser = AztecParser(plugins)
-        builder.append(parser.fromHtml(source, context))
+
+        val cleanSource = Format.removeSourceEditorFormatting(source, isInCalypsoMode)
+        builder.append(parser.fromHtml(cleanSource, context))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1041,8 +1041,8 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
             if (clip.itemCount > 0) {
                 val textToPaste = clip.getItemAt(0).coerceToHtmlText(context, AztecParser(plugins))
 
-                val oldHtml = toPlainHtml()
-                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste)
+                val oldHtml = toPlainHtml().replace("<aztec_cursor>", "")
+                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste + "<" + AztecCursorSpan.AZTEC_CURSOR_TAG + ">")
 
                 history.beforeTextChanged(toFormattedHtml())
                 fromHtml(newHtml)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -979,14 +979,17 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         if (clip != null) {
             val parser = AztecParser(plugins)
 
-            editable.replace(min, max, Constants.REPLACEMENT_MARKER_STRING)
+            if (min == 0 && max == text.length) {
+                setText(Constants.REPLACEMENT_MARKER_STRING)
+            } else {
+                editable.replace(min, max, Constants.REPLACEMENT_MARKER_STRING)
+            }
 
-            for (i in 0..clip.itemCount - 1) {
-                val textToPaste = clip.getItemAt(i).coerceToText(context)
+            if (clip.itemCount > 0) {
+                val textToPaste = clip.getItemAt(0).coerceToText(context)
 
-                val oldHtml = Format.removeSourceEditorFormatting(parser.toHtml(editable))
-                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_CHAR_ESCAPED,
-                        Format.removeSourceEditorFormatting(textToPaste.toString()))
+                val oldHtml = toPlainHtml()
+                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_CHAR_ESCAPED, textToPaste.toString())
 
                 fromHtml(newHtml)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1001,7 +1001,8 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
             if (min == 0 && max == text.length) {
                 setText(Constants.REPLACEMENT_MARKER_STRING)
             } else {
-                editable.replace(min, max, Constants.REPLACEMENT_MARKER_STRING)
+                editable.delete(min, max)
+                editable.insert(min, Constants.REPLACEMENT_MARKER_STRING)
             }
 
             // don't let the pasted text be included in any existing style

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -995,7 +995,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 val textToPaste = clip.getItemAt(0).coerceToText(context)
 
                 val oldHtml = toPlainHtml()
-                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_CHAR_ESCAPED, textToPaste.toString())
+                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste.toString())
 
                 fromHtml(newHtml)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -968,6 +968,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
 
         clearMetaSpans(output)
         parser.syncVisualNewlinesOfBlockElements(output)
+        Format.postProcessSpanedText(output, isInCalypsoMode)
 
         // do not copy unnecessary block hierarchy, just the minimum required
         var deleteNext = false
@@ -985,7 +986,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 }
             }
 
-        val html = Format.removeSourceEditorFormatting(parser.toHtml(output))
+        val html = Format.removeSourceEditorFormatting(parser.toHtml(output), isInCalypsoMode)
 
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
         clipboard.primaryClip = ClipData.newPlainText(null, html)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -51,6 +51,8 @@ import org.wordpress.aztec.source.Format
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.spans.*
 import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.util.coerceToHtmlText
+import org.wordpress.aztec.util.coerceToStyledText
 import org.wordpress.aztec.watchers.*
 import org.xml.sax.Attributes
 import java.util.*
@@ -989,13 +991,14 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         val html = Format.removeSourceEditorFormatting(parser.toHtml(output), isInCalypsoMode)
 
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-        clipboard.primaryClip = ClipData.newPlainText(null, html)
+        clipboard.primaryClip = ClipData.newHtmlText("aztec", output.toString(), html)
     }
 
     //copied from TextView with some changes
     fun paste(editable: Editable, min: Int, max: Int) {
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clip = clipboard.primaryClip
+
         if (clip != null) {
             disableTextChangedListener()
 
@@ -1021,7 +1024,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
             enableTextChangedListener()
 
             if (clip.itemCount > 0) {
-                val textToPaste = clip.getItemAt(0).coerceToText(context)
+                val textToPaste = clip.getItemAt(0).coerceToHtmlText(context, AztecParser(plugins))
 
                 val oldHtml = toPlainHtml()
                 val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste.toString())

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -712,9 +712,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
     fun fromHtml(source: String) {
         val builder = SpannableStringBuilder()
         val parser = AztecParser(plugins)
-        builder.append(parser.fromHtml(
-                Format.removeSourceEditorFormatting(
-                        Format.addSourceEditorFormatting(source, isInCalypsoMode), isInCalypsoMode), context))
+        builder.append(parser.fromHtml(source, context))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1015,6 +1015,8 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         val clip = clipboard.primaryClip
 
         if (clip != null) {
+            history.beforeTextChanged(toFormattedHtml())
+
             disableTextChangedListener()
 
             if (min == 0 && max == text.length) {
@@ -1044,7 +1046,6 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 val oldHtml = toPlainHtml().replace("<aztec_cursor>", "")
                 val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste + "<" + AztecCursorSpan.AZTEC_CURSOR_TAG + ">")
 
-                history.beforeTextChanged(toFormattedHtml())
                 fromHtml(newHtml)
                 history.handleHistory(this@AztecText)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -52,7 +52,6 @@ import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.spans.*
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.util.coerceToHtmlText
-import org.wordpress.aztec.util.coerceToStyledText
 import org.wordpress.aztec.watchers.*
 import org.xml.sax.Attributes
 import java.util.*
@@ -1043,7 +1042,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                 val textToPaste = clip.getItemAt(0).coerceToHtmlText(context, AztecParser(plugins))
 
                 val oldHtml = toPlainHtml()
-                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste.toString())
+                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste)
 
                 fromHtml(newHtml)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
@@ -3,6 +3,9 @@ package org.wordpress.aztec
 object Constants {
     val MAGIC_CHAR = '\uFEFF' //'*'
     val MAGIC_STRING = "" + MAGIC_CHAR
+    val REPLACEMENT_MARKER_CHAR = '\u202F'
+    val REPLACEMENT_MARKER_CHAR_ESCAPED = "&#8239;"
+    val REPLACEMENT_MARKER_STRING = "" + REPLACEMENT_MARKER_CHAR
     val ZWJ_CHAR = '\u200B'//'§'
     val ZWJ_STRING = "" + ZWJ_CHAR
     val IMG_CHAR = '\uFFFC'

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
@@ -4,7 +4,6 @@ object Constants {
     val MAGIC_CHAR = '\uFEFF' //'*'
     val MAGIC_STRING = "" + MAGIC_CHAR
     val REPLACEMENT_MARKER_CHAR = '\u202F'
-    val REPLACEMENT_MARKER_CHAR_ESCAPED = "&#8239;"
     val REPLACEMENT_MARKER_STRING = "" + REPLACEMENT_MARKER_CHAR
     val ZWJ_CHAR = '\u200B'//'§'
     val ZWJ_STRING = "" + ZWJ_CHAR

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -18,6 +18,7 @@ object Format {
 
     fun addSourceEditorFormatting(content: String, isCalypsoFormat: Boolean = false): String {
         var html = replaceAll(content, "iframe", iframePlaceholder)
+        html = html.replace("<aztec_cursor>", "")
 
         val doc = Jsoup.parseBodyFragment(html).outputSettings(Document.OutputSettings().prettyPrint(!isCalypsoFormat))
         if (isCalypsoFormat) {
@@ -27,7 +28,6 @@ object Format {
                     .forEach { it.remove() }
 
             html = replaceAll(doc.body().html(), iframePlaceholder, "iframe")
-            html = html.replace("aztec_cursor", "")
 
             html = replaceAll(html, "<p>(?:<br ?/?>|\u00a0|\uFEFF| )*</p>", "<p>&nbsp;</p>")
             html = toCalypsoSourceEditorFormat(html)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -12,7 +12,7 @@ import java.util.regex.Pattern
 object Format {
 
     // list of block elements
-    private val block = "div|br|blockquote|ul|ol|li|p|pre|h1|h2|h3|h4|h5|h6|iframe|hr|aztec_cursor"
+    private val block = "div|br|blockquote|ul|ol|li|p|pre|h1|h2|h3|h4|h5|h6|iframe|hr"
 
     private val iframePlaceholder = "iframe-replacement-0x0"
 
@@ -251,7 +251,6 @@ object Format {
             html = sb.toString()
         }
 
-        html += "\n\n"
 
         html = replaceAll(html, "(?i)<br ?/?>\\s*<br ?/?>", "\n\n")
         html = replaceAll(html, "(?i)(<(?:$blocklist)(?: [^>]*)?>)", "\n$1")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -88,15 +88,13 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     }
 
     open fun getHtml(): String {
-        val sb = StringBuilder()
-        sb.append("<")
-        sb.append(TAG)
-        sb.append(' ')
+        val sb = StringBuilder("<$TAG ")
 
         attributes.removeAttribute("aztec_id")
 
         sb.append(attributes)
-        sb.append("/>")
+        sb.trim()
+        sb.append(" />")
 
         return sb.toString()
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/Extensions.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/Extensions.kt
@@ -1,7 +1,12 @@
 package org.wordpress.aztec.util
 
+import android.content.ClipData
+import android.content.Context
 import android.text.Editable
+import android.text.Html
 import android.text.Spannable
+import android.text.Spanned
+import org.wordpress.aztec.AztecParser
 
 fun Editable.getLast(kind: Class<*>): Any? {
     val spans = this.getSpans(0, this.length, kind)
@@ -25,4 +30,31 @@ inline fun <reified T> Editable.getLast(): T? {
                 .firstOrNull { this.getSpanFlags(spans[it - 1]) == Spannable.SPAN_MARK_MARK }
                 ?.let { spans[it - 1] }
     }
+}
+
+fun ClipData.Item.coerceToStyledText(context: Context, parser: AztecParser): CharSequence {
+
+    val text = text ?: ""
+    if (text is Spanned) {
+        return text
+    }
+
+    val html = htmlText ?: ""
+    return parser.fromHtml(html, context)
+}
+
+fun ClipData.Item.coerceToHtmlText(context: Context, parser: AztecParser): String {
+    // If the item has an explicit HTML value, simply return that.
+    val htmlText = htmlText
+    if (htmlText != null) {
+        return htmlText
+    }
+
+    // If this Item has a plain text value, return it as HTML.
+    val text = text ?: ""
+    if (text is Spanned) {
+        return parser.toHtml(text)
+    }
+
+    return text.toString()
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/Extensions.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/Extensions.kt
@@ -3,7 +3,6 @@ package org.wordpress.aztec.util
 import android.content.ClipData
 import android.content.Context
 import android.text.Editable
-import android.text.Html
 import android.text.Spannable
 import android.text.Spanned
 import org.wordpress.aztec.AztecParser

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -3,7 +3,6 @@ package org.wordpress.aztec.watchers
 import android.text.Editable
 import android.text.TextWatcher
 import org.wordpress.aztec.AztecText
-import org.wordpress.aztec.Constants
 import org.wordpress.aztec.spans.AztecMediaSpan
 import java.lang.ref.WeakReference
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -69,7 +69,8 @@ class AztecParserTest : AndroidTestCase() {
             "<div><span>1</span><br><div>2</div>3<span></span><br>4</div><br><br>5<br><br><div></div>"
     private val HTML_NESTED_INLINE = "<u><i><b>Nested</b></i></u>"
     private val HTML_HIDDEN_WITH_NO_TEXT = "<br><br><div></div><br><br>"
-    private val HTML_EMOJI = "&#128077;&#10084;" // Thumbsup + heart
+    private val HTML_EMOJI = "\uD83D\uDC4D❤" // Thumbsup + heart
+    private val HTML_NON_LATIN_TEXT = "测试一个"
 
     private val SPAN_BOLD = "Bold\n\n"
     private val SPAN_LIST_ORDERED = "Ordered\n\n"
@@ -127,7 +128,8 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_NESTED_EMPTY +
                 HTML_NESTED_WITH_TEXT +
                 HTML_NESTED_INTERLEAVING +
-                HTML_EMOJI
+                HTML_EMOJI +
+                HTML_NON_LATIN_TEXT
 
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -1171,4 +1171,13 @@ class AztecParserTest : AndroidTestCase() {
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlProperVisualNewlineSync_isEqual() {
+        val input = "<blockquote>Hello</blockquote><u>Bye</u><blockquote>Hello</blockquote>End"
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -148,4 +148,22 @@ class ClipboardTest {
 
         Assert.assertEquals("<h1>H1</h1><h2>H2</h2><u>Bye</u>End<h1>1</h1><h2>H</h2>", editText.toHtml())
     }
+
+    @SuppressLint("SetTextI18n")
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteCalypsoParagraphs() {
+        editText.setCalypsoMode(true)
+        editText.fromHtml("<p>aaa</p><p>bbb</p><p>ccc</p>")
+
+        editText.setSelection(0, editText.length())
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("aaa\n\nbbb\n\nccc\n\naaa\n\nbbb\n\nccc", editText.toHtml())
+
+        editText.setCalypsoMode(false)
+    }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -1,0 +1,56 @@
+package org.wordpress.aztec
+
+import android.app.Activity
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+class ClipboardTest {
+
+    lateinit var editText: AztecText
+
+    /**
+     * Initialize variables.
+     */
+    @Before
+    fun init() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+        editText = AztecText(activity)
+        editText.setCalypsoMode(false)
+        activity.setContentView(editText)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteSameInlineStyle() {
+        editText.fromHtml("<b>Bold</b>")
+
+        editText.setSelection(0, editText.length())
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<b>Bold</b><b>Bold</b>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteDifferentInlineStyle() {
+        editText.fromHtml("<b>Bold</b><i>Italic</i>")
+
+        editText.setSelection(0, editText.length())
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<b>Bold</b><i>Italic</i><b>Bold</b><i>Italic</i>", editText.toHtml())
+    }
+}

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -11,10 +11,97 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
 @Config(constants = BuildConfig::class, sdk = intArrayOf(23))
 class ClipboardTest {
+
+    private val HEADING =
+            "<h1>Heading 1</h1>" +
+                    "<h2>Heading 2</h2>" +
+                    "<h3>Heading 3</h3>" +
+                    "<h4>Heading 4</h4>" +
+                    "<h5>Heading 5</h5>" +
+                    "<h6>Heading 6</h6>"
+    private val BOLD = "<b>Bold</b><br>"
+    private val ITALIC = "<i>Italic</i><br>"
+    private val UNDERLINE = "<u>Underline</u><br>"
+    private val STRIKETHROUGH = "<s class=\"test\">Strikethrough</s>" // <s> or <strike> or <del>
+    private val ORDERED = "<ol><li>Ordered</li><li></li></ol>"
+    private val LINE = "<hr>"
+    private val UNORDERED = "<ul><li>Unordered</li><li></li></ul>"
+    private val QUOTE = "<blockquote>Quote</blockquote>"
+    private val LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a><br>"
+    private val UNKNOWN = "<iframe class=\"classic\">Menu</iframe><br>"
+    private val COMMENT = "<!--Comment--><br>"
+    private val COMMENT_MORE = "<!--more--><br>"
+    private val COMMENT_PAGE = "<!--nextpage--><br>"
+    private val HIDDEN =
+            "<span></span>" +
+                    "<div class=\"first\">" +
+                    "    <div class=\"second\">" +
+                    "        <div class=\"third\">" +
+                    "            Div<br><span><b>Span</b></span><br>Hidden" +
+                    "</div>" +
+                    "        <div class=\"fourth\"></div>" +
+                    "        <div class=\"fifth\"></div>" +
+                    "    </div>" +
+                    "    <span class=\"second last\"></span>" +
+                    "</div>" +
+                    "<br>"
+    private val PREFORMAT = "<pre>if (this) then that;</pre>"
+    private val CODE = "<code>if (value == 5) printf(value)</code><br>"
+    private val IMG = "<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />"
+    private val EMOJI = "\uD83D\uDC4D"
+    private val HTML_NON_LATIN_TEXT = "测试一个"
+    private val LONG_TEXT = "<br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+
+    private val EVERYTHING =
+            IMG +
+                    HEADING +
+                    BOLD +
+                    ITALIC +
+                    UNDERLINE +
+                    STRIKETHROUGH +
+                    ORDERED +
+                    LINE +
+                    UNORDERED +
+                    QUOTE +
+                    PREFORMAT +
+                    LINK +
+                    HIDDEN +
+                    COMMENT +
+                    COMMENT_MORE +
+                    COMMENT_PAGE +
+                    CODE +
+                    UNKNOWN +
+                    EMOJI +
+                    HTML_NON_LATIN_TEXT +
+                    LONG_TEXT
+
+    private val EVERYTHING_EXPECTED =
+            IMG +
+                    HEADING +
+                    BOLD +
+                    ITALIC +
+                    UNDERLINE +
+                    STRIKETHROUGH +
+                    ORDERED +
+                    LINE +
+                    UNORDERED +
+                    QUOTE +
+                    PREFORMAT +
+                    LINK +
+                    Format.removeSourceEditorFormatting(HIDDEN) +
+                    COMMENT +
+                    COMMENT_MORE +
+                    COMMENT_PAGE +
+                    CODE +
+                    UNKNOWN +
+                    EMOJI +
+                    HTML_NON_LATIN_TEXT +
+                    LONG_TEXT
 
     lateinit var editText: AztecText
 
@@ -165,5 +252,33 @@ class ClipboardTest {
         Assert.assertEquals("aaa\n\nbbb\n\nccc\n\naaa\n\nbbb\n\nccc", editText.toHtml())
 
         editText.setCalypsoMode(false)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteEverything() {
+        editText.fromHtml(EVERYTHING)
+
+        editText.setSelection(0, editText.length())
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals(EVERYTHING_EXPECTED + EVERYTHING_EXPECTED, editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndReplaceEverything() {
+        editText.fromHtml(EVERYTHING)
+
+        editText.setSelection(0, editText.length())
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(0, editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals(EVERYTHING_EXPECTED, editText.toHtml())
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -2,8 +2,6 @@ package org.wordpress.aztec
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.text.Html
-import android.text.SpannableString
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -37,7 +37,7 @@ class ClipboardTest {
         editText.setSelection(editText.length())
         TestUtils.pasteFromClipboard(editText)
 
-        Assert.assertEquals("<b>Bold</b><b>Bold</b>", editText.toHtml())
+        Assert.assertEquals("<b>BoldBold</b>", editText.toHtml())
     }
 
     @Test

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -1,6 +1,9 @@
 package org.wordpress.aztec
 
+import android.annotation.SuppressLint
 import android.app.Activity
+import android.text.Html
+import android.text.SpannableString
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -52,5 +55,97 @@ class ClipboardTest {
         TestUtils.pasteFromClipboard(editText)
 
         Assert.assertEquals("<b>Bold</b><i>Italic</i><b>Bold</b><i>Italic</i>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteNestedListItem() {
+        editText.fromHtml("<ul><li>aaa</li><li>bbb<ul><li>ccc</li></ul></li></ul>")
+
+        // select "ccc"
+        editText.setSelection(8, 11)
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<ul><li>aaa</li><li>bbb<ul><li>ccc<ul><li>ccc</li></ul></li></ul></li></ul>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteMultipleListLevelsWithInlineStyle() {
+        editText.fromHtml("<ul><li>aaa</li><li>bb<b>b</b><ul><li>ccc</li></ul></li></ul>")
+
+        // select text starting with "b<b>..."
+        editText.setSelection(5, 10)
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<ul><li>aaa</li><li>bb<b>b</b><ul><li>ccc<ul><li>b<b>b</b><ul><li>cc</li></ul></li></ul></li></ul></li></ul>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyUpperListItemAndReplaceEntireText() {
+        editText.fromHtml("<ul><li>aaa</li><li>bb<b>b</b><ul><li>ccc</li></ul></li></ul>")
+
+        // select text with "b<b>b</b>"
+        editText.setSelection(5, 7)
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(0, editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<ul><li>b<b>b</b></li></ul>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyBlockquoteAndReplaceInlineStyleText() {
+        editText.fromHtml("<blockquote>Hello</blockquote><u>Bye</u>End")
+
+        // select text with "Hello"
+        editText.setSelection(0, 5)
+        TestUtils.copyToClipboard(editText)
+
+        // Select "Bye"
+        editText.setSelection(6, 9)
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<blockquote>Hello</blockquote><blockquote>Hello</blockquote>End", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyBlockquoteAndPartiallyReplaceInlineStyleText() {
+        editText.fromHtml("<blockquote>Hello</blockquote><u>Bye</u>End")
+
+        // select text with "Hello"
+        editText.setSelection(0, 5)
+        TestUtils.copyToClipboard(editText)
+
+        // Select "Bye"
+        editText.setSelection(7, 9)
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<blockquote>Hello</blockquote><u>B</u><blockquote>Hello</blockquote>End", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteHeadings() {
+        editText.fromHtml("<h1>H1</h1><h2>H2</h2><u>Bye</u>End")
+
+        // select half of first and half of second heading
+        editText.setSelection(1, 4)
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<h1>H1</h1><h2>H2</h2><u>Bye</u>End<h1>1</h1><h2>H</h2>", editText.toHtml())
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -41,7 +41,7 @@ class ClipboardTest {
                     "    <div class=\"second\">" +
                     "        <div class=\"third\">" +
                     "            Div<br><span><b>Span</b></span><br>Hidden" +
-                    "</div>" +
+                    "        </div>" +
                     "        <div class=\"fourth\"></div>" +
                     "        <div class=\"fifth\"></div>" +
                     "    </div>" +
@@ -53,7 +53,8 @@ class ClipboardTest {
     private val IMG = "<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />"
     private val EMOJI = "\uD83D\uDC4D"
     private val HTML_NON_LATIN_TEXT = "测试一个"
-    private val LONG_TEXT = "<br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+    private val LONG_TEXT = "<br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    private val LONG_TEXT_EXPECTED = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 
     private val EVERYTHING =
             IMG +
@@ -278,5 +279,36 @@ class ClipboardTest {
         TestUtils.pasteFromClipboard(editText)
 
         Assert.assertEquals(EVERYTHING_EXPECTED, editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndReplacePlainText() {
+        editText.fromHtml(LONG_TEXT)
+
+        editText.setSelection(0, editText.text.indexOf(' ', 2))
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(0, editText.text.indexOf(' ', 2))
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals(LONG_TEXT, editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndReplacePlainTextCalypsoMode() {
+        editText.setCalypsoMode(true)
+        editText.fromHtml(LONG_TEXT)
+
+        editText.setSelection(0, editText.text.indexOf(' ', 2))
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(0, editText.text.indexOf(' ', 2))
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals(LONG_TEXT_EXPECTED, editText.toHtml())
+
+        editText.setCalypsoMode(false)
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/TestUtils.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/TestUtils.kt
@@ -47,6 +47,24 @@ object TestUtils {
     }
 
     /**
+     * Issue a copy-to-clipboard key event
+     *
+     * @param text The EditText to issue the key event to
+     */
+    fun copyToClipboard(text: AztecText) {
+        text.copy(text.text, text.selectionStart, text.selectionEnd)
+    }
+
+    /**
+     * Issue a copy to clipboard key event
+     *
+     * @param text The EditText to issue the key event to
+     */
+    fun pasteFromClipboard(text: AztecText) {
+        text.paste(text.text, text.selectionStart, text.selectionEnd)
+    }
+
+    /**
      * Helper for calculating the EditText's length *without* counting the the end-of-text marker char if present
      *
      * @param text The EditText to check for length sans the end-of-text marker char if present


### PR DESCRIPTION
Fixes #424, #447 and #285.

Summary of things this PR addressed:

- Fixes block element style copying: Headings, lists, quotes are now preserved.
- Copying now works across multiple list hierarchies: When copying inside a nested list, only the minimum required level gets copied. For example, copying a list item nested under 3 levels of lists will copy just the last one. 
- When pasting text next to an inline style, the pasted text is affected by the original text next to it.
- Copy/pasting of exotic unicode characters, such as non-Latin characters and emoji works now (those characters are not escaped anymore during parsing). 
- Copied Calypso paragraphs are also preserved now. 
- The paste logic now tries to look at the type of data being pasted. If it detects styled text (`Spanned`) or HTML, the data is parsed first and the styling is preserved. That means copying text from a website copies the HTML and all the headings, lists, typefaces are copied along.