### PR TITLE
Add toolbarStateAboutToChange method to IToolbarAction interface

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/IToolbarButton.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/IToolbarButton.kt
@@ -3,6 +3,7 @@ package org.wordpress.aztec.plugins
 import android.content.Context
 import android.view.KeyEvent
 import android.view.ViewGroup
+import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IToolbarAction
 import org.wordpress.aztec.toolbar.RippleToggleButton
 
@@ -40,4 +41,11 @@ interface IToolbarButton : IAztecPlugin {
      * @param parent view to be the parent of the generated hierarchy.
      */
     fun inflateButton(parent: ViewGroup)
+
+    /**
+     * Signals the ToolbarButton that the toolbar is about to change its enabled/disabled state
+     *
+     * This method is called when the toolbar buttons get "disabled/enabled"
+     */
+    fun toolbarStateAboutToChange(toolbar: AztecToolbar, enable: Boolean)
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -766,7 +766,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                 toggleButtonState(findViewById(action.buttonId), !isEnabled)
             }
         }
-        toolbarButtonPlugins.forEach { button -> button.toolbarStateAboutToChange(this, !isEnabled)}
+        toolbarButtonPlugins.forEach { button -> button.toolbarStateAboutToChange(this, !isEnabled) }
     }
 
     private fun showDialogShortcuts() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -766,6 +766,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                 toggleButtonState(findViewById(action.buttonId), !isEnabled)
             }
         }
+        toolbarButtonPlugins.forEach { button -> button.toolbarStateAboutToChange(this, !isEnabled)}
     }
 
     private fun showDialogShortcuts() {

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -6,17 +6,19 @@ import android.text.Spanned
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.ToggleButton
+import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Constants
 import org.wordpress.aztec.plugins.IToolbarButton
 import org.wordpress.aztec.plugins.wpcomments.R
 import org.wordpress.aztec.plugins.wpcomments.spans.WordPressCommentSpan
 import org.wordpress.aztec.spans.IAztecNestable
+import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IToolbarAction
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
 
 class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
-
     override val action: IToolbarAction = CommentsToolbarAction.MORE
     override val context = visualEditor.context!!
 
@@ -53,5 +55,9 @@ class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
 
     override fun inflateButton(parent: ViewGroup) {
         LayoutInflater.from(context).inflate(R.layout.more_button, parent)
+    }
+
+    override fun toolbarStateAboutToChange(toolbar: AztecToolbar, enable: Boolean) {
+        toolbar.findViewById<ToggleButton>(R.id.format_bar_button_more).isEnabled = enable
     }
 }

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -7,7 +7,6 @@ import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.ToggleButton
-import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Constants
 import org.wordpress.aztec.plugins.IToolbarButton

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
@@ -12,6 +12,7 @@ import org.wordpress.aztec.plugins.IToolbarButton
 import org.wordpress.aztec.plugins.wpcomments.R
 import org.wordpress.aztec.plugins.wpcomments.spans.WordPressCommentSpan
 import org.wordpress.aztec.spans.IAztecNestable
+import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IToolbarAction
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
 
@@ -53,5 +54,9 @@ class PageToolbarButton(val visualEditor: AztecText) : IToolbarButton {
 
     override fun inflateButton(parent: ViewGroup) {
         LayoutInflater.from(context).inflate(R.layout.page_button, parent)
+    }
+
+    override fun toolbarStateAboutToChange(toolbar: AztecToolbar, enable: Boolean) {
+        // no op
     }
 }


### PR DESCRIPTION

This PR expands the `IToolbarAction` interface so plugins are signalled that the toolbar is going to be enabled/disabled, for plugins to do their required stuff (i.e. disabling the more button, for example).

The problem is that the [`enableMediaMode()` method in `AztecToolbar`](https://github.com/wordpress-mobile/AztecEditor-Android/blob/develop/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt#L760) only goes through all "native" Aztec toolbar buttons, but not through the plugin buttons, thus leaving these buttons enabled all the time.
As plugins might have their own purpose, I decided to extend the functionality by augmenting the `IToolbarAction` interface to let the plugin button know when the toolbar state has changed.


### Fix
Check the related WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/6871

### Test
1. start a draft post
2. tap on the body area of the editor
3. expand the toolbar and check that the `More` option is tappable and works (inserts a More item in the body of the Post)
4. tap on the `+` at the leftmost part of the toolbar to show the mediapicker.
5. once the mediapicker is showing, check in the toolbar that the `More` option is disabled now.
7. exit the media picker (either by pressing back or by actually choosing to insert some media item)
8. observe the `More` item in the toolbar is enabled now again.

### Review
@0nko 