### PR TITLE
adding test for issue #530

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -124,6 +124,15 @@ class EditorPage : BasePage() {
         return this
     }
 
+    fun moveCursorLeftAsManyTimes(times: Int): EditorPage {
+        for (time in 1..times) {
+            editor.perform(pressKey(KeyEvent.KEYCODE_DPAD_LEFT))
+        }
+        label("Moved cursor left " + times + " times")
+
+        return this
+    }
+
     fun insertHTML(html: String): EditorPage {
         htmlEditor.perform(typeText(html), ViewActions.closeSoftKeyboard())
         label("Inserted HTML")

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -34,6 +34,26 @@ class MixedTextFormattingTests : BaseTest() {
                 .verifyHTML(regex)
     }
 
+    // Test reproducing the issue described in
+    // https://github.com/wordpress-mobile/AztecEditor-Android/issues/530
+    @Test
+    fun testBoldFormattingAndSpaceInsertion() {
+        val text1 = "a"
+        val text2 = "b"
+        val text3 = " "
+        val html = "a <b>b</b>"
+
+        EditorPage()
+                .insertText(text1)
+                .toggleBold()
+                .focusedInsertText(text2)
+                .moveCursorLeftAsManyTimes(1)
+                .focusedInsertText(text3)
+                .toggleHtml()
+                .verifyHTML(html)
+
+    }
+
     @Test
     fun testRemoveFormattingAndContinueTyping() {
         val text1 = "some"


### PR DESCRIPTION
This PR adds a test for issue #530 

#### Steps
1. on the editor, type "a" 
2. toggle Bold style, 
3. type "b". 
4. Put the cursor between "a" and "b" 
5. press space. Notice that "b" became unstyled.

#### Tested
Test should pass on: API 22, 5.1.0
Test should **not** pass on: API 26 (8.0)

### Review
@maxme 