### PR TITLE
Fixed History Reliability Issues and Added Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ annotations/
 # Enforce plugins
 !/.idea/externalDependencies.xml
 
+# OS generated
+/.DS_Store
+

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ annotations/
 # OS generated
 /.DS_Store
 
+# Kotlin lint
+ktlint

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Actions.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Actions.kt
@@ -14,6 +14,8 @@ import android.view.View
 import android.widget.EditText
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
 
 object Actions {
     fun invokeClick(): ViewAction {
@@ -32,7 +34,6 @@ object Actions {
         }
     }
 
-    @Suppress("DEPRECATION")
     fun relativeClick(xPercent: Float = 0.5f, yPercent: Float = 0.5f): ViewAction {
         return GeneralClickAction(
                 Tap.SINGLE,
@@ -45,7 +46,7 @@ object Actions {
 
                     floatArrayOf(x, y)
                 },
-                Press.FINGER)
+                Press.FINGER, 0, 0)
     }
 
     fun selectAll(): ViewAction {
@@ -61,6 +62,60 @@ object Actions {
             override fun perform(uiController: UiController, view: View) {
                 if (view is EditText) {
                     view.selectAll()
+                }
+            }
+        }
+    }
+
+    fun copyToClipboardAztec(): ViewAction {
+        return object : ViewAction {
+            override fun getConstraints(): Matcher<View> {
+                return allOf(isDisplayed(), isAssignableFrom(EditText::class.java))
+            }
+
+            override fun getDescription(): String {
+                return "Copy to Aztec clipboard"
+            }
+
+            override fun perform(uiController: UiController?, view: View?) {
+                if (view is AztecText) {
+                    view.copy(view.text, view.selectionStart, view.selectionEnd)
+                }
+            }
+        }
+    }
+
+    fun pasteFromClipboardAztec(): ViewAction {
+        return object : ViewAction {
+            override fun getConstraints(): Matcher<View> {
+                return allOf(isDisplayed(), isAssignableFrom(EditText::class.java))
+            }
+
+            override fun getDescription(): String {
+                return "Paste from Aztec clipboard"
+            }
+
+            override fun perform(uiController: UiController?, view: View?) {
+                if (view is AztecText) {
+                    view.paste(view.text, view.selectionStart, view.selectionEnd)
+                }
+            }
+        }
+    }
+
+    fun setAztecCursorPositionEnd(): ViewAction {
+        return object : ViewAction {
+            override fun getConstraints(): Matcher<View> {
+                return allOf(isDisplayed(), isAssignableFrom(EditText::class.java))
+            }
+
+            override fun getDescription(): String {
+                return "Set Aztec cursor at the end of current text buffer"
+            }
+
+            override fun perform(uiController: UiController?, view: View?) {
+                if (view is AztecText) {
+                    view.setSelection(EndOfBufferMarkerAdder.safeLength(view))
                 }
             }
         }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Actions.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Actions.kt
@@ -85,6 +85,24 @@ object Actions {
         }
     }
 
+    fun copyRangeToClipboardAztec(start: Int, end: Int): ViewAction {
+        return object : ViewAction {
+            override fun getConstraints(): Matcher<View> {
+                return allOf(isDisplayed(), isAssignableFrom(EditText::class.java))
+            }
+
+            override fun getDescription(): String {
+                return "Copy to Aztec clipboard"
+            }
+
+            override fun perform(uiController: UiController?, view: View?) {
+                if (view is AztecText) {
+                    view.copy(view.text, start, end)
+                }
+            }
+        }
+    }
+
     fun pasteFromClipboardAztec(): ViewAction {
         return object : ViewAction {
             override fun getConstraints(): Matcher<View> {
@@ -98,6 +116,24 @@ object Actions {
             override fun perform(uiController: UiController?, view: View?) {
                 if (view is AztecText) {
                     view.paste(view.text, view.selectionStart, view.selectionEnd)
+                }
+            }
+        }
+    }
+
+    fun pasteRangeFromClipboardAztec(start: Int, end: Int): ViewAction {
+        return object : ViewAction {
+            override fun getConstraints(): Matcher<View> {
+                return allOf(isDisplayed(), isAssignableFrom(EditText::class.java))
+            }
+
+            override fun getDescription(): String {
+                return "Paste from Aztec clipboard from range [$start] to [$end]"
+            }
+
+            override fun perform(uiController: UiController?, view: View?) {
+                if (view is AztecText) {
+                    view.paste(view.text, start, end)
                 }
             }
         }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/BaseHistoryTest.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/BaseHistoryTest.kt
@@ -1,0 +1,27 @@
+package org.wordpress.aztec.demo
+
+import android.support.test.rule.ActivityTestRule
+import org.junit.Before
+import org.junit.Rule
+import org.wordpress.aztec.AztecText
+
+/**
+ * Base class for History testing.
+ */
+abstract class BaseHistoryTest : BaseTest() {
+
+    protected val throttleTime: Long = 1000L
+
+    @Rule
+    @JvmField
+    var mActivityTestRule = ActivityTestRule(MainActivity::class.java)
+
+    /**
+     * Increases the history time to cover test device variability.
+     */
+    @Before
+    fun init() {
+        val aztecText = mActivityTestRule.activity.findViewById<AztecText>(R.id.aztec)
+        aztecText.history.historyThrottleTime = throttleTime
+    }
+}

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -365,9 +365,23 @@ class EditorPage : BasePage() {
         return this
     }
 
+    fun copyRangeToClipboard(start: Int, end: Int): EditorPage {
+        editor.perform(Actions.copyRangeToClipboardAztec(start, end))
+        label("Copy text from index [$start] to [$end] to clipboard")
+
+        return this
+    }
+
     fun pasteFromClipboard(): EditorPage {
         editor.perform(Actions.pasteFromClipboardAztec())
         label("Paste from Aztec clipboard")
+
+        return this
+    }
+
+    fun pasteRangeFromClipboard(start: Int, end: Int): EditorPage {
+        editor.perform(Actions.pasteRangeFromClipboardAztec(start, end))
+        label("Past from Aztec clipboard from range [$start] to [$end]")
 
         return this
     }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -95,10 +95,36 @@ class EditorPage : BasePage() {
         return this
     }
 
+    /**
+     * Using selectAllText() + delete() do not work as intended. This method
+     * will select all the text in the editor and then delete that text.
+     */
+    fun selectAllAndDelete(): EditorPage {
+        selectAllText()
+        editor.perform(pressKey(KeyEvent.KEYCODE_FORWARD_DEL))
+        label("Select all text and delete")
+
+        return this
+    }
+
     fun delete(characters: Int): EditorPage {
         for (i in 1..characters) {
             editor.perform(pressKey(KeyEvent.KEYCODE_DEL))
         }
+
+        return this
+    }
+
+    fun insertNewLine(): EditorPage {
+        editor.perform(pressKey(KeyEvent.KEYCODE_ENTER))
+        label("Insert new line")
+
+        return this
+    }
+
+    fun clearText(): EditorPage {
+        editor.perform(ViewActions.clearText())
+        label("Clear editor text")
 
         return this
     }
@@ -304,17 +330,57 @@ class EditorPage : BasePage() {
         return this
     }
 
+    fun verify(expected: String): EditorPage {
+        editor.check(matches(Matchers.withStrippedText(expected)))
+        label("Verified expected editor contents")
+
+        return this
+    }
+
     fun verifyHTML(expected: String): EditorPage {
         htmlEditor.check(matches(Matchers.withStrippedText(expected)))
-        label("Verified expected editor contents")
+        label("Verified expected HTML editor contents")
 
         return this
     }
 
     fun verifyHTML(expected: Regex): EditorPage {
         htmlEditor.check(matches(Matchers.withRegex(expected)))
-        label("Verified expected editor contents")
+        label("Verified expected HTML editor contents")
 
+        return this
+    }
+
+    fun verifyHTMLNoStripping(expected: String): EditorPage {
+        htmlEditor.check(matches(withText(expected)))
+        label("Verified expected HTML editor contents without stripping")
+
+        return this
+    }
+
+    fun copyToClipboard(): EditorPage {
+        editor.perform(Actions.copyToClipboardAztec())
+        label("Copy to Aztec clipboard")
+
+        return this
+    }
+
+    fun pasteFromClipboard(): EditorPage {
+        editor.perform(Actions.pasteFromClipboardAztec())
+        label("Paste from Aztec clipboard")
+
+        return this
+    }
+
+    fun setCursorPositionAtEnd(): EditorPage {
+        editor.perform(Actions.setAztecCursorPositionEnd())
+        label("Set Aztec cursor position at the end of text buffer")
+
+        return this
+    }
+
+    fun threadSleep(millis: Long): EditorPage {
+        Thread.sleep(millis)
         return this
     }
 

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/BasicEditorHistoryTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/BasicEditorHistoryTests.kt
@@ -1,0 +1,142 @@
+package org.wordpress.aztec.demo.tests
+
+import org.junit.Test
+import org.wordpress.aztec.History
+import org.wordpress.aztec.demo.BaseHistoryTest
+import org.wordpress.aztec.demo.pages.EditorPage
+
+/**
+ * Various tests for testing the [History] component for basic editing:
+ * * Add/Delete Text
+ * * Copy/Paste Text
+ */
+class BasicEditorHistoryTests : BaseHistoryTest() {
+
+    @Test
+    fun testAddWordsUndoRedo() {
+        val word1 = "Testing"
+        val word2 = " new"
+        val word3 = " history"
+        val word4 = " timer."
+        val editorPage = EditorPage()
+
+        // Add words to the editor
+        editorPage
+                .insertText(word1)
+                .threadSleep(throttleTime)
+                .insertText(word2)
+                .threadSleep(throttleTime)
+                .insertText(word3)
+                .threadSleep(throttleTime)
+                .insertText(word4)
+                .threadSleep(throttleTime)
+
+        // Undo each change and verify.
+        editorPage
+                .undoChange()
+                .verify(word1 + word2 + word3)
+                .undoChange()
+                .verify(word1 + word2)
+                .undoChange()
+                .verify(word1)
+                .undoChange()
+                .verify("")
+                .threadSleep(throttleTime)
+
+        // Redo each change and verify.
+        editorPage
+                .redoChange()
+                .verify(word1)
+                .redoChange()
+                .verify(word1 + word2)
+                .redoChange()
+                .verify(word1 + word2 + word3)
+                .redoChange()
+                .verify(word1 + word2 + word3 + word4)
+    }
+
+    @Test
+    fun testCopyPasteTextUndoRedo() {
+        val word1 = "Testing"
+        val editorPage = EditorPage()
+
+        // Add text to the editor
+        editorPage
+                .insertText(word1)
+                .threadSleep(throttleTime)
+
+        // Select text and copy to clipboard, then set the
+        // cursor position to the end of the current text buffer.
+        editorPage
+                .selectAllText()
+                .copyToClipboard()
+                .setCursorPositionAtEnd()
+                .threadSleep(throttleTime)
+
+        // Paste text from clipboard
+        editorPage
+                .pasteFromClipboard()
+                .threadSleep(throttleTime)
+
+        // verify text pasted
+        editorPage
+                .verify(word1 + word1)
+
+        // Undo paste and verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .verify(word1)
+
+        // Redo paste and verify
+        editorPage
+                .redoChange()
+                .verify(word1 + word1)
+    }
+
+    @Test
+    fun testAddHtmlWordsUndoRedo() {
+        // Add words to the editor
+        val word1 = "Testing"
+        val word2 = " new"
+        val word3 = " history"
+        val word4 = " timer."
+        val editorPage = EditorPage()
+
+        // Insert words. Wait between each word to ensure history
+        // is properly recorded.
+        editorPage
+                .toggleHtml()
+                .insertHTML(word1)
+                .threadSleep(throttleTime)
+                .insertHTML(word2)
+                .threadSleep(throttleTime)
+                .insertHTML(word3)
+                .threadSleep(throttleTime)
+                .insertHTML(word4)
+                .threadSleep(throttleTime)
+
+        // Undo each change and verify.
+        editorPage
+                .undoChange()
+                .verifyHTML(word1 + word2 + word3)
+                .undoChange()
+                .verifyHTML(word1 + word2)
+                .undoChange()
+                .verifyHTML(word1)
+                .undoChange()
+                .verifyHTML("")
+                .threadSleep(throttleTime)
+
+        // Redo each change and verify.
+        editorPage
+                .redoChange()
+                .verifyHTML(word1)
+                .redoChange()
+                .verifyHTML(word1 + word2)
+                .redoChange()
+                .verifyHTML(word1 + word2 + word3)
+                .redoChange()
+                .verifyHTML(word1 + word2 + word3 + word4)
+    }
+}

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/BlockElementHistoryTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/BlockElementHistoryTests.kt
@@ -1,0 +1,285 @@
+package org.wordpress.aztec.demo.tests
+
+import org.junit.Test
+import org.wordpress.aztec.demo.BaseHistoryTest
+import org.wordpress.aztec.demo.pages.EditorPage
+
+/**
+ * Tests History (undo/redo) functionality on block elements:
+ * * Headings
+ * * Quotes
+ * * Ordered/Unordered Lists
+ */
+class BlockElementHistoryTests : BaseHistoryTest() {
+
+    @Test
+    fun testMakeHeadingUndoRedo() {
+        // Add heading to editor
+        val word1 = "TESTING"
+        val headingHtml = "<h1>$word1</h1>"
+        val editorPage = EditorPage()
+
+        editorPage
+                .insertText(word1)
+                .threadSleep(throttleTime)
+                .selectAllText()
+                .makeHeader(EditorPage.HeadingStyle.ONE)
+                .threadSleep(throttleTime)
+
+        // Verify header added
+        editorPage
+                .toggleHtml()
+                .verifyHTML(headingHtml)
+                .toggleHtml()
+
+        // Undo make heading and verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(word1)
+                .toggleHtml()
+
+        // Redo make heading and verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(headingHtml)
+    }
+
+    @Test
+    fun testMakeMultipleHeadingDeleteAllUndo() {
+        val headingsHtml = "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3>"
+        val editorPage = EditorPage()
+
+        // Add multiple heading styles to editor
+        editorPage
+                .toggleHtml() // enter the source view
+                .insertHTML(headingsHtml)
+                .toggleHtml() // enter editor view
+                .threadSleep(throttleTime)
+
+        // select all text and delete
+        editorPage
+                .selectAllAndDelete()
+                .threadSleep(throttleTime)
+
+        // undo select all and delete action
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+
+        // verify
+        editorPage
+                .toggleHtml()
+                .verifyHTML(headingsHtml)
+    }
+
+    @Test
+    fun testInsertBlockQuoteUndoRedo() {
+        val quote = "Chuck Norris counted to infinity, twice"
+        val quoteHtml = "<blockquote>$quote</blockquote>"
+        val quoteEmptyHtml = "<blockquote></blockquote>"
+        val editorPage = EditorPage()
+
+        // Add some block quote text and verify
+        editorPage
+                .toggleQuote()
+                .threadSleep(throttleTime)
+                .insertText(quote)
+                .toggleHtml()
+                .verifyHTML(quoteHtml)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Undo adding of block quote and verify.
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(quoteEmptyHtml)
+                .toggleHtml()
+
+        // Redo adding of block quote and verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(quoteHtml)
+                .toggleHtml()
+    }
+
+    @Test
+    fun testInsertBlockQuoteAddNewLineUndoRedo() {
+        val firstLine = "Chuck Norris counted to infinity, twice,"
+        val firstLineHtml = "<blockquote>$firstLine</blockquote>"
+        val secondLine = "even still, the dragon won!"
+        val secondLineHtml = "<blockquote>$firstLine\n\n$secondLine</blockquote>"
+        val editorPage = EditorPage()
+
+        // Add some block quote text and verify
+        editorPage
+                .toggleQuote()
+                .threadSleep(throttleTime)
+                .insertText(firstLine)
+                .threadSleep(throttleTime)
+
+        // Add new line, verify
+        editorPage
+                .insertNewLine()
+                .insertText(secondLine)
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(secondLineHtml)
+                .toggleHtml()
+
+        // Undo add new line, verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(firstLineHtml)
+                .toggleHtml()
+
+        // Redo add new line, verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(secondLineHtml)
+    }
+
+    @Test
+    fun testToggleSelectedBlockQuoteUndoRedo() {
+        val quote = "Chuck Norris counted to infinity, twice"
+        val quoteHtml = "<blockquote>$quote</blockquote>"
+        val editorPage = EditorPage()
+
+        // Add some text to the editor
+        editorPage
+                .insertText(quote)
+                .threadSleep(throttleTime)
+
+        // Select text, convert to block quote, verify
+        editorPage
+                .selectAllText()
+                .toggleQuote()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(quoteHtml)
+                .toggleHtml()
+
+        // Undo convert to block quote, verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(quote)
+                .toggleHtml()
+
+        // Redo convert to block quote, verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(quoteHtml)
+    }
+
+    @Test
+    fun testInsertListUndoRedo() {
+        val item1 = "Item 1"
+        val item2 = "Item 2"
+        val item3 = "Item 3"
+        val htmlFullList = "<ol><li>$item1</li><li>$item2</li><li>$item3</li></ol>"
+        val htmlItem2 = "<ol><li>Item 1</li><li>Item 2</li></ol>"
+        val htmlItem1 = "<ol><li>Item 1</li></ol>"
+        val editorPage = EditorPage()
+
+        // Add some text to the editor, verify
+        editorPage
+                .makeList(EditorPage.ListStyle.ORDERED)
+                .insertText(item1)
+                .threadSleep(throttleTime)
+                .insertNewLine()
+                .threadSleep(throttleTime)
+                .insertText(item2)
+                .threadSleep(throttleTime)
+                .insertNewLine()
+                .threadSleep(throttleTime)
+                .insertText(item3)
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(htmlFullList)
+                .toggleHtml()
+
+        // Undo Item 3, verify.
+        editorPage
+                .undoChange().undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(htmlItem2)
+                .toggleHtml()
+
+        // Undo Item 2, verify
+        editorPage
+                .undoChange().undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(htmlItem1)
+                .toggleHtml()
+
+        // Redo Item 2, verify
+        editorPage
+                .redoChange().redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(htmlItem2)
+                .toggleHtml()
+
+        // Redo Item 3, verify
+        editorPage
+                .redoChange().redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(htmlFullList)
+    }
+
+    @Test
+    fun testListDeleteEmptyItemUndoRedo() {
+        val item1 = "Item 1"
+        val itemHtml = "<ul><li>$item1</li></ul>"
+        val itemNewLineHtml = "<ul><li>$item1</li><li></li></ul>"
+        val editorPage = EditorPage()
+
+        // Add list with one item
+        editorPage
+                .makeList(EditorPage.ListStyle.UNORDERED)
+                .insertText(item1)
+                .threadSleep(throttleTime)
+
+        // Insert a new line and verify
+        editorPage
+                .insertNewLine()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(itemNewLineHtml)
+                .toggleHtml()
+
+        // Undo insert new line, verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(itemHtml)
+                .toggleHtml()
+
+        // Redo insert new line, verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(itemNewLineHtml)
+                .toggleHtml()
+    }
+}

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/FormattingHistoryTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/FormattingHistoryTests.kt
@@ -1,0 +1,270 @@
+package org.wordpress.aztec.demo.tests
+
+import org.junit.Test
+import org.wordpress.aztec.History
+import org.wordpress.aztec.demo.BaseHistoryTest
+import org.wordpress.aztec.demo.pages.EditorPage
+
+/**
+ * Various tests for testing the [History] component for formatting styles in the editor:
+ * * Bold
+ * * Italic
+ * * Underline
+ * * Strikethrough
+ * * Code
+ */
+class FormattingHistoryTests : BaseHistoryTest() {
+
+    @Test
+    fun testAddBoldUndoRedo() {
+        val word = "Testing"
+        val html = "<b>$word</b>"
+        val editorPage = EditorPage()
+
+        // Add bold text, verify
+        editorPage
+                .toggleBold()
+                .threadSleep(throttleTime) // Guarantee the <b> tags are in their own history stack
+                .insertText(word)
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+                .toggleHtml()
+
+        // Undo add bold text, verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+
+        //  Redo add bold text, verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testAddBoldBetweenTwoWordsUndoRedo() {
+        val word1 = "Testing"
+        val word2 = " Bolder"
+        val word3 = " History"
+        val htmlSecond = "$word1<b>$word2</b>"
+        val htmlFinal = "$word1<b>$word2</b>$word3"
+        val editorPage = EditorPage()
+
+        // Add first word - regular
+        editorPage
+                .insertText(word1)
+                .threadSleep(throttleTime)
+
+        // Add second word - bold
+        editorPage
+                .toggleBold()
+                .threadSleep(throttleTime)
+                .insertText(word2)
+                .threadSleep(throttleTime)
+
+        // Verify
+        editorPage
+                .toggleHtml()
+                .verifyHTMLNoStripping(htmlSecond)
+                .toggleHtml()
+                .toggleBold()
+                .threadSleep(throttleTime)
+
+        // Add third word - regular
+        editorPage
+                .insertText(word3)
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(htmlFinal)
+                .toggleHtml()
+
+        // Undo add third and second word
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(word1)
+                .toggleHtml()
+
+        // Redo add 2nd bolded word, verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(htmlSecond)
+    }
+
+    @Test
+    fun testSelectToMakeBoldUndoRedo() {
+        val text = "There's no crying in baseball!"
+        val html = "<b>$text</b>"
+        val editorPage = EditorPage()
+
+        // Insert text snippet
+        editorPage
+                .insertText(text)
+                .threadSleep(throttleTime)
+
+        // Select snippet1 and toggle bold, verify
+        editorPage
+                .selectAllText()
+                .toggleBold()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(html)
+                .toggleHtml()
+
+        // Undo make snippet1 bold
+        editorPage
+                .tapTop()
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(text)
+                .toggleHtml()
+
+        // Redo make snippet1 bold
+        editorPage
+                .tapTop()
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(html)
+    }
+
+    @Test
+    fun testAddItalicAndUnderlineUndoRedo() {
+        val text = "There's no crying in baseball!"
+        val htmlRegex = Regex("<i><u>$text</u></i>|<u><i>$text</i></u>")
+        val editorPage = EditorPage()
+
+        // Insert text snippet
+        editorPage
+                .insertText(text)
+                .threadSleep(throttleTime)
+
+        // Select snippet1 and toggle italic, then underline
+        editorPage
+                .selectAllText()
+                .toggleItalics()
+                .threadSleep(throttleTime)
+                .toggleUnderline()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(htmlRegex)
+                .toggleHtml()
+
+        // Undo formatting on snippet1, verify
+        editorPage
+                .tapTop()
+                .undoChange()
+                .threadSleep(throttleTime)
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(text)
+                .toggleHtml()
+
+        // Redo formatting on snippet1, verify
+        editorPage
+                .tapTop()
+                .redoChange()
+                .threadSleep(throttleTime)
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(htmlRegex)
+    }
+
+    @Test
+    fun testMakeStrikethroughUndoRedo() {
+        val snippet1 = "There's no crying in"
+        val snippet2 = " baseball!"
+        val html = "$snippet1<del>$snippet2</del>"
+        val editorPage = EditorPage()
+
+        // Insert first snippet
+        editorPage
+                .insertText(snippet1)
+                .threadSleep(throttleTime)
+
+        // Toggle strikethrough, add second snippet and verify
+        editorPage
+                .toggleStrikethrough()
+                .threadSleep(throttleTime)
+                .focusedInsertText(snippet2)
+                .toggleStrikethrough()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(html)
+                .toggleHtml()
+
+        // Undo adding stikethrough snippet
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(snippet1)
+                .toggleHtml()
+
+        // Redo adding strikethrough snippet
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(html)
+    }
+
+    @Test
+    fun testAddCodeStyleHtmlUndoRedo() {
+        val html1 = "<code>"
+        val html2 = "testing code"
+        val html3 = "</code>"
+        val html = "$html1$html2$html3"
+        val editorPage = EditorPage()
+
+        // Insert html in chunks to guarantee history stack layout
+        editorPage
+                .toggleHtml()
+                .insertHTML(html1)
+                .threadSleep(throttleTime)
+                .insertHTML(html2)
+                .threadSleep(throttleTime)
+                .insertHTML(html3)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Verify html
+        editorPage
+                .toggleHtml()
+                .verifyHTML(html)
+                .toggleHtml()
+
+        // Undo changes, verify
+        editorPage
+                .undoChange().undoChange().undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+
+        // Redo changes, verify
+        editorPage
+                .redoChange().redoChange().redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+}

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/FormattingHistoryTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/FormattingHistoryTests.kt
@@ -145,6 +145,46 @@ class FormattingHistoryTests : BaseHistoryTest() {
     }
 
     @Test
+    fun testCopyPasteBoldUndoRedo() {
+        val html = "<b>Bold</b> <i>Italic</i> <u>Underline</u> <s class=\"test\">Strikethrough</s>"
+        val verifyHtml = "<b>Bold</b> <b>Bold</b><i>Italic</i> <u>Underline</u> <s class=\"test\">Strikethrough</s>"
+        val editorPage = EditorPage()
+
+        // Insert html text snippet
+        editorPage
+                .toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+
+        // Copy the bold text and paste to end of string
+        editorPage
+                .tapTop()
+                .copyRangeToClipboard(0, 4)
+                .tapTop()
+                .pasteRangeFromClipboard(5, 5)
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(verifyHtml)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Undo paste and verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+                .toggleHtml()
+
+        // Redo and verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(verifyHtml)
+    }
+
+    @Test
     fun testAddItalicAndUnderlineUndoRedo() {
         val text = "There's no crying in baseball!"
         val htmlRegex = Regex("<i><u>$text</u></i>|<u><i>$text</i></u>")

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/HistoryMixedTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/HistoryMixedTests.kt
@@ -1,0 +1,96 @@
+package org.wordpress.aztec.demo.tests
+
+import org.junit.Test
+import org.wordpress.aztec.demo.BaseHistoryTest
+import org.wordpress.aztec.demo.pages.EditorPage
+
+class HistoryMixedTests : BaseHistoryTest() {
+
+    private val HTML =
+            "[caption align=\"alignright\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\">Caption[/caption]\n" +
+            "\n" +
+            "<h1>Heading 1</h1>\n" +
+            "<h2>Heading 2</h2>\n" +
+            "<h3>Heading 3</h3>\n" +
+            "<h4>Heading 4</h4>\n" +
+            "<h5>Heading 5</h5>\n" +
+            "<h6>Heading 6</h6>\n" +
+            "<b>Bold</b>\n" +
+            "<i>Italic</i>\n" +
+            "<u>Underline</u>\n" +
+            "<s class=\"test\">Strikethrough</s>\n" +
+            "<ol>\n" +
+            "\t<li>Ordered</li>\n" +
+            "\t<li></li>\n" +
+            "</ol>\n" +
+            "\n" +
+            "<hr>\n" +
+            "\n" +
+            "<ul>\n" +
+            "\t<li>Unordered</li>\n" +
+            "\t<li></li>\n" +
+            "</ul>\n" +
+            "<blockquote>Quote</blockquote>\n" +
+            "<pre>when (person) {\n" +
+            "    MOCTEZUMA -&gt; {\n" +
+            "        print (\"friend\")\n" +
+            "    }\n" +
+            "    CORTES -&gt; {\n" +
+            "        print (\"foe\")\n" +
+            "    }\n" +
+            "}</pre><a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a>\n" +
+            "<div class=\"first\">\n" +
+            "<div class=\"second\">\n" +
+            "<div class=\"third\">Div\n" +
+            "<span><b>Span</b></span>\n" +
+            "Hidden</div>\n" +
+            "<div class=\"fourth\"></div>\n" +
+            "<div class=\"fifth\"></div>\n" +
+            "</div>\n" +
+            "</div>\n" +
+            "<!--Comment-->\n" +
+            "\n" +
+            "<!--more-->\n" +
+            "\n" +
+            "<!--nextpage-->\n" +
+            "\n" +
+            "<code>if (value == 5) printf(value)</code>\n" +
+            "<iframe class=\"classic\">Menu</iframe>\n" +
+            "\uD83D\uDC4D测试一个\n" +
+            "\n" +
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. [video src=\"https://examplebloge.files.wordpress.com/2017/06/d7d88643-88e6-d9b5-11e6-92e03def4804.mp4\"][audio src=\"https://upload.wikimedia.org/wikipedia/commons/9/94/H-Moll.ogg\"]"
+
+    @Test
+    fun testSelectAllDeleteUndoRedo() {
+        // Add demo html text to editor
+        EditorPage()
+                .toggleHtml()
+                .replaceHTML(HTML)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Select all text and delete, verify
+        EditorPage()
+                .tapTop()
+                .clearText()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+
+        // Undo select all and delete, verify
+        EditorPage()
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTMLNoStripping(HTML)
+                .toggleHtml()
+
+        // Redo select all and delete, verify
+        EditorPage()
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+    }
+}

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageHistoryTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageHistoryTests.kt
@@ -1,0 +1,230 @@
+package org.wordpress.aztec.demo.tests
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.support.test.espresso.intent.Intents
+import android.support.test.espresso.intent.matcher.IntentMatchers
+import android.support.test.espresso.intent.rule.IntentsTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.wordpress.aztec.demo.BaseTest
+import org.wordpress.aztec.demo.MainActivity
+import org.wordpress.aztec.demo.R
+import org.wordpress.aztec.demo.pages.EditorPage
+import java.io.File
+import java.io.FileOutputStream
+
+class ImageHistoryTests : BaseTest() {
+
+    @Rule
+    @JvmField
+    val mActivityIntentsTestRule = IntentsTestRule<MainActivity>(MainActivity::class.java)
+
+    val throttleTime = 1000L
+
+    @Test
+    fun testUndoRedoImageUpload() {
+        val regex = Regex("<img src=.+ id=.+>|<img id=.+ src=.+>")
+        val editorPage = EditorPage()
+
+        // Upload image and verify
+        uploadImageFromDeviceAndVerify(regex, editorPage)
+
+        // Undo upload image and verify
+        editorPage
+                .undoChange()
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+                .threadSleep(throttleTime) // wait for history button to enable
+
+        // Redo upload image and verify
+        editorPage
+                .redoChange()
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
+
+    @Test
+    fun testAddImageDeleteUndoRedo() {
+        val regex = Regex("<img src=.+ id=.+>|<img id=.+ src=.+>")
+        val editorPage = EditorPage()
+
+        // Upload image and verify
+        uploadImageFromDeviceAndVerify(regex, editorPage)
+
+        // Delete image and verify
+        editorPage
+                .threadSleep(throttleTime)
+                .tapTop()
+                .selectAllAndDelete()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+
+        // Undo delete and verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(regex)
+                .toggleHtml()
+
+        // Redo delete and verify
+        editorPage
+                .redoChange()
+                .toggleHtml()
+                .verifyHTML("")
+    }
+
+    @Test
+    fun testCopyPasteImageUndoRedo() {
+        val regex1Image = Regex("<img src=.+ id=.+>|<img id=.+ src=.+>")
+        val regex2Images = Regex("(<img src=.+ id=.+>|<img id=.+ src=.+>).*(<img src=.+ id=.+>|<img id=.+ src=.+>)")
+        val editorPage = EditorPage()
+
+        // Upload image and verify
+        uploadImageFromDeviceAndVerify(regex1Image, editorPage)
+
+        // Copy image to clipboard
+        editorPage
+                .threadSleep(throttleTime)
+                .selectAllText()
+                .copyToClipboard()
+                .threadSleep(throttleTime)
+                .setCursorPositionAtEnd()
+
+        // Paste from clipboard and verify
+        editorPage
+                .pasteFromClipboard()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(regex2Images)
+                .toggleHtml()
+
+        // Undo paste and verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(regex1Image)
+                .toggleHtml()
+
+        // Redo paste and verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(regex2Images)
+    }
+
+    @Test
+    fun testAddTwoImagesUndoRedo() {
+        val regex1Image = Regex("<img src=.+ id=.+>|<img id=.+ src=.+>")
+        val regex2Images = Regex("(<img src=.+ id=.+>|<img id=.+ src=.+>).*(<img src=.+ id=.+>|<img id=.+ src=.+>)")
+        val editorPage = EditorPage()
+
+        // Upload first image and verify
+        uploadImageFromDeviceAndVerify(regex1Image, editorPage)
+
+        // Upload second image and verify
+        uploadImageFromDeviceAndVerify(regex2Images, editorPage)
+
+        // Undo adding second image
+        editorPage
+                .undoChange()
+                .toggleHtml()
+                .verifyHTML(regex1Image)
+                .toggleHtml()
+
+        // Undo adding first image
+        editorPage
+                .undoChange()
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Redo adding both images
+        editorPage
+                .redoChange()
+                .redoChange()
+                .toggleHtml()
+                .verifyHTML(regex2Images)
+    }
+
+    @Test
+    fun testAddPhotoWithHtmlUndoRedo() {
+        val regex = Regex("<img src=.+>")
+        val editorPage = EditorPage()
+
+        // Add image with html and verify
+        createImageIntentFilter()
+        addPhotoWithHTML()
+
+        editorPage
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(regex)
+                .toggleHtml()
+
+        // Undo adding html image and verify
+        editorPage
+                .undoChange()
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Redo adding html image and verify
+        editorPage
+                .redoChange()
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
+
+    private fun uploadImageFromDeviceAndVerify(regex: Regex, editorPage: EditorPage = EditorPage()) {
+        // Upload image
+        createImageIntentFilter()
+        editorPage
+                .tapTop()
+                .insertMedia()
+
+        // Must wait for the simulated upload to start
+        Thread.sleep(10000)
+
+        // Verify image uploaded
+        editorPage
+                .toggleHtml()
+                .verifyHTML(regex)
+                .toggleHtml()
+    }
+
+    private fun addPhotoWithHTML() {
+        val imageHtml = "<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\">"
+
+        EditorPage()
+                .tapTop()
+                .toggleHtml()
+                .replaceHTML(imageHtml)
+                .toggleHtml()
+    }
+
+    private fun createImageIntentFilter() {
+        val file = File(mActivityIntentsTestRule.activity.filesDir, "aztec.png")
+        val outputStream = FileOutputStream(file)
+        val bitmap = BitmapFactory.decodeResource(mActivityIntentsTestRule.activity.resources, R.drawable.aztec)
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        outputStream.close()
+
+        val intent = Intent()
+        intent.data = Uri.fromFile(file)
+        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_OPEN_DOCUMENT))
+                .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, intent))
+    }
+}

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/ImageTests.kt
@@ -47,7 +47,7 @@ class ImageTests : BaseTest() {
     @Test
     fun testAddPhotoAndText() {
         var sampleText = "sample text "
-        val regex = Regex(".+<img src=.+>.+")
+        val regex = Regex(".+<img src=.+>.+", RegexOption.DOT_MATCHES_ALL)
 
         for (i in 1..5) {
             sampleText += sampleText

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/LinkHistoryTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/LinkHistoryTests.kt
@@ -1,0 +1,219 @@
+package org.wordpress.aztec.demo.tests
+
+import org.junit.Test
+import org.wordpress.aztec.History
+import org.wordpress.aztec.demo.BaseHistoryTest
+import org.wordpress.aztec.demo.pages.EditLinkPage
+import org.wordpress.aztec.demo.pages.EditorPage
+import org.wordpress.aztec.formatting.LinkFormatter.LinkStyle
+
+/**
+ * Tests [History] component (undo/redo) functionality on [LinkStyle] elements.
+ */
+class LinkHistoryTests : BaseHistoryTest() {
+
+    @Test
+    fun testAddLinkViaDialogUndoRedo() {
+        val link = "http://wordpress.com"
+        val name = "WordPress"
+        val html = "<a href=\"$link\">$name</a>"
+        val editorPage = EditorPage()
+
+        // Add link and verify
+        addLinkAndVerify(editorPage, link, html, name)
+
+        // Undo make link and verify
+        editorPage
+                .threadSleep(throttleTime)
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+
+        // Redo make link and verify
+        editorPage
+                .threadSleep(throttleTime)
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testAddNameAndMakeLinkUndoRedo() {
+        val link = "http://wordpress.com"
+        val name = "WordPress"
+        val html = "<a href=\"$link\">$name</a>"
+        val editorPage = EditorPage()
+
+        // Add the text
+        editorPage
+                .insertText(name)
+                .threadSleep(throttleTime)
+                .selectAllText()
+
+        // Make link from selected text
+        addLinkAndVerify(editorPage, link, html)
+
+        // Undo make link - should just leave the text
+        editorPage
+                .threadSleep(throttleTime)
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(name)
+                .toggleHtml()
+
+        // Undo add name and verify
+        editorPage
+                .threadSleep(throttleTime)
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+
+        // Redo both steps and verify
+        editorPage
+                .threadSleep(throttleTime)
+                .redoChange()
+                .threadSleep(throttleTime)
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+                .toggleHtml()
+    }
+
+    @Test
+    fun testCopyPasteLinkUndoRedo() {
+        val link = "http://wordpress.com"
+        val name = "WordPress"
+        val html = "<a href=\"$link\">$name</a>"
+        val html2Links = "$html $html"
+        val editorPage = EditorPage()
+
+        // Add link and verify
+        addLinkAndVerify(editorPage, link, html, name)
+
+        // Insert a space
+        editorPage
+                .setCursorPositionAtEnd()
+                .insertText(" ")
+                .threadSleep(throttleTime)
+
+        // Copy link and paste, verify
+        editorPage
+                .selectAllText()
+                .copyToClipboard()
+                .setCursorPositionAtEnd()
+                .pasteFromClipboard()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html2Links)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Undo paste link, verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Redo paste link, verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html2Links)
+    }
+
+    @Test
+    fun testAddLinkAfterTextUndoRedo() {
+        val link = "http://wordpress.com"
+        val name = "WordPress"
+        val html = "Testing <a href=\"$link\">$name</a>"
+        val text = "Testing"
+        val editorPage = EditorPage()
+
+        // Add text and link, verify
+        editorPage
+                .insertText("$text ")
+                .threadSleep(throttleTime)
+                .setCursorPositionAtEnd()
+        addLinkAndVerify(editorPage, link, html, name)
+
+        // Undo add link, verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(text)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Redo add link, verify
+        editorPage
+                .redoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testAddLinkInHtmlUndoRedo() {
+        val link = "http://wordpress.com"
+        val name = "WordPress"
+        val html = "<a href=\"$link\">$name</a>"
+        val editorPage = EditorPage()
+
+        // Add link in source editor, switch to editor.
+        editorPage
+                .toggleHtml()
+                .insertHTML(html)
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Undo and verify
+        editorPage
+                .undoChange()
+                .threadSleep(throttleTime)
+                .toggleHtml()
+                .verifyHTML("")
+                .toggleHtml()
+                .threadSleep(throttleTime)
+
+        // Redo and verify
+        editorPage
+                .redoChange()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    /**
+     * Add a link to the editor and verify success
+     *
+     * @param [link] The link URL.
+     * @param [expected] The string to verify link success.
+     * @param [name] The name to assign to the link, or null.
+     */
+    private fun addLinkAndVerify(editorPage: EditorPage, link: String, expected: String, name: String? = null) {
+        editorPage.makeLink()
+        EditLinkPage().updateURL(link)
+        name?.let {
+            EditLinkPage().updateName(it)
+        }
+        EditLinkPage().ok()
+
+        editorPage
+                .toggleHtml()
+                .verifyHTML(expected)
+                .toggleHtml()
+                .threadSleep(throttleTime)
+    }
+}

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -51,7 +51,6 @@ class MixedTextFormattingTests : BaseTest() {
                 .focusedInsertText(text3)
                 .toggleHtml()
                 .verifyHTML(html)
-
     }
 
     @Test

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
@@ -164,6 +164,7 @@ class SimpleTextFormattingTests : BaseTest() {
         EditorPage()
                 .insertText(text1)
                 .addMoreRule()
+                .setCursorPositionAtEnd()
                 .focusedInsertText(text2)
                 .toggleHtml()
                 .verifyHTML(html)

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -227,7 +227,6 @@ open class MainActivity : AppCompatActivity(),
 
                         override fun onThumbnailLoading(drawable: Drawable?) {
                         }
-
                     }, this.resources.displayMetrics.widthPixels)
                 }
             }
@@ -284,7 +283,7 @@ open class MainActivity : AppCompatActivity(),
         var progress = 0
 
         // simulate an upload delay
-        val runnable: Runnable = Runnable {
+        val runnable = Runnable {
             aztec.visualEditor.setOverlayLevel(predicate, 1, progress)
             aztec.visualEditor.updateElementAttributes(predicate, attrs)
             aztec.visualEditor.resetAttributedMediaSpan(predicate)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -49,77 +49,77 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     companion object Factory {
         @JvmStatic
         fun with(activity: Activity, @IdRes aztecTextId: Int, @IdRes sourceTextId: Int,
-                 @IdRes toolbarId: Int, toolbarClickListener: IAztecToolbarClickListener) : Aztec {
+                 @IdRes toolbarId: Int, toolbarClickListener: IAztecToolbarClickListener): Aztec {
             return Aztec(activity, aztecTextId, sourceTextId, toolbarId, toolbarClickListener)
         }
 
         @JvmStatic
         fun with(visualEditor: AztecText, sourceEditor: SourceViewEditText,
-                 toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener) : Aztec {
+                 toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener): Aztec {
             return Aztec(visualEditor, sourceEditor, toolbar, toolbarClickListener)
         }
 
         @JvmStatic
-        fun with(visualEditor: AztecText, toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener) : Aztec {
+        fun with(visualEditor: AztecText, toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener): Aztec {
             return Aztec(visualEditor, toolbar, toolbarClickListener)
         }
     }
 
-    fun setImageGetter(imageGetter: Html.ImageGetter) : Aztec {
+    fun setImageGetter(imageGetter: Html.ImageGetter): Aztec {
         this.imageGetter = imageGetter
         initImageGetter()
         return this
     }
 
-    fun setVideoThumbnailGetter(videoThumbnailGetter: Html.VideoThumbnailGetter) : Aztec {
+    fun setVideoThumbnailGetter(videoThumbnailGetter: Html.VideoThumbnailGetter): Aztec {
         this.videoThumbnailGetter = videoThumbnailGetter
         initVideoGetter()
         return this
     }
 
-    fun setOnImeBackListener(imeBackListener: AztecText.OnImeBackListener) : Aztec {
+    fun setOnImeBackListener(imeBackListener: AztecText.OnImeBackListener): Aztec {
         this.imeBackListener = imeBackListener
         initImeBackListener()
         return this
     }
 
-    fun setOnTouchListener(onTouchListener: View.OnTouchListener) : Aztec {
+    fun setOnTouchListener(onTouchListener: View.OnTouchListener): Aztec {
         this.onTouchListener = onTouchListener
         initTouchListener()
         return this
     }
 
-    fun setOnImageTappedListener(onImageTappedListener: AztecText.OnImageTappedListener) : Aztec {
+    fun setOnImageTappedListener(onImageTappedListener: AztecText.OnImageTappedListener): Aztec {
         this.onImageTappedListener = onImageTappedListener
         initImageTappedListener()
         return this
     }
 
-    fun setOnVideoTappedListener(onVideoTappedListener: AztecText.OnVideoTappedListener) : Aztec {
+    fun setOnVideoTappedListener(onVideoTappedListener: AztecText.OnVideoTappedListener): Aztec {
         this.onVideoTappedListener = onVideoTappedListener
         initVideoTappedListener()
         return this
     }
 
-    fun setOnAudioTappedListener(onAudioTappedListener: AztecText.OnAudioTappedListener) : Aztec {
+    fun setOnAudioTappedListener(onAudioTappedListener: AztecText.OnAudioTappedListener): Aztec {
         this.onAudioTappedListener = onAudioTappedListener
         initAudioTappedListener()
         return this
     }
 
-    fun setOnMediaDeletedListener(onMediaDeletedListener: AztecText.OnMediaDeletedListener) : Aztec {
+    fun setOnMediaDeletedListener(onMediaDeletedListener: AztecText.OnMediaDeletedListener): Aztec {
         this.onMediaDeletedListener = onMediaDeletedListener
         initMediaDeletedListener()
         return this
     }
 
-    fun setHistoryListener(historyListener: IHistoryListener) : Aztec {
+    fun setHistoryListener(historyListener: IHistoryListener): Aztec {
         this.historyListener = historyListener
         initHistoryListener()
         return this
     }
 
-    fun addPlugin(plugin: IAztecPlugin) : Aztec {
+    fun addPlugin(plugin: IAztecPlugin): Aztec {
         plugins.add(plugin)
 
         if (plugin is IToolbarButton) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
@@ -13,7 +13,7 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         }
     }
 
-    fun isEmpty() : Boolean {
+    fun isEmpty(): Boolean {
         return length == 0
     }
 
@@ -24,7 +24,7 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         }
     }
 
-    fun hasAttribute(key: String) : Boolean {
+    fun hasAttribute(key: String): Boolean {
         return getValue(key) != null
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -570,7 +570,6 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
                         } else {
                             (spanEnd != selStart) && selStart in spanStart..spanEnd
                         }
-
                     } else {
                         (selStart in spanStart..spanEnd || selEnd in spanStart..spanEnd) ||
                                 (spanStart in selStart..selEnd || spanEnd in spanStart..spanEnd)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -77,7 +77,6 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle) : AztecFormat
                     (newStart > end && editableText.length > end && editableText[end] == '\n')) {
                 removeInlineStyle(it, newStart, end)
             }
-
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
@@ -66,8 +66,7 @@ abstract class BlockHandler<SpanType : IAztecBlockSpan>(val clazz: Class<SpanTyp
         }
     }
 
-    private fun getNewlinePositionType(text: Spannable, block: SpanWrapper<SpanType>, newlineIndex: Int)
-            : PositionType {
+    private fun getNewlinePositionType(text: Spannable, block: SpanWrapper<SpanType>, newlineIndex: Int): PositionType {
         val isEmptyBody = (block.end - block.start == 1)
                 || (block.end - block.start == 2 && text[block.end - 1] == Constants.END_OF_BUFFER_MARKER)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/html2visual/IHtmlCommentHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/html2visual/IHtmlCommentHandler.kt
@@ -17,7 +17,7 @@ interface IHtmlCommentHandler {
      *
      * @return true if this plugin handled the comment and no other handler should be called, false otherwise.
      */
-    fun handleComment(text: String, output: Editable, nestingLevel: Int) : Boolean {
+    fun handleComment(text: String, output: Editable, nestingLevel: Int): Boolean {
         return true
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/html2visual/IHtmlTextHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/html2visual/IHtmlTextHandler.kt
@@ -6,5 +6,5 @@ import org.wordpress.aztec.plugins.IAztecPlugin
 interface IHtmlTextHandler : IAztecPlugin {
     val pattern: String
 
-    fun onHtmlTextMatch(text: String, output: Editable, nestingLevel: Int) : Boolean
+    fun onHtmlTextMatch(text: String, output: Editable, nestingLevel: Int): Boolean
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -123,7 +123,10 @@ class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatc
     }
 
     override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
-        history?.beforeTextChanged(text.toString())
+        if (!isTextChangedListenerDisabled()) {
+            history?.beforeTextChanged(text.toString())
+        }
+
         styleTextWatcher?.beforeTextChanged(text, start, count, after)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -139,4 +139,6 @@ class AztecHeadingSpan @JvmOverloads constructor(
 
         textPaint.textSize *= heading.scale
     }
+
+    override fun toString() = "AztecHeadingSpan : $TAG"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -57,7 +57,7 @@ abstract class AztecListSpan(override var nestingLevel: Int, var verticalPadding
         return otherLinesAtSameNestingLevel + 1
     }
 
-    fun nestingDepth(text: Spanned, index: Int, nextIndex: Int) : Int {
+    fun nestingDepth(text: Spanned, index: Int, nextIndex: Int): Int {
         val finalNextIndex = if (nextIndex > text.length) index else nextIndex
         return IAztecNestable.getNestingLevelAt(text, index, finalNextIndex)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -58,7 +58,7 @@ class AztecUnorderedListSpan(
         val width = p.measureText(textToDraw)
 
         // Make sure the marker is correctly aligned on RTL languages
-        var markerStartPosition : Float = x + (listStyle.indicatorMargin * dir) * 1f
+        var markerStartPosition: Float = x + (listStyle.indicatorMargin * dir) * 1f
         if (dir == 1)
             markerStartPosition -= width
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/BlockElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/BlockElementWatcher.kt
@@ -68,12 +68,12 @@ open class BlockElementWatcher(aztecText: AztecText) : TextWatcher {
 
     override fun afterTextChanged(text: Editable) {}
 
-    fun add(textChangeHandler: TextChangeHandler) : BlockElementWatcher {
+    fun add(textChangeHandler: TextChangeHandler): BlockElementWatcher {
         handlers.add(textChangeHandler)
         return this
     }
 
-    fun install(text: AztecText) : BlockElementWatcher {
+    fun install(text: AztecText): BlockElementWatcher {
         text.addTextChangedListener(this)
         return this
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
@@ -99,7 +99,7 @@ class EndOfBufferMarkerAdder(text: Editable) : TextWatcher {
             return sb.toString()
         }
 
-        fun <T: CharSequence> removeEndOfTextMarker(string: T): T {
+        fun <T : CharSequence> removeEndOfTextMarker(string: T): T {
             if (string.isNotEmpty() && string[string.length - 1] == Constants.END_OF_BUFFER_MARKER) {
                 string.substring(0, string.length - 2)
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/InlineTextWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/InlineTextWatcher.kt
@@ -64,7 +64,6 @@ class InlineTextWatcher(var inlineFormatter: InlineFormatter, aztecText: AztecTe
         } else {
             aztecTextRef.get()?.enableInlineTextHandling()
         }
-
     }
 
     fun removeLeadingStyle(text: Editable, spanClass: Class<*>) {

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -4,8 +4,8 @@
     <style name="FormatBarButton">
         <item name="android:minWidth">@dimen/format_bar_height</item>
         <item name="android:minHeight">@dimen/format_bar_height</item>
-        <item name="android:textOn">""</item>
-        <item name="android:textOff">""</item>
+        <item name="android:textOn">@null</item>
+        <item name="android:textOff">@null</item>
     </style>
 
     <style name="DividerHorizontal">

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
@@ -29,7 +29,7 @@ class WordPressCommentsPlugin(val visualEditor: AztecText) : IInlineSpanHandler,
         html.append("-->")
     }
 
-    override fun handleComment(text: String, output: Editable, nestingLevel: Int) : Boolean {
+    override fun handleComment(text: String, output: Editable, nestingLevel: Int): Boolean {
 
         val spanStart = output.length
 

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/handlers/CaptionHandler.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/handlers/CaptionHandler.kt
@@ -57,5 +57,4 @@ class CaptionHandler(aztecText: AztecText) : BlockHandler<CaptionShortcodeSpan>(
         // delete the newline as it's purpose was served (to translate it as a command to close the block)
         TextDeleter.mark(text, newlineIndex, newlineIndex + 1)
     }
-
 }


### PR DESCRIPTION
### Fix
This PR fixes the issues outlined in [#445](https://github.com/wordpress-mobile/AztecEditor-Android/issues/445) and are described below. 

#### Recording History
Previously, the history component would record every textChangedEvent, even the ones not initiated by the user but by different TextWatchers. This caused the historical stack to include changes not visible until a user clicks UNDO. To fix this issue, I have added a timer that will only record text changes when there haven't been any new TextChangedEvents for 500 ms. 

Added a new variable to `AztecText` called `consumeHistoryEvent`, which is used to prevent history from recording events like the backspace generated in the `setupZeroIndexBackspaceDetection` method. 

#### Copy/Pasting
Most of the issues with copy/pasting were due to editor changes by other TextWatchers that were being recorded in the history stack. The rest:
- Copy/Pasting Images: Added a new method to History called `refreshLastHistoryItem`. This method replaces the last history item with fresh data. This is specifically important for Images because the image html has the `uploading` attribute until the upload is complete. History was just storing the initial html so if you UNDO/REDO, the editor will be left in a bad state with the user unable to switch to source view. 

#### Block Elements
The `ParagraphCollapseRemover` was breaking REDO history by removing spans of type _IParagraphFlagged_ during the _beforeTextChanged_ event. For example, I would add the following html:
```kotlin
<h1>Heading 1</h1>
<h2>Heading 2</h2>
<h3>Heading 3</h3>
```
Switch to editor mode, select all, and then hit delete. Click UNDO and the html was be restored as:
```
<h1>Heading 1</h1>
Heading 2
Heading 3
```
The H2 and H3 heading spans were being removed by the `ParagraphCollapseRemover` _before_ history was recorded. `ParagraphCollapseRemover` must do all of it's changes in the beforeTextChanged event because that's where the positions are still in tact. So to fix this, I moved the registering of the `AztecText` and `ParagraphCollapseRemover` text watchers. Now they are the very last textWatchers to register and AztecText **_must_** register **_before_** `ParagraphCollapseRemover`:
```
// History related logging has to happen before the changes in [ParagraphCollapseRemover]
addTextChangedListener(this)
ParagraphCollapseRemover.install(this)
```
### Tests
A bunch of tests were added, at least one test for each type of element. All the tests are Instrumented Tests. I added some `Actions` and `Matchers` and several new methods to `EditorPage` to support my tests. One of those new methods is `threadSleep`. This is used during History testing to wait for history to be recorded now that there is a timer in use. I added this method here for convenience so when I'm writing tests, instead of writing:
```
editorPage
	.insertText(word1)
Thread.sleep(throttleTime())
editorPage
	.insertText(word2)	
Thread.sleep(throttleTime())
editorPage
	.insertText(word3)
Thread.sleep(throttleTime())	
editorPage
	.insertText(word4)
Thread.sleep(throttleTime())	
```
I can write it like this:
```
editorPage
    .insertText(word1)
    .threadSleep(throttleTime())
    .insertText(word2)
    .threadSleep(throttleTime())
    .insertText(word3)
    .threadSleep(throttleTime())
    .insertText(word4)
    .threadSleep(throttleTime())
```
### Misc
- Cleaned up some lint errors for classes I had modified. 
- Optimized styles.xml by replacing "" with `@null` for textOn and textOff. While stepping through the code I ran into a bunch of work that was happening to process the empty text. 
- Cleaned up ktlint formatting errors.
### Review
@0nko Please let me know if there are any scenarios that can be added.

