### PR TITLE
Caption-deleting fix

### DIFF
--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/CaptionShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/CaptionShortcodePlugin.kt
@@ -59,6 +59,10 @@ class CaptionShortcodePlugin @JvmOverloads constructor(private val aztecText: Az
                     }
                 }
                 output.setSpan(span, wrapper.start, output.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+                if (wrapper.end - wrapper.start == 1) {
+                    wrapper.remove()
+                }
             }
         }
         return true

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
@@ -51,6 +51,11 @@ class CaptionWatcher(private val aztecText: AztecText) : BlockElementWatcher(azt
                 }
             }
 
+            if (it.start < aztecText.length() && aztecText.text[it.start] != Constants.IMG_CHAR) {
+                it.remove()
+                return@forEach
+            }
+
             // if a caption's ending doesn't align with an ending of a line immediately following an image, align them
             // if the last line is the end of the text, make the caption end there
             val firstNewline = aztecText.text.indexOf(Constants.NEWLINE, it.start)

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
@@ -51,11 +51,13 @@ class CaptionWatcher(private val aztecText: AztecText) : BlockElementWatcher(azt
                 }
             }
 
+            // remove captions that are not attached to any image
             if (it.start < aztecText.length() && aztecText.text[it.start] != Constants.IMG_CHAR) {
                 it.remove()
                 return@forEach
             }
 
+            // remove captions that are blank
             if (count == 0 && it.span.caption.isBlank() && !aztecText.isTextChangedListenerDisabled()) {
                 it.remove()
                 return@forEach

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
@@ -56,6 +56,11 @@ class CaptionWatcher(private val aztecText: AztecText) : BlockElementWatcher(azt
                 return@forEach
             }
 
+            if (count == 0 && it.span.caption.isBlank() && !aztecText.isTextChangedListenerDisabled()) {
+                it.remove()
+                return@forEach
+            }
+
             // if a caption's ending doesn't align with an ending of a line immediately following an image, align them
             // if the last line is the end of the text, make the caption end there
             val firstNewline = aztecText.text.indexOf(Constants.NEWLINE, it.start)

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
@@ -468,4 +468,37 @@ class ImageCaptionTest {
         Assert.assertNull(newAttrs.getValue("align"))
         Assert.assertNull(newAttrs.getValue("aaa"))
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun testEmptyCaptionRemoval() {
+        Assert.assertTrue(safeEmpty(editText))
+
+        val html = IMG_HTML
+        editText.fromHtml(html)
+
+        editText.text.delete(2, 9)
+        Assert.assertEquals(editText.toPlainHtml(), "<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" /><br>test<br>test2")
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testEmptyHtmlCaption() {
+        Assert.assertTrue(safeEmpty(editText))
+
+        val html = IMG_HTML.replace("Caption", "")
+        editText.fromHtml(html)
+        Assert.assertEquals(editText.toPlainHtml(), "<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />test<br>test2")
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testCaptionWithLinebreaks() {
+        Assert.assertTrue(safeEmpty(editText))
+
+        val html = "[caption align=\"alignright\" width=\"100\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" /><br>Cap<br>tion<br>[/caption]test<br>test2"
+        val expectedHtml = "[caption align=\"alignright\" width=\"100\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />Cap tion[/caption]test<br>test2"
+        editText.fromHtml(html)
+        Assert.assertEquals(editText.toPlainHtml(), expectedHtml)
+    }
 }


### PR DESCRIPTION
Fixes #573, #536 and #574.

Empty captions are not allowed anymore. As soon as the text gets deleted, the span is removed as well.