### PR TITLE
Fixed URL span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+- URL span not including href attribute when other attributes are present
+
 ## [1.0-beta.11](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.11) - 2017-11-20
 ### Fixed
 - Paragraphs with attributes being removed

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -31,11 +31,12 @@ class AztecURLSpan : URLSpan, IAztecInlineSpan {
     override var attributes: AztecAttributes = AztecAttributes()
 
     constructor(url: String, attributes: AztecAttributes = AztecAttributes()) : super(url) {
-        if (attributes.isEmpty()) {
+        this.attributes = attributes
+
+        if (!this.attributes.hasAttribute("href")) {
             this.attributes.setValue("href", url)
-        } else {
-            this.attributes = attributes
         }
+
     }
 
     constructor(url: String, linkStyle: LinkFormatter.LinkStyle, attributes: AztecAttributes = AztecAttributes()) : this(url, attributes) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -36,7 +36,6 @@ class AztecURLSpan : URLSpan, IAztecInlineSpan {
         if (!this.attributes.hasAttribute("href")) {
             this.attributes.setValue("href", url)
         }
-
     }
 
     constructor(url: String, linkStyle: LinkFormatter.LinkStyle, attributes: AztecAttributes = AztecAttributes()) : this(url, attributes) {


### PR DESCRIPTION
URL span didn't include a `href` attribute when additional attributes, like `target`, was passed to the constructor.