### PR TITLE
Fix a connected test: `testAddTwoPhotos`

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
@@ -50,7 +50,7 @@ class ImageTests : BaseTest() {
 
     @Test
     fun testAddTwoPhotos() {
-        val regex = Regex(".*<img src=.+>.*<img src=.+>.*")
+        val regex = Regex(".*<img src=.+>.*<img src=.+>.*", RegexOption.DOT_MATCHES_ALL)
 
         createImageIntentFilter()
         addPhotoWithHTML()

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -57,6 +57,7 @@ import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
 import org.wordpress.aztec.watchers.BlockElementWatcher
 import org.xml.sax.Attributes
 import java.io.File
+import java.util.Random
 
 class MainActivity : AppCompatActivity(),
         AztecText.OnImeBackListener,
@@ -252,8 +253,7 @@ class MainActivity : AppCompatActivity(),
     }
 
     private fun generateAttributesForMedia(mediaPath: String, isVideo: Boolean): Pair<String, AztecAttributes> {
-        val id = (Math.random() * Int.MAX_VALUE).toString()
-
+        val id = Random().nextInt(Integer.MAX_VALUE).toString()
         val attrs = AztecAttributes()
         attrs.setValue("src", mediaPath) // Temporary source value.  Replace with URL after uploaded.
         attrs.setValue("id", id)


### PR DESCRIPTION
Fix `testAddTwoPhotos` - test broke after the merge of https://github.com/wordpress-mobile/AztecEditor-Android/pull/525 (introduced new lines after media)