### PR TITLE
Add high priority text formatting UI tests

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -1,0 +1,110 @@
+package org.wordpress.aztec.demo.tests
+
+import android.support.test.rule.ActivityTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.wordpress.aztec.demo.BaseTest
+import org.wordpress.aztec.demo.MainActivity
+import org.wordpress.aztec.demo.pages.EditorPage
+
+class MixedTextFormattingTests : BaseTest() {
+
+    @Rule
+    @JvmField
+    var mActivityTestRule = ActivityTestRule(MainActivity::class.java)
+
+    @Test
+    fun testBoldAndItalicFormatting() {
+        val text1 = "so"
+        val text2 = "me "
+        val text3 = "text "
+        val html = "<b>$text1</b><i>$text2</i><b><i>$text3</i></b>"
+
+        EditorPage()
+                .toggleBold()
+                .insertText(text1)
+                .toggleBold()
+                .toggleItalics()
+                .insertText(text2)
+                .toggleBold()
+                .insertText(text3)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testRemoveFormattingAndContinueTyping() {
+        val text1 = "some"
+        val text2 = "more"
+        val text3 = "text"
+        val html = "$text1<b>$text2</b>$text3"
+
+        EditorPage()
+                .insertText(text1)
+                .toggleBold()
+                .insertText(text2)
+                .toggleBold()
+                .insertText(text3)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testParagraphAndBlockFormatting() {
+        val text = "some text"
+        val html1 = "<p>$text</p>"
+        val html2 = "<blockquote>$text</blockquote>"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(html1)
+                .toggleHtml()
+                .toggleQuote()
+                .toggleHtml()
+                .verifyHTML(html2)
+    }
+
+    @Test
+    fun testRetainParagraphFormatting() {
+        val text = "some text"
+        val html = "<p>$text</p>"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testRetainHeadingFormatting() {
+        val text = "some text"
+        val html = "<h1>$text</h1>"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+                .selectAllText()
+                .makeHeader(EditorPage.HeadingStyle.ONE)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testSwitchHeadingFormatting() {
+        val text = "some text"
+        val html = "<h1>$text</h1>"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+                .selectAllText()
+                .makeHeader(EditorPage.HeadingStyle.DEFAULT)
+                .toggleHtml()
+                .verifyHTML(text)
+    }
+
+}


### PR DESCRIPTION
### Fix

This PR adds a suite of text formatting UI tests based on high priority bugs:

- Bold and italic formatting test (based on quirky style behavior described by @maxme)
- Remove formatting and continue typing (based on an issue where @maxme couldn't remove styling when writing text)
- Paragraph and block formatting (based on https://github.com/wordpress-mobile/AztecEditor-Android/issues/247)
- Retain paragraph formatting (based on https://github.com/wordpress-mobile/AztecEditor-Android/issues/480 — note that this test will fail as the issue is unresolved)
- Retain heading formatting (based on https://github.com/wordpress-mobile/AztecEditor-Android/issues/297)
- Switch heading formatting (also based on https://github.com/wordpress-mobile/AztecEditor-Android/issues/297)

### Test
1. Prepare your device/emulator for UI testing as described [in the project README](https://github.com/wordpress-mobile/AztecEditor-Android/tree/add/high-priority-formatting-tests#before-running-instrumentation-tests)
2. Run the tests in `MixedTextFormattingTests`

### Review
@maxme 