### PR TITLE
Unknown element tap fix

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1261,11 +1261,16 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             disableTextChangedListener()
 
             text.removeSpan(unknownHtmlSpan)
-            text.replace(spanStart, spanStart + 1, textBuilder)
-
             val unknownClickSpan = text.getSpans(spanStart, spanStart + 1, UnknownClickableSpan::class.java).firstOrNull()
             if (unknownClickSpan != null) {
                 text.removeSpan(unknownClickSpan)
+            }
+
+            text.replace(spanStart, spanStart + 1, textBuilder)
+
+            val newUnknownSpan = textBuilder.getSpans(0, textBuilder.length, UnknownHtmlSpan::class.java).firstOrNull()
+            if (newUnknownSpan != null) {
+                newUnknownSpan.onUnknownHtmlTappedListener = this
             }
 
             enableTextChangedListener()


### PR DESCRIPTION
Fixes a problem when the unknown element editor dialog wouldn't show up after previously opening and saving the unknown element.

To reproduce:
1. Tap an unknown element
2. Tap Save on the dialog
3. Try tapping on the unknown element again
4. A dialog should pop up again