### PR TITLE
UI tests fix

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
@@ -5,6 +5,7 @@ import android.widget.EditText
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
+import org.wordpress.aztec.source.Format
 
 object Matchers {
     fun withRegex(expected: Regex): Matcher<View> {
@@ -37,7 +38,26 @@ object Matchers {
                 if (view is EditText) {
                     val regex = Regex(">\\s+<")
                     val strippedText = view.text.toString().replace(regex, "><")
-                    return strippedText.equals(expected)
+                    return strippedText == expected
+                }
+
+                return false
+            }
+        }
+    }
+
+    fun withText(expected: String): Matcher<View> {
+
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("EditText matches $expected")
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                if (view is EditText) {
+                    val expectedHtml = Format.removeSourceEditorFormatting(expected, false)
+                    val actualHtml = Format.removeSourceEditorFormatting(view.text.toString(), false)
+                    return actualHtml == expectedHtml
                 }
 
                 return false

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
@@ -27,25 +27,6 @@ object Matchers {
         }
     }
 
-    fun withStrippedText(expected: String): Matcher<View> {
-
-        return object : TypeSafeMatcher<View>() {
-            override fun describeTo(description: Description) {
-                description.appendText("EditText matches $expected")
-            }
-
-            public override fun matchesSafely(view: View): Boolean {
-                if (view is EditText) {
-                    val regex = Regex(">\\s+<")
-                    val strippedText = view.text.toString().replace(regex, "><")
-                    return strippedText == expected
-                }
-
-                return false
-            }
-        }
-    }
-
     fun withText(expected: String): Matcher<View> {
 
         return object : TypeSafeMatcher<View>() {

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
@@ -27,7 +27,7 @@ object Matchers {
         }
     }
 
-    fun withText(expected: String): Matcher<View> {
+    fun withStrippedText(expected: String): Matcher<View> {
 
         return object : TypeSafeMatcher<View>() {
             override fun describeTo(description: Description) {

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -305,7 +305,7 @@ class EditorPage : BasePage() {
     }
 
     fun verifyHTML(expected: String): EditorPage {
-        htmlEditor.check(matches(Matchers.withText(expected)))
+        htmlEditor.check(matches(Matchers.withStrippedText(expected)))
         label("Verified expected editor contents")
 
         return this

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -14,7 +14,6 @@ import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.KeyEvent
 import android.view.View
-import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.hasToString
@@ -22,7 +21,6 @@ import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage
 import org.wordpress.aztec.demo.Matchers
 import org.wordpress.aztec.demo.R
-import org.wordpress.aztec.source.Format
 
 class EditorPage : BasePage() {
     private var editor: ViewInteraction

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -14,6 +14,7 @@ import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.KeyEvent
 import android.view.View
+import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.hasToString
@@ -21,6 +22,7 @@ import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage
 import org.wordpress.aztec.demo.Matchers
 import org.wordpress.aztec.demo.R
+import org.wordpress.aztec.source.Format
 
 class EditorPage : BasePage() {
     private var editor: ViewInteraction
@@ -305,7 +307,7 @@ class EditorPage : BasePage() {
     }
 
     fun verifyHTML(expected: String): EditorPage {
-        htmlEditor.check(matches(Matchers.withStrippedText(expected)))
+        htmlEditor.check(matches(Matchers.withText(expected)))
         label("Verified expected editor contents")
 
         return this

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -1,17 +1,30 @@
 package org.wordpress.aztec.demo.tests
 
 import android.support.test.rule.ActivityTestRule
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.demo.BaseTest
 import org.wordpress.aztec.demo.MainActivity
+import org.wordpress.aztec.demo.R
 import org.wordpress.aztec.demo.pages.EditorPage
+import org.wordpress.aztec.source.SourceViewEditText
 
 class MixedTextFormattingTests : BaseTest() {
 
     @Rule
     @JvmField
     var mActivityTestRule = ActivityTestRule(MainActivity::class.java)
+
+    @Before
+    fun init() {
+        val aztecText = mActivityTestRule.activity.findViewById<AztecText>(R.id.aztec)
+        val sourceText = mActivityTestRule.activity.findViewById<SourceViewEditText>(R.id.source)
+
+        aztecText.setCalypsoMode(true)
+        sourceText.setCalypsoMode(true)
+    }
 
     // Test reproducing the issue described in
     // https://github.com/wordpress-mobile/AztecEditor-Android/pull/476#issuecomment-327762497

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
@@ -1,18 +1,31 @@
 package org.wordpress.aztec.demo.tests
 
 import android.support.test.rule.ActivityTestRule
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.demo.BaseTest
 import org.wordpress.aztec.demo.MainActivity
+import org.wordpress.aztec.demo.R
 import org.wordpress.aztec.demo.pages.EditLinkPage
 import org.wordpress.aztec.demo.pages.EditorPage
+import org.wordpress.aztec.source.SourceViewEditText
 
 class SimpleTextFormattingTests : BaseTest() {
 
     @Rule
     @JvmField
     var mActivityTestRule = ActivityTestRule(MainActivity::class.java)
+
+    @Before
+    fun init() {
+        val aztecText = mActivityTestRule.activity.findViewById<AztecText>(R.id.aztec)
+        val sourceText = mActivityTestRule.activity.findViewById<SourceViewEditText>(R.id.source)
+
+        aztecText.setCalypsoMode(true)
+        sourceText.setCalypsoMode(true)
+    }
 
     @Test
     fun testSimpleBoldFormatting() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -13,7 +13,7 @@ import org.wordpress.aztec.spans.ParagraphSpan
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-internal object Format {
+object Format {
     // list of block elements
     private val block = "div|br|blockquote|ul|ol|li|p|pre|h1|h2|h3|h4|h5|h6|iframe|hr"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '3.0.0'
+        gradlePluginVersion = '3.0.1'
         kotlinVersion = '1.1.60'
         supportLibVersion = '26.1.0'
         tagSoupVersion = '1.2.1'


### PR DESCRIPTION
This PR enables the Calypso mode for certain formatting tests that are failing since Calypso mode is disabled by default in the demo app.