### PR TITLE
issue/451 fixing OOB when unmarshalling URL span

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -17,7 +17,6 @@
 
 package org.wordpress.aztec.spans
 
-import android.os.Parcel
 import android.text.TextPaint
 import android.text.style.URLSpan
 import org.wordpress.aztec.AztecAttributes
@@ -43,17 +42,6 @@ class AztecURLSpan : URLSpan, IAztecInlineSpan {
     constructor(url: String, linkStyle: LinkFormatter.LinkStyle, attributes: AztecAttributes = AztecAttributes()) : this(url, attributes) {
         this.linkColor = linkStyle.linkColor
         this.linkUnderline = linkStyle.linkUnderline
-    }
-
-    constructor(src: Parcel) : super(src) {
-        this.linkColor = src.readInt()
-        this.linkUnderline = src.readInt() != 0
-    }
-
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        super.writeToParcel(dest, flags)
-        dest.writeInt(linkColor)
-        dest.writeInt(if (linkUnderline) 1 else 0)
     }
 
     override fun updateDrawState(ds: TextPaint) {


### PR DESCRIPTION
Fixes #451

Was caused by the artifact from the past.

This issue is not reproducible on every device. So far I was able to reproduce it only on Genymotion emulator of Galaxy S3 (4.3). 

To test:

- Turn on "Don't keep activities"
- Load demo app with default content or just a URL in it.
- Go to home screen, and return back to the editor, so the activity will get recreated.
- Notice that the editor is not crashing.
