### PR TITLE
Check the beginning of changed text for images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- The text handling following immediately after images
+
 ## [1.0-beta.11](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.11) - 2017-11-20
 ### Fixed
 - Paragraphs with attributes being removed

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/FullWidthImageElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/FullWidthImageElementWatcher.kt
@@ -42,7 +42,8 @@ class FullWidthImageElementWatcher(aztecText: AztecText) : TextWatcher {
             val end = start + count
             var lines = aztecText.text.getSpans(start, end, IAztecFullWidthImageSpan::class.java)
 
-            // necessary as spans starting at the `end` are not included in the list above
+            // necessary as spans starting at the `start` and ending at the `end` are not included in the list above
+            lines += aztecText.text.getSpans(start, start, IAztecFullWidthImageSpan::class.java)
             lines += aztecText.text.getSpans(end, end, IAztecFullWidthImageSpan::class.java)
 
             lines.distinct().forEach {


### PR DESCRIPTION
Resolves the problem when adding text behind an image doesn't put the text on a new line.