### PR TITLE
Log the text that caused RuntimeException in AztecText.toPlainHtml

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -45,6 +45,7 @@ import android.view.View
 import android.view.WindowManager
 import android.view.inputmethod.BaseInputConnection
 import android.widget.EditText
+import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.formatting.InlineFormatter
 import org.wordpress.aztec.formatting.LineBlockFormatter
@@ -901,7 +902,15 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     // platform agnostic HTML
     fun toPlainHtml(withCursorTag: Boolean = false): String {
         val parser = AztecParser(plugins)
-        val output = SpannableStringBuilder(text)
+        var output: SpannableStringBuilder
+        try {
+            output = SpannableStringBuilder(text)
+        } catch (e: java.lang.ArrayIndexOutOfBoundsException) {
+            // FIXME: Remove this log once we've data to replicate the issue, and fix it in some way.
+            AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 for details. " +
+                    "Following is the text that caused the issue " + text)
+            throw e
+        }
 
         clearMetaSpans(output)
 


### PR DESCRIPTION
This PR just adds the text that caused the issue to AppLog, and keep letting the app crash.
We need to remove the log line once we've enough data to replicate it. I've added a FIXME there to remember us to remove it.