### PR TITLE
Issue/196 make images stay inside link

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
@@ -88,6 +88,26 @@ class ImageTests : BaseTest() {
     }
 
     // Tests the issue described in
+    // https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
+    // Currently it's only possible to reproduce this issue on real device or emulator, and not with Genymotion
+    @Test
+    fun testParsingOfPhotoSurroundedByLink() {
+        val imageHtml = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">" +
+                "<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\">" +
+                "</a>"
+
+        EditorPage()
+                .tapTop()
+                .toggleHtml()
+                .replaceHTML(imageHtml)
+                .toggleHtml()
+
+        EditorPage()
+                .toggleHtml()
+                .verifyHTML(imageHtml)
+    }
+
+    // Tests the issue described in
     // https://github.com/wordpress-mobile/AztecEditor-Android/issues/299
     @Test
     fun testUndoImageUpload() {

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
@@ -91,7 +91,7 @@ class ImageTests : BaseTest() {
     // https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
     // Currently it's only possible to reproduce this issue on real device or emulator, and not with Genymotion
     @Test
-    fun testParsingOfPhotoSurroundedByLink() {
+    fun testParsingOfImagesWithLink() {
         val imageHtml = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">" +
                 "<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\">" +
                 "</a>"

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -32,7 +32,6 @@ import org.wordpress.aztec.spans.AztecCursorSpan
 import org.wordpress.aztec.spans.AztecHorizontalRuleSpan
 import org.wordpress.aztec.spans.AztecListItemSpan
 import org.wordpress.aztec.spans.AztecListSpan
-import org.wordpress.aztec.spans.AztecMediaClickableSpan
 import org.wordpress.aztec.spans.AztecMediaSpan
 import org.wordpress.aztec.spans.AztecURLSpan
 import org.wordpress.aztec.spans.AztecVisualLinebreak
@@ -513,17 +512,11 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
             val urlSpanStart = text.getSpanStart(urlSpan)
             val urlSpanEnd = text.getSpanEnd(urlSpan)
 
-            val isUrlSpanOutsideMediaSpan = spans.indexOf(urlSpan) > spans.indexOf(mediaSpan)
+            val isUrlSpanFollowsMediaSpan = spans.indexOf(urlSpan) > spans.indexOf(mediaSpan)
+            val isMediaSpanWithinUrlSpan = text.getSpanStart(mediaSpan) >= urlSpanStart && text.getSpanEnd(mediaSpan) <= urlSpanEnd
 
-            if (isUrlSpanOutsideMediaSpan) {
-                val isSpanMatch = spans.filter {
-                    it is AztecMediaSpan || it is AztecURLSpan || it is AztecMediaClickableSpan
-                            && text.getSpanStart(it) >= urlSpanStart && text.getSpanEnd(it) <= urlSpanEnd
-                }.size == 3
-
-                if (isSpanMatch) {
-                    Collections.swap(spans, spans.indexOf(urlSpan), spans.indexOf(mediaSpan))
-                }
+            if (isUrlSpanFollowsMediaSpan && isMediaSpanWithinUrlSpan) {
+                Collections.swap(spans, spans.indexOf(urlSpan), spans.indexOf(mediaSpan))
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1158,7 +1158,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     fun removeLink() {
         val urlSpanBounds = linkFormatter.getUrlSpanBounds()
 
-        linkFormatter.linkInvalid(urlSpanBounds.first, urlSpanBounds.second)
+        linkFormatter.removeLink(urlSpanBounds.first, urlSpanBounds.second)
         onSelectionChanged(urlSpanBounds.first, urlSpanBounds.second)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/extensions/MediaLinkExtensions.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/extensions/MediaLinkExtensions.kt
@@ -7,36 +7,34 @@ import org.wordpress.aztec.spans.AztecMediaSpan
 import org.wordpress.aztec.spans.AztecURLSpan
 
 fun AztecText.getMediaLink(attributePredicate: AztecText.AttributePredicate): String {
-    text.getSpans(0, text.length, AztecMediaSpan::class.java).firstOrNull {
-        attributePredicate.matches(it.attributes)
-    }?.let {
-        val start = text.getSpanStart(it)
-        val end = text.getSpanEnd(it)
+    text.getSpans(0, text.length, AztecMediaSpan::class.java)
+            .firstOrNull { attributePredicate.matches(it.attributes) }
+            ?.let {
+                val start = text.getSpanStart(it)
+                val end = text.getSpanEnd(it)
 
-        editableText.getSpans(start, end, AztecURLSpan::class.java).firstOrNull()?.let { return it.url }
-    }
+                editableText.getSpans(start, end, AztecURLSpan::class.java).firstOrNull()?.let { return it.url }
+            }
 
     return ""
 }
 
 fun AztecText.getMediaLinkAttributes(attributePredicate: AztecText.AttributePredicate): AztecAttributes {
-    text.getSpans(0, text.length, AztecMediaSpan::class.java).firstOrNull {
-        attributePredicate.matches(it.attributes)
-    }?.let {
-        val start = text.getSpanStart(it)
-        val end = text.getSpanEnd(it)
+    text.getSpans(0, text.length, AztecMediaSpan::class.java)
+            .firstOrNull { attributePredicate.matches(it.attributes) }
+            ?.let {
+                val start = text.getSpanStart(it)
+                val end = text.getSpanEnd(it)
 
-        text.getSpans(start, end, AztecURLSpan::class.java).firstOrNull()?.let { return it.attributes }
-    }
+                text.getSpans(start, end, AztecURLSpan::class.java).firstOrNull()?.let { return it.attributes }
+            }
 
     return AztecAttributes()
 }
 
 fun AztecText.removeLinkFromMedia(attributePredicate: AztecText.AttributePredicate) {
     text.getSpans(0, text.length, AztecMediaSpan::class.java)
-            .filter {
-                attributePredicate.matches(it.attributes)
-            }
+            .filter { attributePredicate.matches(it.attributes) }
             .forEach {
                 val start = text.getSpanStart(it)
                 val end = text.getSpanEnd(it)
@@ -46,7 +44,8 @@ fun AztecText.removeLinkFromMedia(attributePredicate: AztecText.AttributePredica
 }
 
 fun AztecText.addLinkToMedia(attributePredicate: AztecText.AttributePredicate, link: String, linkAttributes: AztecAttributes = AztecAttributes()) {
-    text.getSpans(0, text.length, AztecMediaSpan::class.java).filter { attributePredicate.matches(it.attributes) }
+    text.getSpans(0, text.length, AztecMediaSpan::class.java)
+            .filter { attributePredicate.matches(it.attributes) }
             .forEach {
                 val start = text.getSpanStart(it)
                 val end = text.getSpanEnd(it)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/extensions/MediaLinkExtensions.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/extensions/MediaLinkExtensions.kt
@@ -1,4 +1,4 @@
-package org.wordpress.aztec.util
+package org.wordpress.aztec.extensions
 
 import android.text.Spanned
 import org.wordpress.aztec.AztecAttributes

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
@@ -19,7 +19,7 @@ class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle) : AztecFormatte
         return !urlSpans.isEmpty()
     }
 
-    fun getSelectedUrlWithAnchor(start: Int = selectionStart, end: Int = selectionEnd): Pair<String, String> {
+    fun getSelectedUrlWithAnchor(): Pair<String, String> {
         val url: String
         var anchor: String
 
@@ -27,14 +27,14 @@ class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle) : AztecFormatte
             val clipboardUrl = getUrlFromClipboard(editor.context)
 
             url = if (TextUtils.isEmpty(clipboardUrl)) "" else clipboardUrl
-            anchor = if (start == end) "" else editor.getSelectedText()
+            anchor = if (selectionStart == selectionEnd) "" else editor.getSelectedText()
         } else {
-            val urlSpan = editableText.getSpans(start, end, AztecURLSpan::class.java).first()
+            val urlSpan = editableText.getSpans(selectionStart, selectionEnd, AztecURLSpan::class.java).first()
 
             val spanStart = editableText.getSpanStart(urlSpan)
             val spanEnd = editableText.getSpanEnd(urlSpan)
 
-            if (start < spanStart || end > spanEnd) {
+            if (selectionStart < spanStart || selectionEnd > spanEnd) {
                 // looks like some text that is not part of the url was included in selection
                 anchor = editor.getSelectedText()
                 url = ""
@@ -78,13 +78,13 @@ class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle) : AztecFormatte
         return Pair(spanStart, spanEnd)
     }
 
-    fun addLink(link: String, anchor: String, start: Int, end: Int, linkAttributes: AztecAttributes = AztecAttributes()) {
+    fun addLink(link: String, anchor: String, start: Int, end: Int) {
         val cleanLink = link.trim()
 
         val actualAnchor = if (TextUtils.isEmpty(anchor)) cleanLink else anchor
 
         val ssb = SpannableStringBuilder(actualAnchor)
-        setLinkSpan(ssb, cleanLink, 0, actualAnchor.length, linkAttributes)
+        setLinkSpan(ssb, cleanLink, 0, actualAnchor.length)
 
         if (start == end) {
             // insert anchor
@@ -94,7 +94,7 @@ class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle) : AztecFormatte
             if (editor.getSelectedText() != anchor) {
                 editableText.replace(start, end, ssb)
             } else {
-                setLinkSpan(editableText, cleanLink, start, end, linkAttributes)
+                setLinkSpan(editableText, cleanLink, start, end)
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/MediaExtensions.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/MediaExtensions.kt
@@ -1,5 +1,6 @@
 package org.wordpress.aztec.util
 
+import android.text.Spanned
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecMediaSpan
@@ -44,16 +45,13 @@ fun AztecText.removeLinkFromMedia(attributePredicate: AztecText.AttributePredica
             }
 }
 
-fun AztecText.addLinkToMedia(attributePredicate: AztecText.AttributePredicate, link: String, linkAttributes: AztecAttributes) {
-    text.getSpans(0, text.length, AztecMediaSpan::class.java)
-            .filter {
-                attributePredicate.matches(it.attributes)
-            }
+fun AztecText.addLinkToMedia(attributePredicate: AztecText.AttributePredicate, link: String, linkAttributes: AztecAttributes = AztecAttributes()) {
+    text.getSpans(0, text.length, AztecMediaSpan::class.java).filter { attributePredicate.matches(it.attributes) }
             .forEach {
                 val start = text.getSpanStart(it)
                 val end = text.getSpanEnd(it)
 
                 removeLinkFromMedia(attributePredicate)
-                linkFormatter.setLinkSpan(text, link, start, end, linkAttributes)
+                text.setSpan(AztecURLSpan(link, linkAttributes), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/MediaExtensions.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/MediaExtensions.kt
@@ -1,0 +1,59 @@
+package org.wordpress.aztec.util
+
+import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.spans.AztecMediaSpan
+import org.wordpress.aztec.spans.AztecURLSpan
+
+fun AztecText.getMediaLink(attributePredicate: AztecText.AttributePredicate): String {
+    text.getSpans(0, text.length, AztecMediaSpan::class.java).firstOrNull {
+        attributePredicate.matches(it.attributes)
+    }?.let {
+        val start = text.getSpanStart(it)
+        val end = text.getSpanEnd(it)
+
+        editableText.getSpans(start, end, AztecURLSpan::class.java).firstOrNull()?.let { return it.url }
+    }
+
+    return ""
+}
+
+fun AztecText.getMediaLinkAttributes(attributePredicate: AztecText.AttributePredicate): AztecAttributes {
+    text.getSpans(0, text.length, AztecMediaSpan::class.java).firstOrNull {
+        attributePredicate.matches(it.attributes)
+    }?.let {
+        val start = text.getSpanStart(it)
+        val end = text.getSpanEnd(it)
+
+        text.getSpans(start, end, AztecURLSpan::class.java).firstOrNull()?.let { return it.attributes }
+    }
+
+    return AztecAttributes()
+}
+
+fun AztecText.removeLinkFromMedia(attributePredicate: AztecText.AttributePredicate) {
+    text.getSpans(0, text.length, AztecMediaSpan::class.java)
+            .filter {
+                attributePredicate.matches(it.attributes)
+            }
+            .forEach {
+                val start = text.getSpanStart(it)
+                val end = text.getSpanEnd(it)
+
+                linkFormatter.removeLink(start, end)
+            }
+}
+
+fun AztecText.addLinkToMedia(attributePredicate: AztecText.AttributePredicate, link: String, linkAttributes: AztecAttributes) {
+    text.getSpans(0, text.length, AztecMediaSpan::class.java)
+            .filter {
+                attributePredicate.matches(it.attributes)
+            }
+            .forEach {
+                val start = text.getSpanStart(it)
+                val end = text.getSpanEnd(it)
+
+                removeLinkFromMedia(attributePredicate)
+                linkFormatter.setLinkSpan(text, link, start, end, linkAttributes)
+            }
+}


### PR DESCRIPTION
Fixes #196 and adds a couple of methods for simplifying working with links attached to media.

The issue was caused by the span order problem, present in some versions of Android. URL span was processed after image tag and discarded because it was empty.
Fix simply detects situations when this happens and swaps spans so that they will be parsed correctly.