### PR TITLE
Fix for 'PARAGRAPH span must start at paragraph boundary'

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -157,6 +157,12 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
             val repelling = it is AztecListSpan && parent?.span is AztecListItemSpan
 
             val spanStart = spanned.getSpanStart(it)
+            val spanEnd = spanned.getSpanEnd(it)
+
+            // no need for newline if empty span. This fix 'PARAGRAPH span must start at paragraph boundary'. See: #501.
+            if (spanStart == spanEnd) {
+                return@forEach
+            }
 
             // no need for newline if at text start, unless repelling needs to happen
             if (!repelling && spanStart < 1) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -6,6 +6,7 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
 
     // Copied from SpannableStringBuilder
     private val START_MASK = 0xF0
+    private val END_MASK = 0x0F
     private val START_SHIFT = 4
     private val PARAGRAPH = 3
 
@@ -24,10 +25,11 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
     var flags: Int
         get() { return spannable.getSpanFlags(span) }
         set(flags) {
-            // Do not set the span if it's a PARAGRAPH that doesn't start at paragraph boundary
+            // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
             // Copied from SpannableStringBuilder that throws an exception in this case.
             val flagsStart = flags and START_MASK shr START_SHIFT
-            if (!isInvalidParagraph(start, flagsStart)) {
+            val flagsEnd = flags and END_MASK
+            if (!isInvalidParagraph(start, flagsStart) and !isInvalidParagraph(end, flagsEnd)) {
                 spannable.setSpan(span, start, end, flags)
             }
         }


### PR DESCRIPTION
Fix #501 and #481 by not adding new lines to empty spans.

**To Test**
Paste the following HTML code in the visual editor
```
<p></p><span>[caption]</span>
```
It should not crash the app.

There is a change that the same problem can occur for other tags that are not "caption" or "img", but I wan't able to reproduce on those other tags.

