### PR TITLE
Issue/516 crash special comments

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1361,4 +1361,15 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     override fun onUnknownHtmlTapped(unknownHtmlSpan: UnknownHtmlSpan) {
         showBlockEditorDialog(unknownHtmlSpan)
     }
+
+    // workaround as per https://github.com/wordpress-mobile/AztecEditor-Android/issues/516#issuecomment-346672779
+    // getting a reference to the Editable, handling its span and then re-setting the reference maybe makes
+    // the Editable be re-calculated and thus this avoid the ArrayIndexOutOfBounds situation.
+    // This is similar to doing the following, but in a more reusable way:
+    //      val t = aztecText.text
+    //      t.setSpan(...)
+    //      aztecText.text = t
+    fun replaceTextEditable(callback: (editable: Editable) -> Editable) {
+        text = callback(text)
+    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1362,7 +1362,8 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         showBlockEditorDialog(unknownHtmlSpan)
     }
 
-    // workaround as per https://github.com/wordpress-mobile/AztecEditor-Android/issues/516#issuecomment-346672779
+    // This following method should be removed once the bug is not observed in the support library anymore:
+    // Workaround as per https://github.com/wordpress-mobile/AztecEditor-Android/issues/516#issuecomment-346672779
     // getting a reference to the Editable, handling its span and then re-setting the reference maybe makes
     // the Editable be re-calculated and thus this avoid the ArrayIndexOutOfBounds situation.
     // This is similar to doing the following, but in a more reusable way:

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcher.kt
@@ -14,7 +14,7 @@ class DeleteMediaElementWatcher(aztecText: AztecText) : TextWatcher {
             return
         }
 
-        if (count > 0) {
+        if (count > 0 && count != after) {
             aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)
                     ?.forEach {
                         it.onMediaDeleted()

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
@@ -1,5 +1,6 @@
 package org.wordpress.aztec.plugins.shortcodes.watchers
 
+import android.text.Editable
 import android.text.Spanned
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Constants
@@ -9,19 +10,25 @@ import org.wordpress.aztec.watchers.BlockElementWatcher
 
 class CaptionWatcher(private val aztecText: AztecText) : BlockElementWatcher(aztecText) {
 
+
+    private fun moveTextOutOfCaption (editable: Editable, start: Int, count: Int) : Editable {
+        val spans = SpanWrapper.getSpans<CaptionShortcodeSpan>(editable, start + count, start + count,
+                CaptionShortcodeSpan::class.java)
+        spans.forEach {
+            if (it.start < start + count && it.end > start + count) {
+                editable.setSpan(it.span, start + count, it.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+        }
+        return editable
+    }
+
     override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
         super.onTextChanged(s, start, before, count)
 
         if (start + count < s.length && s[start + count] == Constants.IMG_CHAR) {
-            val spans = SpanWrapper.getSpans<CaptionShortcodeSpan>(aztecText.text, start + count, start + count,
-                    CaptionShortcodeSpan::class.java)
-            spans.forEach {
-
-                // if text is added right before an image, move it out of the caption
-                if (it.start < start + count && it.end > start + count) {
-                    aztecText.text.setSpan(it.span, start + count, it.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                }
-            }
+            // if text is added right before an image, move it out of the caption
+            // use replaceTextEditable wrapper when manipulating spans
+            aztecText.replaceTextEditable({editable -> moveTextOutOfCaption(editable, start, count)})
         } else if (count > 0) {
             val spans = SpanWrapper.getSpans<CaptionShortcodeSpan>(aztecText.text, start, start, CaptionShortcodeSpan::class.java)
             spans.forEach {

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
@@ -10,7 +10,6 @@ import org.wordpress.aztec.watchers.BlockElementWatcher
 
 class CaptionWatcher(private val aztecText: AztecText) : BlockElementWatcher(aztecText) {
 
-
     private fun moveTextOutOfCaption (editable: Editable, start: Int, count: Int) : Editable {
         val spans = SpanWrapper.getSpans<CaptionShortcodeSpan>(editable, start + count, start + count,
                 CaptionShortcodeSpan::class.java)
@@ -28,7 +27,7 @@ class CaptionWatcher(private val aztecText: AztecText) : BlockElementWatcher(azt
         if (start + count < s.length && s[start + count] == Constants.IMG_CHAR) {
             // if text is added right before an image, move it out of the caption
             // use replaceTextEditable wrapper when manipulating spans
-            aztecText.replaceTextEditable({editable -> moveTextOutOfCaption(editable, start, count)})
+            aztecText.replaceTextEditable({ editable -> moveTextOutOfCaption(editable, start, count) })
         } else if (count > 0) {
             val spans = SpanWrapper.getSpans<CaptionShortcodeSpan>(aztecText.text, start, start, CaptionShortcodeSpan::class.java)
             spans.forEach {


### PR DESCRIPTION
### Fix
Fixes #516 by by re-setting the Editable after manipulating its spans, as commented in https://github.com/wordpress-mobile/AztecEditor-Android/issues/516#issuecomment-346672779
This PR proposes the use of a method within `AztecEditor` to make sure the `Editable` is reset.

It also fixes the case commented in https://github.com/wordpress-mobile/AztecEditor-Android/issues/516#issuecomment-346502539

Note: as a consequence of this change, I've observed the `onMediaDeleted` method for the `DeleteMediaElementWatcher` was called each time a new character/span was inserted right before the Caption, so that was also fixed in f43d5e2.

### Test
on API 26/27:
CASE A:
1. start the demo app
2. tap on any special comment (More, Page) or HorizontalRuler icons on the Aztec toolbar
3. verify such character is inserted at the top of the demo content without crashing.

CASE B:
1. start the demo app
2. tap on the very left edge of the demo content image, trying to not touch the image itself, just to position the cursor at the very beginning.
3. enter any character on the keyboard, for example "a"
4. verify such character is inserted at the top of the demo content without crashing.


Also verify there's no changes in behavior for other API versions.

### Review
@0nko 