### PR TITLE
removed unused var

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -135,7 +135,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     private var isViewInitialized = false
     private var isLeadingStyleRemoved = false
-    private var previousCursorPosition = 0
 
     private var isHandlingBackspaceEvent = false
 
@@ -609,8 +608,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 return
             }
         }
-
-        previousCursorPosition = selEnd
 
         // do not update toolbar or selected styles when we removed the last character in editor
         if (!isLeadingStyleRemoved && length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER) {


### PR DESCRIPTION
This PR eliminates an unused class member `var previousCursorPosition`

### Review
@0nko 