### PR TITLE
Add the text that caused RuntimeException in AztecText.toPlainHtml to crash reports

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -46,6 +46,7 @@ import android.view.WindowManager
 import android.view.inputmethod.BaseInputConnection
 import android.widget.EditText
 import org.wordpress.android.util.AppLog
+import org.wordpress.aztec.exceptions.SpannableStringBuilderExceptionsWrapper
 import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.formatting.InlineFormatter
 import org.wordpress.aztec.formatting.LineBlockFormatter
@@ -920,9 +921,10 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             output = SpannableStringBuilder(text)
         } catch (e: java.lang.ArrayIndexOutOfBoundsException) {
             // FIXME: Remove this log once we've data to replicate the issue, and fix it in some way.
-            AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 for details. " +
-                    "Following is the text that caused the issue " + text)
-            throw e
+            val message = "There was an error creating SpannableStringBuilder. See #452 for details. " +
+                    "Following is the text that caused the issue " + text
+            AppLog.e(AppLog.T.EDITOR, message)
+            throw SpannableStringBuilderExceptionsWrapper(message, e)
         }
 
         clearMetaSpans(output)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/exceptions/SpannableStringBuilderExceptionsWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/exceptions/SpannableStringBuilderExceptionsWrapper.kt
@@ -1,0 +1,3 @@
+package org.wordpress.aztec.exceptions
+
+class SpannableStringBuilderExceptionsWrapper(message: String?, cause: Throwable?) : Exception(message, cause)


### PR DESCRIPTION
This PR just adds the text that caused the issue to crash reports, and keep letting the app crash.
We need to remove the log line once we've enough data to replicate it. I've added a FIXME there to remember us to remove it.

This is an addition to the previous PR here #571 where we had added the text to the log of the app only, but not the exceptions stack, so it was not reported in Crashlytics.
Original report of the issue #452
