### PR TITLE
Add logging utils library to Aztec

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 
-
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation "com.android.support:support-v4:$supportLibVersion"
     implementation "com.android.support:design:$supportLibVersion"
 
+    implementation "org.wordpress:utils:$wordpressUtilsVersion"
+
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -41,6 +41,7 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
                         + " (" + end + " follows " + spannable.get(end - 1) + ")")
                 return
             }
+            
             spannable.setSpan(span, start, end, flags)
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -24,24 +24,26 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
         set(end) { spannable.setSpan(span, start, end, flags) }
 
     var flags: Int
-        get() { return spannable.getSpanFlags(span) }
+        get() {
+            return spannable.getSpanFlags(span)
+        }
         set(flags) {
             // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
             // Copied from SpannableStringBuilder that throws an exception in this case.
             val flagsStart = flags and START_MASK shr START_SHIFT
             if (isInvalidParagraph(start, flagsStart)) {
                 AppLog.w(AppLog.T.EDITOR, "PARAGRAPH span must start at paragraph boundary"
-                        + " (" + start + " follows " + spannable.get(start - 1) + ")" )
+                        + " (" + start + " follows " + spannable.get(start - 1) + ")")
                 return
             }
 
             val flagsEnd = flags and END_MASK
-            if(isInvalidParagraph(end, flagsEnd)) {
-                AppLog.w(AppLog.T.EDITOR,"PARAGRAPH span must end at paragraph boundary"
+            if (isInvalidParagraph(end, flagsEnd)) {
+                AppLog.w(AppLog.T.EDITOR, "PARAGRAPH span must end at paragraph boundary"
                         + " (" + end + " follows " + spannable.get(end - 1) + ")")
                 return
             }
-            
+
             spannable.setSpan(span, start, end, flags)
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -17,33 +17,37 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
 
     var start: Int
         get() { return spannable.getSpanStart(span) }
-        set(start) { spannable.setSpan(span, start, end, flags) }
+        set(start) { setSpanOrLogError(span, start, end, flags) }
 
     var end: Int
         get() { return spannable.getSpanEnd(span) }
-        set(end) { spannable.setSpan(span, start, end, flags) }
+        set(end) { setSpanOrLogError(span, start, end, flags) }
 
     var flags: Int
         get() { return spannable.getSpanFlags(span) }
         set(flags) {
-            // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
-            // Copied from SpannableStringBuilder that throws an exception in this case.
-            val flagsStart = flags and START_MASK shr START_SHIFT
-            if (isInvalidParagraph(start, flagsStart)) {
-                AppLog.w(AppLog.T.EDITOR, "PARAGRAPH span must start at paragraph boundary"
-                        + " (" + start + " follows " + spannable.get(start - 1) + ")")
-                return
-            }
-
-            val flagsEnd = flags and END_MASK
-            if (isInvalidParagraph(end, flagsEnd)) {
-                AppLog.w(AppLog.T.EDITOR, "PARAGRAPH span must end at paragraph boundary"
-                        + " (" + end + " follows " + spannable.get(end - 1) + ")")
-                return
-            }
-
-            spannable.setSpan(span, start, end, flags)
+            setSpanOrLogError(span, start, end, flags)
         }
+
+    private fun setSpanOrLogError(span :T, start :Int, end :Int, flags :Int) {
+        // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
+        // Copied from SpannableStringBuilder that throws an exception in this case.
+        val flagsStart = flags and START_MASK shr START_SHIFT
+        if (isInvalidParagraph(start, flagsStart)) {
+            AppLog.w(AppLog.T.EDITOR, "PARAGRAPH span must start at paragraph boundary"
+                    + " (" + start + " follows " + spannable.get(start - 1) + ")")
+            return
+        }
+
+        val flagsEnd = flags and END_MASK
+        if (isInvalidParagraph(end, flagsEnd)) {
+            AppLog.w(AppLog.T.EDITOR, "PARAGRAPH span must end at paragraph boundary"
+                    + " (" + end + " follows " + spannable.get(end - 1) + ")")
+            return
+        }
+
+        spannable.setSpan(span, start, end, flags)
+    }
 
     private fun isInvalidParagraph(index: Int, flag: Int): Boolean {
         return flag == PARAGRAPH && index != 0 && index != spannable.length && spannable.get(index - 1) != '\n'

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -25,11 +25,9 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
 
     var flags: Int
         get() { return spannable.getSpanFlags(span) }
-        set(flags) {
-            setSpanOrLogError(span, start, end, flags)
-        }
+        set(flags) { setSpanOrLogError(span, start, end, flags) }
 
-    private fun setSpanOrLogError(span :T, start :Int, end :Int, flags :Int) {
+    private fun setSpanOrLogError(span: T, start: Int, end: Int, flags: Int) {
         // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
         // Copied from SpannableStringBuilder that throws an exception in this case.
         val flagsStart = flags and START_MASK shr START_SHIFT

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -24,9 +24,7 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
         set(end) { spannable.setSpan(span, start, end, flags) }
 
     var flags: Int
-        get() {
-            return spannable.getSpanFlags(span)
-        }
+        get() { return spannable.getSpanFlags(span) }
         set(flags) {
             // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
             // Copied from SpannableStringBuilder that throws an exception in this case.

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.aztec.util
 
 import android.text.Spannable
+import org.wordpress.android.util.AppLog
 
 class SpanWrapper<T>(var spannable: Spannable, var span: T) {
 
@@ -28,10 +29,19 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
             // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
             // Copied from SpannableStringBuilder that throws an exception in this case.
             val flagsStart = flags and START_MASK shr START_SHIFT
-            val flagsEnd = flags and END_MASK
-            if (!isInvalidParagraph(start, flagsStart) and !isInvalidParagraph(end, flagsEnd)) {
-                spannable.setSpan(span, start, end, flags)
+            if (isInvalidParagraph(start, flagsStart)) {
+                AppLog.w(AppLog.T.EDITOR, "PARAGRAPH span must start at paragraph boundary"
+                        + " (" + start + " follows " + spannable.get(start - 1) + ")" )
+                return
             }
+
+            val flagsEnd = flags and END_MASK
+            if(isInvalidParagraph(end, flagsEnd)) {
+                AppLog.w(AppLog.T.EDITOR,"PARAGRAPH span must end at paragraph boundary"
+                        + " (" + end + " follows " + spannable.get(end - 1) + ")")
+                return
+            }
+            spannable.setSpan(span, start, end, flags)
         }
 
     private fun isInvalidParagraph(index: Int, flag: Int): Boolean {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         robolectricVersion = '3.4.2'
         jUnitVersion = '4.12'
         jSoupVersion = '1.10.3'
-        wordpressUtilsVersion = '1.17.0'
+        wordpressUtilsVersion = '1.18.1'
         espressoVersion = '3.0.1'
     }
 


### PR DESCRIPTION
This PR just adds our Logging utils library to Aztec, and use it (`AppLog`) to start logging the PARAGRAPH issue details. 
With this PR in the repo we can send logs into out main app log.

### Review
@0nko 