### PR TITLE
Issue/496 experiment fix

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -32,6 +32,7 @@ class AztecOrderedListSpan(
     override val TAG = "ol"
 
     private var horizontalShift = 0
+    private var maxWidth = 0f
 
     override fun getLeadingMargin(first: Boolean): Int {
         return listStyle.indicatorMargin + 2 * listStyle.indicatorWidth + listStyle.indicatorPadding + horizontalShift
@@ -58,12 +59,17 @@ class AztecOrderedListSpan(
         val textToDraw = if (lineIndex > -1) getIndexOfProcessedLine(text, end).toString() + "." else ""
 
         val width = p.measureText(textToDraw)
+        maxWidth = Math.max(maxWidth, width)
 
         var textStart = (listStyle.indicatorMargin + x + dir - width) * dir
 
         if (textStart < 0) {
             horizontalShift = -textStart.toInt()
             textStart = 0f
+        }
+
+        if (horizontalShift > 0 && width < maxWidth) {
+            textStart += horizontalShift
         }
 
         c.drawText(textToDraw, textStart, baseline.toFloat(), p)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -31,8 +31,10 @@ class AztecOrderedListSpan(
     ) : AztecListSpan(nestingLevel, listStyle.verticalPadding) {
     override val TAG = "ol"
 
+    private var horizontalShift = 0
+
     override fun getLeadingMargin(first: Boolean): Int {
-        return listStyle.indicatorMargin + 2 * listStyle.indicatorWidth + listStyle.indicatorPadding
+        return listStyle.indicatorMargin + 2 * listStyle.indicatorWidth + listStyle.indicatorPadding + horizontalShift
     }
 
     override fun drawLeadingMargin(c: Canvas, p: Paint, x: Int, dir: Int,
@@ -56,7 +58,15 @@ class AztecOrderedListSpan(
         val textToDraw = if (lineIndex > -1) getIndexOfProcessedLine(text, end).toString() + "." else ""
 
         val width = p.measureText(textToDraw)
-        c.drawText(textToDraw, (listStyle.indicatorMargin + x + dir - width) * dir, baseline.toFloat(), p)
+
+        var textStart = (listStyle.indicatorMargin + x + dir - width) * dir
+
+        if (textStart < 0) {
+            horizontalShift = -textStart.toInt()
+            textStart = 0f
+        }
+
+        c.drawText(textToDraw, textStart, baseline.toFloat(), p)
 
         p.color = oldColor
         p.style = style


### PR DESCRIPTION
Fixes #496.

The solution shifts the numbers to the right if it can't fit all digits. The leading margin is shifted too, so that the numbers are all right-aligned with the items' text.

![image](https://user-images.githubusercontent.com/1522856/32543590-5c37b7fe-c476-11e7-9a6c-57a7a23ea3f0.png)

![image](https://user-images.githubusercontent.com/1522856/32543625-712dc69e-c476-11e7-88b2-c8519f52188c.png)
