### PR TITLE
Add VideoPress support

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -839,7 +839,10 @@ open class MainActivity : AppCompatActivity(),
         See: https://developer.wordpress.com/docs/api/1.1/get/videos/%24guid/
         The response has all info in it. We're skipping it here, and set the poster image directly
         */
-        aztec.visualEditor.updateVideoPressThumb("https://videos.files.wordpress.com/OcobLTqC/img_5786_hd.original.jpg", videoID)
+        aztec.visualEditor.updateVideoPressThumb(
+                "https://videos.files.wordpress.com/OcobLTqC/img_5786_hd.original.jpg",
+                "https://videos.files.wordpress.com/OcobLTqC/img_5786.m4v",
+                videoID)
     }
 
     override fun onAudioTapped(attrs: AztecAttributes) {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -63,6 +63,7 @@ open class MainActivity : AppCompatActivity(),
         AztecText.OnVideoTappedListener,
         AztecText.OnAudioTappedListener,
         AztecText.OnMediaDeletedListener,
+        AztecText.OnVideoPressInfoRequestedListener,
         IAztecToolbarClickListener,
         IHistoryListener,
         OnRequestPermissionsResultCallback,
@@ -121,6 +122,8 @@ open class MainActivity : AppCompatActivity(),
         private val LONG_TEXT = "<br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
         private val VIDEO = "[video src=\"https://examplebloge.files.wordpress.com/2017/06/d7d88643-88e6-d9b5-11e6-92e03def4804.mp4\"]"
         private val AUDIO = "[audio src=\"https://upload.wikimedia.org/wikipedia/commons/9/94/H-Moll.ogg\"]"
+        private val VIDEOPRESS = "[wpvideo CAXoLjpu]"
+        private val VIDEOPRESS2 = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true3]"
 
         private val EXAMPLE =
                 IMG +
@@ -145,6 +148,8 @@ open class MainActivity : AppCompatActivity(),
                 NON_LATIN_TEXT +
                 LONG_TEXT +
                 VIDEO +
+                VIDEOPRESS +
+                VIDEOPRESS2 +
                 AUDIO
 
         private val isRunningTest: Boolean by lazy {
@@ -335,6 +340,7 @@ open class MainActivity : AppCompatActivity(),
             .setOnVideoTappedListener(this)
             .setOnAudioTappedListener(this)
             .setOnMediaDeletedListener(this)
+            .setOnVideoPressInfoRequestedListener(this)
             .addPlugin(WordPressCommentsPlugin(visualEditor))
             .addPlugin(MoreToolbarButton(visualEditor))
             .addPlugin(PageToolbarButton(visualEditor))
@@ -817,6 +823,10 @@ open class MainActivity : AppCompatActivity(),
                 }
             }
         }
+    }
+
+    override fun onVideoPressInfoRequested(videoID: String) {
+        // TODO
     }
 
     override fun onAudioTapped(attrs: AztecAttributes) {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -122,8 +122,8 @@ open class MainActivity : AppCompatActivity(),
         private val LONG_TEXT = "<br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
         private val VIDEO = "[video src=\"https://examplebloge.files.wordpress.com/2017/06/d7d88643-88e6-d9b5-11e6-92e03def4804.mp4\"]"
         private val AUDIO = "[audio src=\"https://upload.wikimedia.org/wikipedia/commons/9/94/H-Moll.ogg\"]"
-        private val VIDEOPRESS = "[wpvideo CAXoLjpu]"
-        private val VIDEOPRESS2 = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true3]"
+        private val VIDEOPRESS = "[wpvideo OcobLTqC]"
+        private val VIDEOPRESS_2 = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true3]"
 
         private val EXAMPLE =
                 IMG +
@@ -149,7 +149,7 @@ open class MainActivity : AppCompatActivity(),
                 LONG_TEXT +
                 VIDEO +
                 VIDEOPRESS +
-                VIDEOPRESS2 +
+                VIDEOPRESS_2 +
                 AUDIO
 
         private val isRunningTest: Boolean by lazy {
@@ -826,7 +826,7 @@ open class MainActivity : AppCompatActivity(),
     }
 
     override fun onVideoPressInfoRequested(videoID: String) {
-        // TODO
+        AppLog.d(AppLog.T.EDITOR, "VideoPress Info Requested for video ID " + videoID)
     }
 
     override fun onAudioTapped(attrs: AztecAttributes) {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -52,7 +52,6 @@ import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton
 import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
-import org.wordpress.aztec.spans.AztecVideoSpan
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
 import org.xml.sax.Attributes
@@ -835,38 +834,12 @@ open class MainActivity : AppCompatActivity(),
     override fun onVideoPressInfoRequested(videoID: String) {
         AppLog.d(AppLog.T.EDITOR, "VideoPress Info Requested for video ID " + videoID)
 
-        /* Here should go the Network request to retrieve additional info about the video.
-           The response has all info in it. We're skipping it here, and set the poster image directly
-         */
-
-        val originalURL = "https://videos.files.wordpress.com/OcobLTqC/img_5786.m4v"
-        val spans = aztec.visualEditor.text.getSpans(0, aztec.visualEditor.text.length, AztecVideoSpan::class.java)
-        spans.forEach {
-            if (it.attributes.hasAttribute(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) &&
-                    it.attributes.getValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) == videoID) {
-
-                // Set the hidden videopress source. Used when the video is tapped
-                it.attributes.setValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC, originalURL)
-
-                val callbacks = object : Html.VideoThumbnailGetter.Callbacks {
-                    override fun onThumbnailFailed() {
-                    }
-
-                    override fun onThumbnailLoaded(drawable: Drawable?) {
-                        it.drawable = drawable
-                        aztec.visualEditor.post {
-                            aztec.visualEditor.refreshText()
-                        }
-                    }
-
-                    override fun onThumbnailLoading(drawable: Drawable?) {
-                    }
-                }
-                aztec.visualEditor.videoThumbnailGetter?.loadVideoThumbnail(
-                        originalURL,
-                        callbacks, aztec.visualEditor.maxImagesWidth, aztec.visualEditor.minImagesWidth)
-            }
-        }
+        /*
+        Here should go the Network request that retrieves additional info about the video.
+        See: https://developer.wordpress.com/docs/api/1.1/get/videos/%24guid/
+        The response has all info in it. We're skipping it here, and set the poster image directly
+        */
+        aztec.visualEditor.updateVideoPressThumb("https://videos.files.wordpress.com/OcobLTqC/img_5786_hd.original.jpg", videoID)
     }
 
     override fun onAudioTapped(attrs: AztecAttributes) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -21,7 +21,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     private var onVideoTappedListener: AztecText.OnVideoTappedListener? = null
     private var onAudioTappedListener: AztecText.OnAudioTappedListener? = null
     private var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null
-    private var onVideoPressInfoRequestedListener: AztecText.OnVideoPressInfoRequestedListener? = null
+    private var onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener? = null
     private var plugins: ArrayList<IAztecPlugin> = visualEditor.plugins
     var sourceEditor: SourceViewEditText? = null
 
@@ -114,9 +114,9 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
         return this
     }
 
-    fun setOnVideoPressInfoRequestedListener(onVideoPressInfoRequestedListener: AztecText.OnVideoPressInfoRequestedListener): Aztec {
-        this.onVideoPressInfoRequestedListener = onVideoPressInfoRequestedListener
-        initVideoPressInfoRequestedListener()
+    fun setOnVideoInfoRequestedListener(onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener): Aztec {
+        this.onVideoInfoRequestedListener = onVideoInfoRequestedListener
+        initVideoInfoRequestedListener()
         return this
     }
 
@@ -200,9 +200,9 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
         }
     }
 
-    private fun initVideoPressInfoRequestedListener() {
-        if (onVideoPressInfoRequestedListener != null) {
-            visualEditor.setOnVideoPressInfoRequestedListener(onVideoPressInfoRequestedListener!!)
+    private fun initVideoInfoRequestedListener() {
+        if (onVideoInfoRequestedListener != null) {
+            visualEditor.setOnVideoInfoRequestedListener(onVideoInfoRequestedListener!!)
         }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -21,6 +21,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     private var onVideoTappedListener: AztecText.OnVideoTappedListener? = null
     private var onAudioTappedListener: AztecText.OnAudioTappedListener? = null
     private var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null
+    private var onVideoPressInfoRequestedListener: AztecText.OnVideoPressInfoRequestedListener? = null
     private var plugins: ArrayList<IAztecPlugin> = visualEditor.plugins
     var sourceEditor: SourceViewEditText? = null
 
@@ -113,6 +114,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
         return this
     }
 
+    fun setOnVideoPressInfoRequestedListener(onVideoPressInfoRequestedListener: AztecText.OnVideoPressInfoRequestedListener): Aztec {
+        this.onVideoPressInfoRequestedListener = onVideoPressInfoRequestedListener
+        initVideoPressInfoRequestedListener()
+        return this
+    }
+
     fun setHistoryListener(historyListener: IHistoryListener): Aztec {
         this.historyListener = historyListener
         initHistoryListener()
@@ -190,6 +197,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     private fun initMediaDeletedListener() {
         if (onMediaDeletedListener != null) {
             visualEditor.setOnMediaDeletedListener(onMediaDeletedListener!!)
+        }
+    }
+
+    private fun initVideoPressInfoRequestedListener() {
+        if (onVideoPressInfoRequestedListener != null) {
+            visualEditor.setOnVideoPressInfoRequestedListener(onVideoPressInfoRequestedListener!!)
         }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -134,6 +134,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     private var onVideoTappedListener: OnVideoTappedListener? = null
     private var onAudioTappedListener: OnAudioTappedListener? = null
     private var onMediaDeletedListener: OnMediaDeletedListener? = null
+    private var onVideoPressInfoRequestedListener: OnVideoPressInfoRequestedListener? = null
 
     private var isViewInitialized = false
     private var isLeadingStyleRemoved = false
@@ -196,6 +197,10 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     interface OnMediaDeletedListener {
         fun onMediaDeleted(attrs: AztecAttributes)
+    }
+
+    interface OnVideoPressInfoRequestedListener {
+        fun onVideoPressInfoRequested(videoId: String)
     }
 
     constructor(context: Context) : super(context) {
@@ -574,6 +579,10 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     fun setOnMediaDeletedListener(listener: OnMediaDeletedListener) {
         this.onMediaDeletedListener = listener
+    }
+
+    fun setOnVideoPressInfoRequestedListener(listener: OnVideoPressInfoRequestedListener) {
+        this.onVideoPressInfoRequestedListener = listener
     }
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -869,6 +869,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     private fun loadVideos() {
         val spans = this.text.getSpans(0, text.length, AztecVideoSpan::class.java)
         val loadingDrawable = ContextCompat.getDrawable(context, drawableLoading)
+        val videoPressListenerRef = this.onVideoPressInfoRequestedListener
 
         spans.forEach {
             val callbacks = object : Html.VideoThumbnailGetter.Callbacks {
@@ -892,6 +893,11 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 }
             }
             videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)
+
+            // Call the VideoPress and ask for more info about the current video. We need the real src.
+            if (it.attributes.hasAttribute("videopress_inner_id")) {
+                videoPressListenerRef?.onVideoPressInfoRequested(it.attributes.getValue("videopress_inner_id"))
+            }
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -894,9 +894,9 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             }
             videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)
 
-            // Call the VideoPress and ask for more info about the current video. We need the real src.
-            if (it.attributes.hasAttribute("videopress_inner_id")) {
-                videoPressListenerRef?.onVideoPressInfoRequested(it.attributes.getValue("videopress_inner_id"))
+            // Call the VideoPress listener and ask for more info about the current video. We need the real src.
+            if (it.attributes.hasAttribute(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID)) {
+                videoPressListenerRef?.onVideoPressInfoRequested(it.attributes.getValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID))
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -902,11 +902,9 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     fun updateVideoPressThumb(thumbURL: String, videoURL: String, videoPressID: String) {
+        val loadingDrawable = ContextCompat.getDrawable(context, drawableLoading)
         val callbacks = object : Html.ImageGetter.Callbacks {
-            override fun onImageFailed() {
-            }
-
-            override fun onImageLoaded(drawable: Drawable?) {
+            private fun replaceImage(drawable: Drawable?) {
                 val spans = text.getSpans(0, text.length, AztecVideoSpan::class.java)
                 spans.forEach {
                     if (it.attributes.hasAttribute(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) &&
@@ -922,7 +920,16 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 }
             }
 
+            override fun onImageFailed() {
+                replaceImage(ContextCompat.getDrawable(context, drawableFailed))
+            }
+
+            override fun onImageLoaded(drawable: Drawable?) {
+                replaceImage(drawable)
+            }
+
             override fun onImageLoading(drawable: Drawable?) {
+                replaceImage(drawable ?: loadingDrawable)
             }
         }
         imageGetter?.loadImage(thumbURL, callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -901,7 +901,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         }
     }
 
-    fun updateVideoPressThumb(thumbURL: String, videoPressID: String) {
+    fun updateVideoPressThumb(thumbURL: String, videoURL: String, videoPressID: String) {
         val callbacks = object : Html.ImageGetter.Callbacks {
             override fun onImageFailed() {
             }
@@ -913,7 +913,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                             it.attributes.getValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) == videoPressID) {
 
                         // Set the hidden videopress source. Used when the video is tapped
-                        it.attributes.setValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC, thumbURL)
+                        it.attributes.setValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC, videoURL)
                         it.drawable = drawable
                     }
                 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -901,6 +901,33 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         }
     }
 
+    fun updateVideoPressThumb(thumbURL: String, videoPressID: String) {
+        val callbacks = object : Html.ImageGetter.Callbacks {
+            override fun onImageFailed() {
+            }
+
+            override fun onImageLoaded(drawable: Drawable?) {
+                val spans = text.getSpans(0, text.length, AztecVideoSpan::class.java)
+                spans.forEach {
+                    if (it.attributes.hasAttribute(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) &&
+                            it.attributes.getValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) == videoPressID) {
+
+                        // Set the hidden videopress source. Used when the video is tapped
+                        it.attributes.setValue(Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC, thumbURL)
+                        it.drawable = drawable
+                    }
+                }
+                post {
+                    refreshText()
+                }
+            }
+
+            override fun onImageLoading(drawable: Drawable?) {
+            }
+        }
+        imageGetter?.loadImage(thumbURL, callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)
+    }
+
     // returns regular or "calypso" html depending on the mode
     fun toHtml(withCursorTag: Boolean = false): String {
         val html = toPlainHtml(withCursorTag)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
@@ -13,6 +13,4 @@ object Constants {
     val NEWLINE_STRING = "" + NEWLINE
     val END_OF_BUFFER_MARKER = ZWJ_CHAR
     val END_OF_BUFFER_MARKER_STRING = "" + ZWJ_CHAR
-    val ATTRIBUTE_VIDEOPRESS_HIDDEN_ID = "videopress_hidden_id"
-    val ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC = "videopress_hidden_src"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Constants.kt
@@ -13,4 +13,6 @@ object Constants {
     val NEWLINE_STRING = "" + NEWLINE
     val END_OF_BUFFER_MARKER = ZWJ_CHAR
     val END_OF_BUFFER_MARKER_STRING = "" + ZWJ_CHAR
+    val ATTRIBUTE_VIDEOPRESS_HIDDEN_ID = "videopress_hidden_id"
+    val ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC = "videopress_hidden_src"
 }

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
@@ -6,14 +6,69 @@ import org.wordpress.aztec.plugins.visual2html.IHtmlPostprocessor
 class VideoShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
 
     private val TAG = "video"
+    private val TAG_VIDEOPRESS_SHORTCODE = "wpvideo"
+    private val TAG_VIDEOPRESS_INNER_ID = "videopress_inner_id"
+
+    private fun fromVidePressShortCodeToHTML(source: MatchResult): String {
+        val match = source.groupValues.get(1)
+        val splittedMatch = match.split(" ")
+        var attributesBuilder = StringBuilder()
+        attributesBuilder.append("<$TAG ")
+
+
+        splittedMatch.forEach {
+            if (!it.isBlank()) {
+                if (it.contains('=')) {
+                    attributesBuilder.append(it)
+                } else {
+                    // This is the videopress ID
+                    attributesBuilder.append("$TAG_VIDEOPRESS_INNER_ID=" + it)
+                }
+                attributesBuilder.append(' ')
+            }
+        }
+
+        attributesBuilder.append(" />")
+        return attributesBuilder.toString()
+    }
 
     override fun beforeHtmlProcessed(source: String): String {
-        return source.replace(Regex("(?<!\\[)\\[$TAG([^\\]]*)\\](?!\\])"), "<$TAG$1 />")
+        var newSource = source.replace(Regex("(?<!\\[)\\[$TAG([^\\]]*)\\](?!\\])"), "<$TAG$1 />")
+        newSource = newSource.replace(Regex("(?<!\\[)\\[$TAG_VIDEOPRESS_SHORTCODE([^\\]]*)\\](?!\\])"), { it -> fromVidePressShortCodeToHTML(it) })
+        return newSource
+    }
+
+    private fun fromHTMLToShortcode(source: MatchResult): String {
+        val match = source.groupValues.get(1)
+        val splittedMatch = match.split(" ")
+        var attributesBuilder = StringBuilder()
+
+        var isVideoPress = false
+        splittedMatch.forEach {
+            if (!it.isBlank()) {
+                if (it.contains(TAG_VIDEOPRESS_INNER_ID)) {
+                    // This is the videopress ID attribute
+                    val splitted = it.split("=")
+                    if (splitted.size == 2) {
+                        // just make sure there is a correct ID
+                        attributesBuilder.append(splitted[1].replace("\"", ""))
+                        isVideoPress = true
+                    }
+                } else {
+                    attributesBuilder.append(it)
+                }
+                attributesBuilder.append(' ')
+            }
+        }
+
+        val shotcodeTag = if (isVideoPress) TAG_VIDEOPRESS_SHORTCODE else TAG
+        return "[$shotcodeTag " + attributesBuilder.toString().trim() + "]"
     }
 
     override fun onHtmlProcessed(source: String): String {
-        return StringBuilder(source)
-                .replace(Regex("<$TAG([^>]*(?<! )) */>"), "[$TAG$1]")
-                .replace(Regex("<$TAG([^>]*(?<! )) *></$TAG>"), "[$TAG$1]")
+        var newSource = StringBuilder(source)
+                .replace(Regex("<$TAG([^>]*(?<! )) */>"), { it -> fromHTMLToShortcode(it) })
+                .replace(Regex("<$TAG([^>]*(?<! )) */>"), { it -> fromHTMLToShortcode(it) })
+        return newSource
     }
 }

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
@@ -1,7 +1,7 @@
 package org.wordpress.aztec.plugins.shortcodes
 
-import org.wordpress.aztec.Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID
-import org.wordpress.aztec.Constants.ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC
+import org.wordpress.aztec.plugins.shortcodes.extensions.ATTRIBUTE_VIDEOPRESS_HIDDEN_ID
+import org.wordpress.aztec.plugins.shortcodes.extensions.ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC
 import org.wordpress.aztec.plugins.html2visual.IHtmlPreprocessor
 import org.wordpress.aztec.plugins.visual2html.IHtmlPostprocessor
 

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
@@ -12,9 +12,8 @@ class VideoShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
     private fun fromVidePressShortCodeToHTML(source: MatchResult): String {
         val match = source.groupValues.get(1)
         val splittedMatch = match.split(" ")
-        var attributesBuilder = StringBuilder()
+        val attributesBuilder = StringBuilder()
         attributesBuilder.append("<$TAG ")
-
 
         splittedMatch.forEach {
             if (!it.isBlank()) {
@@ -41,7 +40,7 @@ class VideoShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
     private fun fromHTMLToShortcode(source: MatchResult): String {
         val match = source.groupValues.get(1)
         val splittedMatch = match.split(" ")
-        var attributesBuilder = StringBuilder()
+        val attributesBuilder = StringBuilder()
 
         var isVideoPress = false
         splittedMatch.forEach {
@@ -66,7 +65,7 @@ class VideoShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
     }
 
     override fun onHtmlProcessed(source: String): String {
-        var newSource = StringBuilder(source)
+        val newSource = StringBuilder(source)
                 .replace(Regex("<$TAG([^>]*(?<! )) */>"), { it -> fromHTMLToShortcode(it) })
                 .replace(Regex("<$TAG([^>]*(?<! )) */>"), { it -> fromHTMLToShortcode(it) })
         return newSource

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
@@ -74,8 +74,8 @@ class VideoShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
                         isVideoPress = true
                     }
                 } else if (it.contains(ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC)) {
-                    // nope do nothing. It's just used to keep a reference to the real src and use in it in
-                    // apps to play the video
+                    // nope - do nothing. It's just used to keep a reference to the real src of the video,
+                    // and use it to play the video in the apps
                 } else {
                     attributesBuilder.append(it)
                 }

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/VideoPressExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/VideoPressExtensions.kt
@@ -1,0 +1,44 @@
+package org.wordpress.aztec.plugins.shortcodes.extensions
+
+import android.graphics.drawable.Drawable
+import android.support.v4.content.ContextCompat
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.Html
+import org.wordpress.aztec.spans.AztecVideoSpan
+
+val ATTRIBUTE_VIDEOPRESS_HIDDEN_ID = "videopress_hidden_id"
+val ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC = "videopress_hidden_src"
+
+fun AztecText.updateVideoPressThumb(thumbURL: String, videoURL: String, videoPressID: String) {
+    val loadingDrawable = ContextCompat.getDrawable(context, this.drawableLoading)
+    val callbacks = object : Html.ImageGetter.Callbacks {
+        private fun replaceImage(drawable: Drawable?) {
+            val spans = text.getSpans(0, text.length, AztecVideoSpan::class.java)
+            spans.forEach {
+                if (it.attributes.hasAttribute(ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) &&
+                        it.attributes.getValue(ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) == videoPressID) {
+
+                    // Set the hidden videopress source. Used when the video is tapped
+                    it.attributes.setValue(ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC, videoURL)
+                    it.drawable = drawable
+                }
+            }
+            post {
+                refreshText()
+            }
+        }
+
+        override fun onImageFailed() {
+            replaceImage(ContextCompat.getDrawable(context, drawableFailed))
+        }
+
+        override fun onImageLoaded(drawable: Drawable?) {
+            replaceImage(drawable)
+        }
+
+        override fun onImageLoading(drawable: Drawable?) {
+            replaceImage(drawable ?: loadingDrawable)
+        }
+    }
+    imageGetter?.loadImage(thumbURL, callbacks, this.maxImagesWidth, this.minImagesWidth)
+}


### PR DESCRIPTION
This PR adds support for VideoPress short codes. Fixes #469

Since VideoPress videos don't have high usage in the app (it's actually a rarities) i've decided to not introduce a new shortcode class, instead playing around the already available VideoShortcodePlugin code. 
This PR just adds 2 hidden attributes (removed when switching to HTML or posting) and use those attributes to ask for video's thumb, update the video placeholder when the App returns back with the actual poster image, and use the original src when a video is tapped.

### Test
1. Open the demo app
2. See videopress videos at the bottom
They should get updated once the app is started.
3. switch to HTML mode and check that there aren't unexpected attributes added to them 

I've already a first working demo branch of wp-android. Need to fix some issue with uploading a new video.

### Review
@0nko 