### PR TITLE
Fix Multi-digit ordered list items rendering issue

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -28,7 +28,7 @@ class AztecOrderedListSpan(
         override var nestingLevel: Int,
         override var attributes: AztecAttributes = AztecAttributes(),
         var listStyle: BlockFormatter.ListStyle = BlockFormatter.ListStyle(0, 0, 0, 0, 0)
-    ) : AztecListSpan(nestingLevel, listStyle.verticalPadding) {
+) : AztecListSpan(nestingLevel, listStyle.verticalPadding) {
     override val TAG = "ol"
 
     override fun getLeadingMargin(first: Boolean): Int {
@@ -39,6 +39,7 @@ class AztecOrderedListSpan(
                                    top: Int, baseline: Int, bottom: Int,
                                    text: CharSequence, start: Int, end: Int,
                                    first: Boolean, l: Layout) {
+
         if (!first) return
 
         val spanStart = (text as Spanned).getSpanStart(this)
@@ -46,19 +47,30 @@ class AztecOrderedListSpan(
 
         if (start !in spanStart..spanEnd || end !in spanStart..spanEnd) return
 
-        val style = p.style
+        val oldStyle = p.style
         val oldColor = p.color
+        val oldTextSize = p.textSize
 
         p.color = listStyle.indicatorColor
         p.style = Paint.Style.FILL
 
         val lineIndex = getIndexOfProcessedLine(text, end)
-        val textToDraw = if (lineIndex > -1) getIndexOfProcessedLine(text, end).toString() + "." else ""
+        val textToDraw = if (lineIndex > -1) lineIndex.toString() + "." else ""
 
-        val width = p.measureText(textToDraw)
-        c.drawText(textToDraw, (listStyle.indicatorMargin + x + dir - width) * dir, baseline.toFloat(), p)
+        var width = p.measureText(textToDraw)
+        var xStartDraw = (listStyle.indicatorMargin + x + dir - width) * dir
+
+        // If we can't draw the item number in the available space, try with smaller text size until it fits the available space
+        while (xStartDraw < 0) {
+            p.textSize = p.textSize - 1
+            width = p.measureText(textToDraw)
+            xStartDraw = (listStyle.indicatorMargin + x + dir - width) * dir
+        }
+
+        c.drawText(textToDraw, xStartDraw, baseline.toFloat(), p)
 
         p.color = oldColor
-        p.style = style
+        p.style = oldStyle
+        p.textSize = oldTextSize
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -58,7 +58,7 @@ class AztecOrderedListSpan(
         val textToDraw = if (lineIndex > -1) lineIndex.toString() + "." else ""
 
         var width = p.measureText(textToDraw)
-        var xStartDraw = (listStyle.indicatorMargin + x + dir - width) * dir
+        var xStartDraw = (x + listStyle.indicatorMargin + listStyle.indicatorPadding + dir - width) * dir
 
         // If we can't draw the item number in the available space, try with smaller text size until it fits the available space
         while (xStartDraw < 0) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -56,7 +56,7 @@ class AztecUnorderedListSpan(
         val textToDraw = if (lineIndex > -1) "\u2022" else ""
 
         val width = p.measureText(textToDraw)
-        c.drawText(textToDraw, (listStyle.indicatorMargin + x + dir - width) * dir, (baseline + (width - p.descent())), p)
+        c.drawText(textToDraw, (listStyle.indicatorMargin + + listStyle.indicatorPadding + x + dir - width) * dir, (baseline + (width - p.descent())), p)
 
         p.color = oldColor
         p.style = style


### PR DESCRIPTION
### Fix #496 
by reducing the text size used to draw the item number.

It feels like an hacking solution but I didn't find a way to adapt the leading margin to the text being drawn on the screen. `getLeadingMargin` doesn't have any clue of the text being drawn on the screen, and thus we can't change the margin by adapting it to text. We should probably calculate the required space for the margin before, and pass it to `AztecOrderedListSpan` in the listStyle parameter.  

### Test
Change the demo app, and add a bunch of `li` in a `ol`.