### PR TITLE
Feature/min image size support

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -108,6 +108,8 @@ public class Html {
     public interface VideoThumbnailGetter {
         void loadVideoThumbnail(String source, Html.VideoThumbnailGetter.Callbacks callbacks, int maxWidth);
 
+        void loadVideoThumbnail(String source, Html.VideoThumbnailGetter.Callbacks callbacks, int maxWidth, int minWidth);
+
         interface Callbacks {
             void onThumbnailFailed();
 

--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -94,6 +94,8 @@ public class Html {
          */
         void loadImage(String source, Html.ImageGetter.Callbacks callbacks, int maxWidth);
 
+        void loadImage(String source, Html.ImageGetter.Callbacks callbacks, int maxWidth, int minWidth);
+
         interface Callbacks {
             void onImageFailed();
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -874,7 +874,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth,this@AztecText.minImagesWidth)
+            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -843,7 +843,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            imageGetter?.loadImage(it.getSource(), callbacks, this@AztecText.maxImagesWidth)
+            imageGetter?.loadImage(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.lineHeight)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -171,6 +171,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     var verticalParagraphMargin: Int = 0
 
     var maxImagesWidth: Int = 0
+    var minImagesWidth: Int = 0
 
     interface OnSelectionChangedListener {
         fun onSelectionChanged(selStart: Int, selEnd: Int)
@@ -281,6 +282,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val minScreenSize = Math.min(context.resources.displayMetrics.widthPixels,
                 context.resources.displayMetrics.heightPixels)
         maxImagesWidth = Math.min(minScreenSize, DEFAULT_IMAGE_WIDTH)
+        minImagesWidth = lineHeight
 
         if (historyEnable && historySize <= 0) {
             throw IllegalArgumentException("historySize must > 0")
@@ -843,7 +845,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            imageGetter?.loadImage(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.lineHeight)
+            imageGetter?.loadImage(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)
         }
     }
 
@@ -872,7 +874,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth)
+            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth,this@AztecText.minImagesWidth)
         }
     }
 

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideImageLoader.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideImageLoader.kt
@@ -15,7 +15,11 @@ import org.wordpress.aztec.Html
 class GlideImageLoader(private val context: Context) : Html.ImageGetter {
 
     override fun loadImage(source: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int) {
-        Glide.with(context).load(source).asBitmap().fitCenter().into(object : Target<Bitmap> {
+        loadImage(source, callbacks, maxWidth, 0)
+    }
+
+    override fun loadImage(source: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int, minWidth: Int) {
+        Glide.with(context).load(source).asBitmap().into(object : Target<Bitmap> {
             override fun onLoadStarted(placeholder: Drawable?) {
                 callbacks.onImageLoading(placeholder)
             }
@@ -25,6 +29,16 @@ class GlideImageLoader(private val context: Context) : Html.ImageGetter {
             }
 
             override fun onResourceReady(resource: Bitmap?, glideAnimation: GlideAnimation<in Bitmap>?) {
+                //Upscaling bitmap only for demonstration purposes.
+                //This should probably be done somewhere more appropriate for Glide (?).
+                if (resource != null && resource.width < minWidth) {
+                    val ratio = resource.height / resource.width
+                    val height = (ratio * minWidth)
+
+                    val upscaledBitmap = Bitmap.createScaledBitmap(resource, minWidth, height, true)
+                    return callbacks.onImageLoaded(BitmapDrawable(context.resources, upscaledBitmap))
+                }
+
                 // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
                 // to correctly set the input density to 160 ourselves.
                 resource?.density = DisplayMetrics.DENSITY_DEFAULT

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideImageLoader.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideImageLoader.kt
@@ -11,6 +11,7 @@ import com.bumptech.glide.request.animation.GlideAnimation
 import com.bumptech.glide.request.target.SizeReadyCallback
 import com.bumptech.glide.request.target.Target
 import org.wordpress.aztec.Html
+import org.wordpress.aztec.glideloader.extensions.upscaleTo
 
 class GlideImageLoader(private val context: Context) : Html.ImageGetter {
 
@@ -32,11 +33,7 @@ class GlideImageLoader(private val context: Context) : Html.ImageGetter {
                 //Upscaling bitmap only for demonstration purposes.
                 //This should probably be done somewhere more appropriate for Glide (?).
                 if (resource != null && resource.width < minWidth) {
-                    val ratio = resource.height / resource.width
-                    val height = (ratio * minWidth)
-
-                    val upscaledBitmap = Bitmap.createScaledBitmap(resource, minWidth, height, true)
-                    return callbacks.onImageLoaded(BitmapDrawable(context.resources, upscaledBitmap))
+                    return callbacks.onImageLoaded(BitmapDrawable(context.resources, resource.upscaleTo(minWidth)))
                 }
 
                 // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideVideoThumbnailLoader.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideVideoThumbnailLoader.kt
@@ -18,6 +18,7 @@ import com.bumptech.glide.request.animation.GlideAnimation
 import com.bumptech.glide.request.target.SizeReadyCallback
 import com.bumptech.glide.request.target.Target
 import org.wordpress.aztec.Html
+import org.wordpress.aztec.glideloader.extensions.upscaleTo
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -49,11 +50,7 @@ class GlideVideoThumbnailLoader(private val context: Context) : Html.VideoThumbn
                         //Upscaling bitmap only for demonstration purposes.
                         //This should probably be done somewhere more appropriate for Glide (?).
                         if (resource != null && resource.width < minWidth) {
-                            val ratio = resource.height / resource.width
-                            val height = (ratio * minWidth)
-
-                            val upscaledBitmap = Bitmap.createScaledBitmap(resource, minWidth, height, true)
-                            return callbacks.onThumbnailLoaded(BitmapDrawable(context.resources, upscaledBitmap))
+                            return callbacks.onThumbnailLoaded(BitmapDrawable(context.resources, resource.upscaleTo(minWidth)))
                         }
 
                         // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideVideoThumbnailLoader.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideVideoThumbnailLoader.kt
@@ -2,16 +2,17 @@ package org.wordpress.aztec.glideloader
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.util.DisplayMetrics
 import com.bumptech.glide.Glide
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.data.DataFetcher
 import com.bumptech.glide.load.model.GenericLoaderFactory
 import com.bumptech.glide.load.model.ModelLoaderFactory
 import com.bumptech.glide.load.model.stream.StreamModelLoader
-import com.bumptech.glide.load.resource.drawable.GlideDrawable
 import com.bumptech.glide.request.Request
 import com.bumptech.glide.request.animation.GlideAnimation
 import com.bumptech.glide.request.target.SizeReadyCallback
@@ -25,12 +26,17 @@ import java.io.InputStream
 class GlideVideoThumbnailLoader(private val context: Context) : Html.VideoThumbnailGetter {
 
     override fun loadVideoThumbnail(source: String, callbacks: Html.VideoThumbnailGetter.Callbacks, maxWidth: Int) {
+        loadVideoThumbnail(source, callbacks, maxWidth, 0)
+    }
+
+    override fun loadVideoThumbnail(source: String, callbacks: Html.VideoThumbnailGetter.Callbacks, maxWidth: Int, minWidth: Int) {
 
         Glide.with(context)
                 .using(ThumbnailLoader(context))
                 .load(source)
+                .asBitmap()
                 .fitCenter()
-                .into(object : Target<GlideDrawable> {
+                .into(object : Target<Bitmap> {
                     override fun onLoadStarted(placeholder: Drawable?) {
                         callbacks.onThumbnailLoading(placeholder)
                     }
@@ -39,8 +45,21 @@ class GlideVideoThumbnailLoader(private val context: Context) : Html.VideoThumbn
                         callbacks.onThumbnailFailed()
                     }
 
-                    override fun onResourceReady(resource: GlideDrawable?, glideAnimation: GlideAnimation<in GlideDrawable>?) {
-                        callbacks.onThumbnailLoaded(resource)
+                    override fun onResourceReady(resource: Bitmap?, glideAnimation: GlideAnimation<in Bitmap>?) {
+                        //Upscaling bitmap only for demonstration purposes.
+                        //This should probably be done somewhere more appropriate for Glide (?).
+                        if (resource != null && resource.width < minWidth) {
+                            val ratio = resource.height / resource.width
+                            val height = (ratio * minWidth)
+
+                            val upscaledBitmap = Bitmap.createScaledBitmap(resource, minWidth, height, true)
+                            return callbacks.onThumbnailLoaded(BitmapDrawable(context.resources, upscaledBitmap))
+                        }
+
+                        // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
+                        // to correctly set the input density to 160 ourselves.
+                        resource?.density = DisplayMetrics.DENSITY_DEFAULT
+                        callbacks.onThumbnailLoaded(BitmapDrawable(context.resources, resource))
                     }
 
                     override fun onLoadCleared(placeholder: Drawable?) {}
@@ -80,7 +99,8 @@ class GlideVideoThumbnailLoader(private val context: Context) : Html.VideoThumbn
 
         class VideoThumbnailFetcher(val source: String, val context: Context) : DataFetcher<InputStream> {
             var stream: InputStream? = null
-            @Volatile var cancelled = false
+            @Volatile
+            var cancelled = false
 
             override fun getId(): String = source
 

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/extensions/BitmapExtension.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/extensions/BitmapExtension.kt
@@ -4,7 +4,9 @@ import android.graphics.Bitmap
 import android.graphics.Bitmap.createScaledBitmap
 
 internal fun Bitmap.upscaleTo(desiredWidth: Int): Bitmap {
-    val ratio = this.height / this.width
-    val height = (ratio * desiredWidth)
-    return createScaledBitmap(this, desiredWidth, height, true)
+    val ratio = this.height.toFloat() / this.width.toFloat()
+    val proportionateHeight = ratio * desiredWidth
+    val finalHeight = Math.rint(proportionateHeight.toDouble()).toInt()
+
+    return createScaledBitmap(this, desiredWidth, finalHeight, true)
 }

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/extensions/BitmapExtension.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/extensions/BitmapExtension.kt
@@ -1,0 +1,10 @@
+package org.wordpress.aztec.glideloader.extensions
+
+import android.graphics.Bitmap
+import android.graphics.Bitmap.createScaledBitmap
+
+internal fun Bitmap.upscaleTo(desiredWidth: Int): Bitmap {
+    val ratio = this.height / this.width
+    val height = (ratio * desiredWidth)
+    return createScaledBitmap(this, desiredWidth, height, true)
+}

--- a/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
+++ b/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
@@ -14,6 +14,7 @@ import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Html
 
 class PicassoImageLoader(private val context: Context, aztec: AztecText) : Html.ImageGetter {
+
     private val targets: MutableMap<String, com.squareup.picasso.Target>
 
     init {
@@ -24,6 +25,10 @@ class PicassoImageLoader(private val context: Context, aztec: AztecText) : Html.
     }
 
     override fun loadImage(source: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int) {
+        loadImage(source, callbacks, maxWidth, 0)
+    }
+
+    override fun loadImage(source: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int, minWidth: Int) {
         val picasso = Picasso.with(context)
         picasso.isLoggingEnabled = true
 
@@ -47,6 +52,6 @@ class PicassoImageLoader(private val context: Context, aztec: AztecText) : Html.
         // add a strong reference to the target until it's called or the view gets destroyed
         targets.put(source, target)
 
-        picasso.load(source).resize(maxWidth, maxWidth).centerInside().onlyScaleDown().into(target)
+        picasso.load(source).resize(maxWidth, maxWidth).centerInside().into(target)
     }
 }

--- a/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
+++ b/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
@@ -52,6 +52,6 @@ class PicassoImageLoader(private val context: Context, aztec: AztecText) : Html.
         // add a strong reference to the target until it's called or the view gets destroyed
         targets.put(source, target)
 
-        picasso.load(source).resize(maxWidth, maxWidth).centerInside().into(target)
+        picasso.load(source).resize(maxWidth, maxWidth).centerInside().onlyScaleDown().into(target)
     }
 }


### PR DESCRIPTION
This PR adds interface support for loading images with specific minimum width. 
This should solve potential problems on clients where tiny images are untappable.

For demonstration purposes only, I added an upscaling functionality to Glide, but I'm not sure if the implementation is done in proper "Glide" way or if it's efficient enough. I tried to look for a good way to do it but wasn't able to find anything working or suited specifically for this problem. If anyone has any ideas - let me know :)