### PR TITLE
Update README: simplify command to run connected tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ On your device, under Settings -> Accessibility -> Touch & hold delay, set the d
 Run the instrumentation tests:
 
 ```shell
-$ adb shell am instrument -w -r -e package org.wordpress.aztec.demo -e debug false org.wordpress.aztec.test/android.support.test.runner.AndroidJUnitRunner
+$ ./gradlew cAT
 ```
 
 ## Integrating Aztec in your project


### PR DESCRIPTION
@0nko I'm not sure why we use `adb shell` directly to run connected tests, maybe I'm missing something.