### PR TITLE
Fix crashes that occur selecting and cutting all the text when captions were available in text

### DIFF
--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/watchers/CaptionWatcher.kt
@@ -58,7 +58,7 @@ class CaptionWatcher(private val aztecText: AztecText) : BlockElementWatcher(azt
             }
 
             // remove captions that are blank
-            if (count == 0 && it.span.caption.isBlank() && !aztecText.isTextChangedListenerDisabled()) {
+            if (it.start < aztecText.length() && count == 0 && it.span.caption.isBlank() && !aztecText.isTextChangedListenerDisabled()) {
                 it.remove()
                 return@forEach
             }


### PR DESCRIPTION
Fix #588 by making sure the spanWrapper starts at valid position in the available text.