### PR TITLE
Converting content of clipboard into text using coerceToText

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
@@ -10,7 +10,7 @@ import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecURLSpan
 
-class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle):AztecFormatter(editor) {
+class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle) : AztecFormatter(editor) {
 
     data class LinkStyle(val linkColor: Int, val linkUnderline: Boolean)
 
@@ -61,7 +61,7 @@ class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle):AztecFormatter(
 
         val data = clipboard.primaryClip
         if (data == null || data.itemCount <= 0) return ""
-        val clipText = data.getItemAt(0).text.toString()
+        val clipText = data.getItemAt(0).coerceToText(context).toString()
         return if (Patterns.WEB_URL.matcher(clipText).matches()) clipText else ""
     }
 


### PR DESCRIPTION
### Fixes #453 

Switching to a safe method [coerceToText](https://developer.android.com/reference/android/content/ClipData.Item.html#coerceToText(android.content.Context)) to get a content of clipboard as a string.