### PR TITLE
Adding DeleteMediaElementWatcher and new OnMediaDeletedListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Plugin interface for HTML preprocessor
 - Plugin interface for HTML postprocessor
 - Plugin module with `[video]`, `[audio]` and `[caption]` WordPress shrotcode support
+- Added OnMediaDeletedListener interface, detection and handling
 
 ## [1.0-beta.6](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.6) - 2017-07-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Plugin interface for HTML preprocessor
 - Plugin interface for HTML postprocessor
 - Plugin module with `[video]`, `[audio]` and `[caption]` WordPress shrotcode support
-- Added OnMediaDeletedListener interface, detection and handling
+- OnMediaDeletedListener interface, detection and handling
 
 ## [1.0-beta.6](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.6) - 2017-07-25
 ### Changed

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : AppCompatActivity(),
         AztecText.OnImageTappedListener,
         AztecText.OnVideoTappedListener,
         AztecText.OnAudioTappedListener,
+        AztecText.OnMediaDeletedListener,
         IAztecToolbarClickListener,
         IHistoryListener,
         OnRequestPermissionsResultCallback,
@@ -322,6 +323,7 @@ class MainActivity : AppCompatActivity(),
             .setOnImageTappedListener(this)
             .setOnVideoTappedListener(this)
             .setOnAudioTappedListener(this)
+            .setOnMediaDeletedListener(this)
             .addPlugin(WordPressCommentsPlugin(visualEditor))
             .addPlugin(MoreToolbarButton(visualEditor))
             .addPlugin(PageToolbarButton(visualEditor))
@@ -824,5 +826,10 @@ class MainActivity : AppCompatActivity(),
                 }
             }
         }
+    }
+
+    override fun onMediaDeleted(attrs: AztecAttributes) {
+        val url = attrs.getValue("src")
+        ToastUtils.showToast(this, "Media Deleted! " + url)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -21,6 +21,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val sourceEdit
     private var onImageTappedListener: AztecText.OnImageTappedListener? = null
     private var onVideoTappedListener: AztecText.OnVideoTappedListener? = null
     private var onAudioTappedListener: AztecText.OnAudioTappedListener? = null
+    private var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null
     private var plugins: ArrayList<IAztecPlugin> = visualEditor.plugins
 
     init {
@@ -84,6 +85,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val sourceEdit
     fun setOnAudioTappedListener(onAudioTappedListener: AztecText.OnAudioTappedListener) : Aztec {
         this.onAudioTappedListener = onAudioTappedListener
         initAudioTappedListener()
+        return this
+    }
+
+    fun setOnMediaDeletedListener(onMediaDeletedListener: AztecText.OnMediaDeletedListener) : Aztec {
+        this.onMediaDeletedListener = onMediaDeletedListener
+        initMediaDeletedListener()
         return this
     }
 
@@ -158,6 +165,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val sourceEdit
     private fun initAudioTappedListener() {
         if (onAudioTappedListener != null) {
             visualEditor.setOnAudioTappedListener(onAudioTappedListener!!)
+        }
+    }
+
+    private fun initMediaDeletedListener() {
+        if (onMediaDeletedListener != null) {
+            visualEditor.setOnMediaDeletedListener(onMediaDeletedListener!!)
         }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -93,6 +93,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
     private var onImageTappedListener: OnImageTappedListener? = null
     private var onVideoTappedListener: OnVideoTappedListener? = null
     private var onAudioTappedListener: OnAudioTappedListener? = null
+    private var onMediaDeletedListener: OnMediaDeletedListener? = null
 
     private var isViewInitialized = false
     private var isLeadingStyleRemoved = false
@@ -147,6 +148,10 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
 
     interface OnAudioTappedListener {
         fun onAudioTapped(attrs: AztecAttributes)
+    }
+
+    interface OnMediaDeletedListener {
+        fun onMediaDeleted(attrs: AztecAttributes)
     }
 
     constructor(context: Context) : super(context) {
@@ -302,6 +307,8 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
 
         EndOfBufferMarkerAdder.install(this)
         ZeroIndexContentWatcher.install(this)
+
+        DeleteMediaElementWatcher.install(this)
     }
 
     override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
@@ -480,6 +487,10 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
 
     fun setOnAudioTappedListener(listener: OnAudioTappedListener) {
         this.onAudioTappedListener = listener
+    }
+
+    fun setOnMediaDeletedListener(listener: OnMediaDeletedListener) {
+        this.onMediaDeletedListener = listener
     }
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
@@ -858,16 +869,19 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         val imageSpans = editable.getSpans(start, end, AztecImageSpan::class.java)
         imageSpans.forEach {
             it.onImageTappedListener = onImageTappedListener
+            it.onMediaDeletedListener = onMediaDeletedListener
         }
 
         val videoSpans = editable.getSpans(start, end, AztecVideoSpan::class.java)
         videoSpans.forEach {
             it.onVideoTappedListener = onVideoTappedListener
+            it.onMediaDeletedListener = onMediaDeletedListener
         }
 
         val audioSpans = editable.getSpans(start, end, AztecAudioSpan::class.java)
         audioSpans.forEach {
             it.onAudioTappedListener = onAudioTappedListener
+            it.onMediaDeletedListener = onMediaDeletedListener
         }
 
         val unknownHtmlSpans = editable.getSpans(start, end, UnknownHtmlSpan::class.java)
@@ -1160,11 +1174,11 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
     }
 
     fun insertImage(drawable: Drawable?, attributes: Attributes) {
-        lineBlockFormatter.insertImage(drawable, attributes, onImageTappedListener)
+        lineBlockFormatter.insertImage(drawable, attributes, onImageTappedListener, onMediaDeletedListener)
     }
 
     fun insertVideo(drawable: Drawable?, attributes: Attributes) {
-        lineBlockFormatter.insertVideo(drawable, attributes, onVideoTappedListener)
+        lineBlockFormatter.insertVideo(drawable, attributes, onVideoTappedListener, onMediaDeletedListener)
     }
 
     fun removeMedia(attributePredicate: AttributePredicate) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -111,14 +111,18 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         )
     }
 
-    fun insertVideo(drawable: Drawable?, attributes: Attributes, onVideoTappedListener: OnVideoTappedListener?) {
+    fun insertVideo(drawable: Drawable?, attributes: Attributes, onVideoTappedListener: OnVideoTappedListener?,
+                    onMediaDeletedListener: AztecText.OnMediaDeletedListener?) {
         val nestingLevel = IAztecNestable.getNestingLevelAt(editableText, selectionStart)
-        val span = AztecVideoSpan(editor.context, drawable, nestingLevel, AztecAttributes(attributes), onVideoTappedListener, editor)
+        val span = AztecVideoSpan(editor.context, drawable, nestingLevel, AztecAttributes(attributes), onVideoTappedListener,
+                onMediaDeletedListener, editor)
         insertMedia(span)
     }
 
-    fun insertImage(drawable: Drawable?, attributes: Attributes, onImageTappedListener: OnImageTappedListener?) {
-        val span = AztecImageSpan(editor.context, drawable, AztecAttributes(attributes), onImageTappedListener, editor)
+    fun insertImage(drawable: Drawable?, attributes: Attributes, onImageTappedListener: OnImageTappedListener?,
+                    onMediaDeletedListener: AztecText.OnMediaDeletedListener?) {
+        val span = AztecImageSpan(editor.context, drawable, AztecAttributes(attributes), onImageTappedListener,
+                onMediaDeletedListener, editor)
         insertMedia(span)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecAudioSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecAudioSpan.kt
@@ -10,8 +10,9 @@ import org.wordpress.aztec.AztecText
 class AztecAudioSpan(context: Context, drawable: Drawable?, override var nestingLevel: Int,
                      attributes: AztecAttributes = AztecAttributes(),
                      var onAudioTappedListener: AztecText.OnAudioTappedListener? = null,
+                     onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                      editor: AztecText? = null) :
-        AztecMediaSpan(context, drawable, attributes, editor), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
 
     override val TAG: String = "audio"
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
@@ -7,8 +7,9 @@ import org.wordpress.aztec.AztecText
 
 class AztecImageSpan(context: Context, drawable: Drawable?, attributes: AztecAttributes = AztecAttributes(),
                      var onImageTappedListener: AztecText.OnImageTappedListener? = null,
+                     onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                      editor: AztecText? = null) :
-        AztecMediaSpan(context, drawable, attributes, editor) {
+        AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor) {
 
     override val TAG: String = "img"
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -11,6 +11,7 @@ import org.wordpress.aztec.AztecText
 import java.util.*
 
 abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
+                              var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                               editor: AztecText? = null) : AztecDynamicImageSpan(context, drawable), IAztecAttributedSpan {
 
     abstract val TAG: String
@@ -106,4 +107,9 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     }
 
     abstract fun onClick()
+
+    fun onMediaDeleted() {
+        onMediaDeletedListener?.onMediaDeleted(attributes)
+    }
+
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -10,8 +10,9 @@ import org.wordpress.aztec.AztecText
 class AztecVideoSpan(context: Context, drawable: Drawable?, override var nestingLevel: Int,
                      attributes: AztecAttributes = AztecAttributes(),
                      var onVideoTappedListener: AztecText.OnVideoTappedListener? = null,
+                     onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                      editor: AztecText? = null) :
-        AztecMediaSpan(context, drawable, attributes, editor), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
 
     override val TAG: String = "video"
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -19,10 +19,10 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
         var deletedMedia = count > 0  && containsMediaChars(text, start, count)
 
         if (deletedMedia) {
-            var mediaSpanList = findAllMediaSpansWithinRange(start, count)
-            mediaSpanList?.forEach {
-                it.onMediaDeleted()
-            }
+            aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)
+                    ?.forEach {
+                        it.onMediaDeleted()
+                    }
         }
     }
 
@@ -41,10 +41,6 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
             }
         }
         return false
-    }
-
-    fun findAllMediaSpansWithinRange(start: Int, count: Int): Array<AztecMediaSpan>? {
-        return aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)
     }
 
     companion object {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -11,15 +11,15 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
 
     private val aztecTextRef: WeakReference<AztecText?> = WeakReference(aztecText)
 
-    private var deletedMedia: Boolean = false
-    private var mediaSpan: AztecMediaSpan? = null
-
     override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
-        deletedMedia = count > 0 && text[start + count - 1] == Constants.IMG_CHAR
+        if (aztecTextRef.get()?.isTextChangedListenerDisabled() ?: true) {
+            return
+        }
+        var deletedMedia = count > 0 && text[start + count - 1] == Constants.IMG_CHAR
 
         if (deletedMedia) {
-            val aztecText = aztecTextRef.get()
-            mediaSpan = aztecText?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)?.firstOrNull()
+            var mediaSpan = aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)?.firstOrNull()
+            mediaSpan?.onMediaDeleted()
         }
     }
 
@@ -28,14 +28,7 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
     }
 
     override fun afterTextChanged(text: Editable) {
-        if (aztecTextRef.get()?.isTextChangedListenerDisabled() ?: true) {
-            return
-        }
-
-        if (deletedMedia) {
-            deletedMedia = false
-            mediaSpan?.onMediaDeleted()
-        }
+        // no op
     }
 
     companion object {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -35,8 +35,8 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
     }
 
     fun containsMediaChars(text: CharSequence, start: Int, count: Int): Boolean {
-        for (i in 0..count) {
-            if (text[start + i - 1] == Constants.IMG_CHAR) {
+        for (i in 0..(count-1)) {
+            if (text[start + i] == Constants.IMG_CHAR) {
                 return true
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -16,9 +16,7 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
             return
         }
 
-        var deletedMedia = count > 0  && containsMediaChars(text, start, count)
-
-        if (deletedMedia) {
+        if (count > 0) {
             aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)
                     ?.forEach {
                         it.onMediaDeleted()
@@ -32,15 +30,6 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
 
     override fun afterTextChanged(text: Editable) {
         // no op
-    }
-
-    fun containsMediaChars(text: CharSequence, start: Int, count: Int): Boolean {
-        for (i in 0..(count-1)) {
-            if (text[start + i] == Constants.IMG_CHAR) {
-                return true
-            }
-        }
-        return false
     }
 
     companion object {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -1,0 +1,46 @@
+package org.wordpress.aztec.watchers
+
+import android.text.Editable
+import android.text.TextWatcher
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.Constants
+import org.wordpress.aztec.spans.AztecMediaSpan
+import java.lang.ref.WeakReference
+
+class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
+
+    private val aztecTextRef: WeakReference<AztecText?> = WeakReference(aztecText)
+
+    private var deletedMedia: Boolean = false
+    private var mediaSpan: AztecMediaSpan? = null
+
+    override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
+        deletedMedia = count > 0 && text[start + count - 1] == Constants.IMG_CHAR
+
+        if (deletedMedia) {
+            val aztecText = aztecTextRef.get()
+            mediaSpan = aztecText?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)?.firstOrNull()
+        }
+    }
+
+    override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
+        // no op
+    }
+
+    override fun afterTextChanged(text: Editable) {
+        if (aztecTextRef.get()?.isTextChangedListenerDisabled() ?: true) {
+            return
+        }
+
+        if (deletedMedia) {
+            deletedMedia = false
+            mediaSpan?.onMediaDeleted()
+        }
+    }
+
+    companion object {
+        fun install(text: AztecText) {
+            text.addTextChangedListener(DeleteMediaElementWatcher(text))
+        }
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -15,11 +15,14 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
         if (aztecTextRef.get()?.isTextChangedListenerDisabled() ?: true) {
             return
         }
-        var deletedMedia = count > 0 && text[start + count - 1] == Constants.IMG_CHAR
+
+        var deletedMedia = count > 0  && containsMediaChars(text, start, count)
 
         if (deletedMedia) {
-            var mediaSpan = aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)?.firstOrNull()
-            mediaSpan?.onMediaDeleted()
+            var mediaSpanList = findAllMediaSpansWithinRange(start, count)
+            mediaSpanList?.forEach {
+                it.onMediaDeleted()
+            }
         }
     }
 
@@ -29,6 +32,19 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
 
     override fun afterTextChanged(text: Editable) {
         // no op
+    }
+
+    fun containsMediaChars(text: CharSequence, start: Int, count: Int): Boolean {
+        for (i in 0..count) {
+            if (text[start + i - 1] == Constants.IMG_CHAR) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fun findAllMediaSpansWithinRange(start: Int, count: Int): Array<AztecMediaSpan>? {
+        return aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)
     }
 
     companion object {


### PR DESCRIPTION
### Fix
This PR adds the ability to detect when a media item has been deleted and issues a call to `OnMediaDeletedListener` if such a listener has been set.
This will be needed in WPAndroid if an operation is going on with the given media item (for example, an upload needs to be cancelled when the user deletes such an item).

### Test
1. start the demo app
2. position the cursor after any media item (i.e. audio, video, or image)
3. tap `backspace` to delete it
4. observe the `media deleted` toast is shown

### Review
@0nko 