### PR TITLE
Resize pictures to smaller size (800px)

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -29,6 +29,7 @@ import android.widget.PopupMenu
 import android.widget.TextView
 import android.widget.Toast
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.aztec.*
@@ -183,7 +184,6 @@ class MainActivity : AppCompatActivity(),
                     val options = BitmapFactory.Options()
                     options.inDensity = DisplayMetrics.DENSITY_DEFAULT
                     bitmap = BitmapFactory.decodeFile(mediaPath, options)
-
                     insertImageAndSimulateUpload(bitmap, mediaPath)
                 }
                 REQUEST_MEDIA_PHOTO -> {
@@ -229,14 +229,16 @@ class MainActivity : AppCompatActivity(),
     }
 
     fun insertImageAndSimulateUpload(bitmap: Bitmap?, mediaPath: String) {
+        val bitmapResized = ImageUtils.getScaledBitmapAtLongestSide(bitmap, aztec.visualEditor.maxImagesWidth)
         val (id, attrs) = generateAttributesForMedia(mediaPath, isVideo = false)
-        aztec.visualEditor.insertImage(BitmapDrawable(resources, bitmap), attrs)
+        aztec.visualEditor.insertImage(BitmapDrawable(resources, bitmapResized), attrs)
         insertMediaAndSimulateUpload(id, attrs)
     }
 
     fun insertVideoAndSimulateUpload(bitmap: Bitmap?, mediaPath: String) {
+        val bitmapResized = ImageUtils.getScaledBitmapAtLongestSide(bitmap, aztec.visualEditor.maxImagesWidth)
         val (id, attrs) = generateAttributesForMedia(mediaPath, isVideo = true)
-        aztec.visualEditor.insertVideo(BitmapDrawable(resources, bitmap), attrs)
+        aztec.visualEditor.insertVideo(BitmapDrawable(resources, bitmapResized), attrs)
         insertMediaAndSimulateUpload(id, attrs)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -240,7 +240,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         styles.recycle()
 
         // set the pictures max size to the min of screen width/height and DEFAULT_IMAGE_WIDTH
-        var minScreenSize = Math.min(context.resources.displayMetrics.widthPixels,
+        val minScreenSize = Math.min(context.resources.displayMetrics.widthPixels,
                 context.resources.displayMetrics.heightPixels)
         maxImagesWidth = Math.min(minScreenSize, DEFAULT_IMAGE_WIDTH)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -78,6 +78,8 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         val VISIBILITY_KEY = "VISIBILITY_KEY"
         val IS_MEDIA_ADDED_KEY = "IS_MEDIA_ADDED_KEY"
         val RETAINED_HTML_KEY = "RETAINED_HTML_KEY"
+
+        val DEFAULT_IMAGE_WIDTH = 800
     }
 
     private var historyEnable = resources.getBoolean(R.bool.history_enable)
@@ -129,6 +131,8 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
     var widthMeasureSpec: Int = 0
 
     var verticalParagraphMargin: Int = 0
+
+    var maxImagesWidth: Int = 0
 
     interface OnSelectionChangedListener {
         fun onSelectionChanged(selStart: Int, selEnd: Int)
@@ -234,6 +238,11 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
         lineBlockFormatter = LineBlockFormatter(this)
 
         styles.recycle()
+
+        // set the pictures max size to the min of screen width/height and DEFAULT_IMAGE_WIDTH
+        var minScreenSize = Math.min(context.resources.displayMetrics.widthPixels,
+                context.resources.displayMetrics.heightPixels)
+        maxImagesWidth = Math.min(minScreenSize, DEFAULT_IMAGE_WIDTH)
 
         if (historyEnable && historySize <= 0) {
             throw IllegalArgumentException("historySize must > 0")
@@ -748,6 +757,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
 
     private fun loadImages() {
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
+
         spans.forEach {
             val callbacks = object : Html.ImageGetter.Callbacks {
 
@@ -770,17 +780,12 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                     }
                 }
             }
-
-            // maxidth set to the biggest of screen width/height to cater for device rotation
-            val maxWidth = Math.max(context.resources.displayMetrics.widthPixels,
-                    context.resources.displayMetrics.heightPixels)
-            imageGetter?.loadImage(it.getSource(), callbacks, maxWidth)
+            imageGetter?.loadImage(it.getSource(), callbacks, this@AztecText.maxImagesWidth)
         }
     }
 
     private fun loadVideos() {
         val spans = this.text.getSpans(0, text.length, AztecVideoSpan::class.java)
-
         spans.forEach {
             val callbacks = object : Html.VideoThumbnailGetter.Callbacks {
 
@@ -803,8 +808,7 @@ class AztecText : AppCompatAutoCompleteTextView, TextWatcher, UnknownHtmlSpan.On
                     }
                 }
             }
-
-            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, context.resources.displayMetrics.widthPixels)
+            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth)
         }
     }
 


### PR DESCRIPTION
With this PR pictures added to the editor are resized to 800px wide (maximum) before inserting them.
Creating bitmaps at 800px wide saves a lot of memory and the editor is way much more responsive if you try to load several pictures into it. This is a first step for #420 


Note: Bitmap are downloaded from the network at 800px maximum, (resized to 800px max if taken from the camera) but the drawing code keeps changing the density 
```
 override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
                bitmap?.density = DisplayMetrics.DENSITY_DEFAULT
                callbacks.onImageLoaded(BitmapDrawable(context.resources, bitmap))
                targets.remove(source)
            }
```
and then the bitmap are drawn to fill the entire width of the screen.  You can't even tell that it was resized to 800px. 

### Review
@0nko @khaykov 