### PR TITLE
Add high priority and mixed formatting UI tests

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
@@ -7,16 +7,37 @@ import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 
 object Matchers {
-    fun withRegex(regex: Regex): Matcher<View> {
+    fun withRegex(expected: Regex): Matcher<View> {
 
         return object : TypeSafeMatcher<View>() {
             override fun describeTo(description: Description) {
-                description.appendText("EditText matches $regex")
+                description.appendText("EditText matches $expected")
             }
 
             public override fun matchesSafely(view: View): Boolean {
                 if (view is EditText) {
-                    return view.text.toString().matches(regex)
+                    val regex = Regex(">\\s+<")
+                    val strippedText = view.text.toString().replace(regex, "><")
+                    return strippedText.matches(expected)
+                }
+
+                return false
+            }
+        }
+    }
+
+    fun withStrippedText(expected: String): Matcher<View> {
+
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("EditText matches $expected")
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                if (view is EditText) {
+                    val regex = Regex(">\\s+<")
+                    val strippedText = view.text.toString().replace(regex, "><")
+                    return strippedText.equals(expected)
                 }
 
                 return false

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -296,8 +296,7 @@ class EditorPage : BasePage() {
     }
 
     fun verifyHTML(expected: String): EditorPage {
-
-        htmlEditor.check(matches(withText(expected)))
+        htmlEditor.check(matches(Matchers.withStrippedText(expected)))
         label("Verified expected editor contents")
 
         return this

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -26,6 +26,9 @@ class EditorPage : BasePage() {
     private var editor: ViewInteraction
     private var htmlEditor: ViewInteraction
 
+    private var undoButton: ViewInteraction
+    private var redoButton: ViewInteraction
+
     private var insertMediaButton: ViewInteraction
     private var headingButton: ViewInteraction
     private var listButton: ViewInteraction
@@ -49,6 +52,9 @@ class EditorPage : BasePage() {
     init {
         editor = onView(withId(R.id.aztec))
         htmlEditor = onView(withId(R.id.source))
+
+        undoButton = onView(withId(R.id.undo))
+        redoButton = onView(withId(R.id.redo))
 
         insertMediaButton = onView(withId(R.id.format_bar_button_media))
         headingButton = onView(withId(R.id.format_bar_button_heading))
@@ -143,6 +149,20 @@ class EditorPage : BasePage() {
         Thread.sleep(200)
         devicePhotosButton.perform(click())
         label("Chose device photos")
+    }
+
+    fun undoChange(): EditorPage {
+        undoButton.perform(Actions.invokeClick())
+        label("Performed undo")
+
+        return this
+    }
+
+    fun redoChange(): EditorPage {
+        redoButton.perform(Actions.invokeClick())
+        label("Performed redo")
+
+        return this
     }
 
     fun makeHeader(style: HeadingStyle): EditorPage {
@@ -276,6 +296,7 @@ class EditorPage : BasePage() {
     }
 
     fun verifyHTML(expected: String): EditorPage {
+
         htmlEditor.check(matches(withText(expected)))
         label("Verified expected editor contents")
 

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
@@ -24,8 +24,28 @@ class ImageTests : BaseTest() {
     @JvmField
     val mActivityIntentsTestRule = IntentsTestRule<MainActivity>(MainActivity::class.java)
 
+    // Simple photo test, also tests the issue described in
+    // https://github.com/wordpress-mobile/AztecEditor-Android/issues/306
     @Test
     fun testAddPhoto() {
+        val regex = Regex("<img src=.+>")
+
+        createImageIntentFilter()
+
+        EditorPage()
+                .tapTop()
+                .insertMedia()
+
+        // Must wait for simulated upload
+        Thread.sleep(10000)
+
+        EditorPage()
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
+
+    @Test
+    fun testAddPhotoAndText() {
         var sampleText = "sample text "
         val regex = Regex(".+<img src=.+>.+")
 
@@ -65,6 +85,25 @@ class ImageTests : BaseTest() {
         EditorPage()
                 .toggleHtml()
                 .verifyHTML(regex)
+    }
+
+    // Tests the issue described in
+    // https://github.com/wordpress-mobile/AztecEditor-Android/issues/299
+    @Test
+    fun testUndoImageUpload() {
+        createImageIntentFilter()
+
+        EditorPage()
+                .tapTop()
+                .insertMedia()
+
+        // Must wait for simulated upload to start
+        Thread.sleep(1000)
+
+        EditorPage()
+                .undoChange()
+                .toggleHtml()
+                .verifyHTML("")
     }
 
     private fun addPhotoWithHTML() {

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -108,4 +108,84 @@ class MixedTextFormattingTests : BaseTest() {
                 .toggleHtml()
                 .verifyHTML(text)
     }
+
+    @Test
+    fun testTwoHeadings() {
+        val text = "some text"
+        val linebreak = "\n"
+        val html = "<h1>$text</h1>$linebreak<h2>$text</h2>"
+
+        EditorPage()
+                .makeHeader(EditorPage.HeadingStyle.ONE)
+                .insertText(text)
+                .insertText(linebreak)
+                .makeHeader(EditorPage.HeadingStyle.TWO)
+                .insertText(text)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testEndHeadingFormatting() {
+        val text = "some text"
+        val linebreak = "\n"
+        val html = "<h1>$text</h1>$linebreak$text"
+
+        EditorPage()
+                .makeHeader(EditorPage.HeadingStyle.ONE)
+                .insertText(text)
+                .insertText(linebreak)
+                .insertText(text)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testEndQuoteFormatting() {
+        val text = "some text"
+        val linebreak = "\n"
+        val html = "<blockquote>$text</blockquote>$linebreak$text"
+
+        EditorPage()
+                .toggleQuote()
+                .insertText(text)
+                .insertText(linebreak)
+                .insertText(linebreak)
+                .insertText(text)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testRemoveQuoteFormatting() {
+        val text = "some text"
+        val linebreak = "\n"
+        val html = "<blockquote>$text</blockquote>$linebreak$text"
+
+        EditorPage()
+                .toggleQuote()
+                .insertText(text)
+                .insertText(linebreak)
+                .insertText(text)
+                .toggleQuote()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testQuotedListFormatting() {
+        var text = "some text\n"
+        val regex = Regex("<blockquote>\\s+<ul>[\\S\\s]+</ul>\\s+</blockquote>")
+
+        for (i in 1..3) {
+            text += text
+        }
+
+        EditorPage()
+                .toggleQuote()
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .insertText(text)
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
 }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -112,13 +112,12 @@ class MixedTextFormattingTests : BaseTest() {
     @Test
     fun testTwoHeadings() {
         val text = "some text"
-        val linebreak = "\n"
-        val html = "<h1>$text</h1>$linebreak<h2>$text</h2>"
+        val html = "<h1>$text</h1><h2>$text</h2>"
 
         EditorPage()
                 .makeHeader(EditorPage.HeadingStyle.ONE)
                 .insertText(text)
-                .insertText(linebreak)
+                .insertText("\n")
                 .makeHeader(EditorPage.HeadingStyle.TWO)
                 .insertText(text)
                 .toggleHtml()
@@ -128,13 +127,12 @@ class MixedTextFormattingTests : BaseTest() {
     @Test
     fun testEndHeadingFormatting() {
         val text = "some text"
-        val linebreak = "\n"
-        val html = "<h1>$text</h1>$linebreak$text"
+        val html = "<h1>$text</h1>\n$text"
 
         EditorPage()
                 .makeHeader(EditorPage.HeadingStyle.ONE)
                 .insertText(text)
-                .insertText(linebreak)
+                .insertText("\n")
                 .insertText(text)
                 .toggleHtml()
                 .verifyHTML(html)
@@ -143,14 +141,12 @@ class MixedTextFormattingTests : BaseTest() {
     @Test
     fun testEndQuoteFormatting() {
         val text = "some text"
-        val linebreak = "\n"
-        val html = "<blockquote>$text</blockquote>$linebreak$text"
+        val html = "<blockquote>$text</blockquote>\n$text"
 
         EditorPage()
                 .toggleQuote()
                 .insertText(text)
-                .insertText(linebreak)
-                .insertText(linebreak)
+                .insertText("\n\n")
                 .insertText(text)
                 .toggleHtml()
                 .verifyHTML(html)
@@ -159,13 +155,12 @@ class MixedTextFormattingTests : BaseTest() {
     @Test
     fun testRemoveQuoteFormatting() {
         val text = "some text"
-        val linebreak = "\n"
-        val html = "<blockquote>$text</blockquote>$linebreak$text"
+        val html = "<blockquote>$text</blockquote>\n$text"
 
         EditorPage()
                 .toggleQuote()
                 .insertText(text)
-                .insertText(linebreak)
+                .insertText("\n")
                 .insertText(text)
                 .toggleQuote()
                 .toggleHtml()
@@ -174,18 +169,14 @@ class MixedTextFormattingTests : BaseTest() {
 
     @Test
     fun testQuotedListFormatting() {
-        var text = "some text\n"
-        val regex = Regex("<blockquote>\\s+<ul>[\\S\\s]+</ul>\\s+</blockquote>")
-
-        for (i in 1..3) {
-            text += text
-        }
+        var text = "some text\nsome text\nsome text"
+        val html = "<blockquote><ul><li>some text</li><li>some text</li><li>some text</li></ul></blockquote>"
 
         EditorPage()
                 .toggleQuote()
                 .makeList(EditorPage.ListStyle.UNORDERED)
                 .insertText(text)
                 .toggleHtml()
-                .verifyHTML(regex)
+                .verifyHTML(html)
     }
 }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -169,13 +169,42 @@ class MixedTextFormattingTests : BaseTest() {
 
     @Test
     fun testQuotedListFormatting() {
-        var text = "some text\nsome text\nsome text"
+        val text = "some text\nsome text\nsome text"
         val html = "<blockquote><ul><li>some text</li><li>some text</li><li>some text</li></ul></blockquote>"
 
         EditorPage()
                 .toggleQuote()
                 .makeList(EditorPage.ListStyle.UNORDERED)
                 .insertText(text)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testQuotedListRemoveListFormatting() {
+        val text = "some text\nsome text\nsome text"
+        val html = "<blockquote><ul><li>some text</li><li>some text</li></ul>\nsome text</blockquote>"
+
+        EditorPage()
+                .toggleQuote()
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .insertText(text)
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testListwithQuoteFormatting() {
+        val text1 = "some text\nsome text\nsome text\n"
+        val text2 = "some text"
+        val html = "<ul><li>some text</li><li>some text</li><li>some text</li><li><blockquote>some text</blockquote></li></ul>"
+
+        EditorPage()
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .insertText(text1)
+                .toggleQuote()
+                .insertText(text2)
                 .toggleHtml()
                 .verifyHTML(html)
     }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
@@ -88,7 +88,7 @@ class SimpleTextFormattingTests : BaseTest() {
     fun testSimpleUnorderedListFormatting() {
         val text1 = "some\n"
         val text2 = "text"
-        val html = "$text1<ul>\n\t<li>$text2</li>\n</ul>"
+        val html = "$text1<ul><li>$text2</li></ul>"
 
         EditorPage()
                 .insertText(text1)
@@ -102,7 +102,7 @@ class SimpleTextFormattingTests : BaseTest() {
     fun testSimpleOrderedListFormatting() {
         val text1 = "some\n"
         val text2 = "text"
-        val html = "$text1<ol>\n\t<li>$text2</li>\n</ol>"
+        val html = "$text1<ol><li>$text2</li></ol>"
 
         EditorPage()
                 .insertText(text1)

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
@@ -306,6 +306,29 @@ class SimpleTextFormattingTests : BaseTest() {
                 .verifyHTML(expected2)
     }
 
+    @Test
+    fun testRemoveListFormatting() {
+
+        val text = "some text\nsome text\nsome text"
+        val expected1 = "<ul><li>some text</li><li>some text</li><li>some text</li></ul>"
+        val expected2 = "<ul><li>some text</li><li>some text</li></ul>\nsome text"
+
+        EditorPage()
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .insertText(text)
+                .toggleHtml()
+                .verifyHTML(expected1)
+                .toggleHtml()
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .toggleHtml()
+                .verifyHTML(expected2)
+                .toggleHtml()
+                .selectAllText()
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .toggleHtml()
+                .verifyHTML(text)
+    }
+
     // Test reproducing the issue described in
     // https://github.com/wordpress-mobile/AztecEditor-Android/pull/466#issuecomment-322404363
     @Test


### PR DESCRIPTION
1. Adds UI tests for high priority issues #306 and #299.
2. Adds more UI tests for mixed formatting. 
3. Strips whitespace between HTML tags when verifying the HTML output (to match the iOS test behavior in https://github.com/wordpress-mobile/AztecEditor-iOS/pull/817).

### To Test

Build and run the instrumentation tests, e.g. with `./gradlew cAT` ([see README for details](https://github.com/wordpress-mobile/AztecEditor-Android/tree/add/high-priority-ui-tests#build-and-test)).

Note that `testRetainParagraphFormatting` currently fails but will be resolved by https://github.com/wordpress-mobile/AztecEditor-Android/pull/483.