### PR TITLE
Add unit tests for div HTML parsing

### DIFF
--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -8,6 +8,7 @@ import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -1181,6 +1182,7 @@ class AztecParserTest : AndroidTestCase() {
         Assert.assertEquals(input, output)
     }
 
+    @Ignore("Until this issue is fixed: https://github.com/wordpress-mobile/AztecEditor-Android/issues/434")
     @Test
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlListInDiv_isEqual() {
@@ -1190,6 +1192,7 @@ class AztecParserTest : AndroidTestCase() {
         Assert.assertEquals(input, output)
     }
 
+    @Ignore("Until this issue is fixed: https://github.com/wordpress-mobile/AztecEditor-Android/issues/434")
     @Test
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlBrBeforeAndAfterDiv_isEqual() {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -1180,4 +1180,22 @@ class AztecParserTest : AndroidTestCase() {
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlListInDiv_isEqual() {
+        val input = "<div>" + HTML_LIST_UNORDERED + "</div>"
+        val span = SpannableString(mParser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlBrBeforeAndAfterDiv_isEqual() {
+        val input = "<br><div><br></div>"
+        val span = SpannableString(mParser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
 }


### PR DESCRIPTION
This PR adds unit tests for the two `div` parsing issues described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/434#issuecomment-349706228.

1. `div` tags are removed (as above) when a `br` tag precedes it.
Input: `<br><div><br></div>`
Output: `<br><br>`

2. `div` tags are moved inside a list item when there is a list inside the div.
Input: `<div><ul><li>Unordered</li></ul></div>`
Output: `<ul><li><div>Unordered</div></li></ul>`

### Review
@maxme 