### PR TITLE
Fix broken HTML button

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -346,7 +346,7 @@ class MainActivity : AppCompatActivity(),
 
         if (savedInstanceState == null) {
             aztec.visualEditor.fromHtml(aztec.sourceEditor?.getPureHtml()!!)
-            aztec.initHistory()
+            aztec.initSourceEditorHistory()
         }
 
         invalidateOptionsHandler = Handler()
@@ -381,7 +381,7 @@ class MainActivity : AppCompatActivity(),
     override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
         super.onRestoreInstanceState(savedInstanceState)
 
-        aztec.initHistory()
+        aztec.initSourceEditorHistory()
 
         savedInstanceState?.let {
             if (savedInstanceState.getBoolean("isPhotoMediaDialogVisible")) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -44,7 +44,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
         this.sourceEditor = sourceEditor
 
         initToolbar()
-        initHistory()
+        initSourceEditorHistory()
     }
 
     companion object Factory {
@@ -129,7 +129,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
         return this
     }
 
-    fun initHistory() {
+    fun initSourceEditorHistory() {
         sourceEditor?.history = visualEditor.history
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -60,6 +60,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
             return Aztec(visualEditor, sourceEditor, toolbar, toolbarClickListener)
         }
 
+        @JvmStatic
         fun with(visualEditor: AztecText, toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener) : Aztec {
             return Aztec(visualEditor, toolbar, toolbarClickListener)
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -26,7 +26,6 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     var sourceEditor: SourceViewEditText? = null
 
     init {
-        initHistory()
         initToolbar()
     }
 
@@ -43,6 +42,9 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     private constructor(visualEditor: AztecText, sourceEditor: SourceViewEditText,
                 toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener) : this(visualEditor, toolbar, toolbarClickListener) {
         this.sourceEditor = sourceEditor
+
+        initToolbar()
+        initHistory()
     }
 
     companion object Factory {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '3.0.0-beta2'
+        gradlePluginVersion = '3.0.0-beta3'
         kotlinVersion = '1.1.4-2'
         supportLibVersion = '26.0.1'
         tagSoupVersion = '1.2.1'


### PR DESCRIPTION
The primary `Aztec` constructor is called before `sourceEditor` gets initialized by a factory method, so it's always `null` in `AztecToolbar`. This PR fixes this.