### PR TITLE
Upgrade build tools and gradle plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - extra-google-m2repository
     - platform-tools
     - tools
-    - build-tools-25.0.3
+    - build-tools-26.0.2
     - android-26
 
 env:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "org.wordpress.aztec"

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
+
 
     defaultConfig {
         minSdkVersion 16

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -5,7 +5,6 @@ android {
     compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 26

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '3.0.0-beta6'
+        gradlePluginVersion = '3.0.0-beta7'
         kotlinVersion = '1.1.50'
         supportLibVersion = '26.0.1'
         tagSoupVersion = '1.2.1'

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This PR upgrade build tools to `26.0.2` and gradle plugin to `3.0.0-beta7`.