### PR TITLE
Exposes some static methods to java

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -19,6 +19,7 @@ object Format {
 
     private val iframePlaceholder = "iframe-replacement-0x0"
 
+    @JvmStatic
     fun addSourceEditorFormatting(content: String, isCalypsoFormat: Boolean = false): String {
         var html = replaceAll(content, "iframe", iframePlaceholder)
         html = html.replace("<aztec_cursor>", "")
@@ -46,6 +47,7 @@ object Format {
         return html.trim()
     }
 
+    @JvmStatic
     fun removeSourceEditorFormatting(html: String, isCalypsoFormat: Boolean = false): String {
         if (isCalypsoFormat) {
             val htmlWithoutSourceFormatting = toCalypsoHtml(html)
@@ -294,6 +296,7 @@ object Format {
         return html.replace("\n", "").trim()
     }
 
+    @JvmStatic
     fun preProcessSpannedText(text: SpannableStringBuilder, isCalypsoFormat: Boolean) {
         if (isCalypsoFormat) {
             text.getSpans(0, text.length, AztecVisualLinebreak::class.java).forEach {
@@ -314,6 +317,7 @@ object Format {
         }
     }
 
+    @JvmStatic
     fun postProcessSpannedText(text: SpannableStringBuilder, isCalypsoFormat: Boolean) {
         if (isCalypsoFormat) {
             val spans = text.getSpans(0, text.length, EndOfParagraphMarker::class.java)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
@@ -99,6 +99,7 @@ class EndOfBufferMarkerAdder(text: Editable) : TextWatcher {
             return sb.toString()
         }
 
+        @JvmStatic
         fun <T : CharSequence> removeEndOfTextMarker(string: T): T {
             if (string.isNotEmpty() && string[string.length - 1] == Constants.END_OF_BUFFER_MARKER) {
                 string.substring(0, string.length - 2)


### PR DESCRIPTION
This PR adds `@JvmStatic` to several methods that we need to use from outside to cope with Calypso mode formatting.

### Review
@0nko 