### PR TITLE
Fix Image/Video Placeholders dimensions

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -865,7 +865,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     private fun loadImages() {
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
-        val loadingDrawable =  AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
+        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
 
         spans.forEach {
             val callbacks = object : Html.ImageGetter.Callbacks {
@@ -896,7 +896,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     private fun loadVideos() {
         val spans = this.text.getSpans(0, text.length, AztecVideoSpan::class.java)
-        val loadingDrawable =  AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
+        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
         val videoListenerRef = this.onVideoInfoRequestedListener
 
         spans.forEach {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -876,7 +876,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 }
 
                 override fun onImageLoaded(drawable: Drawable?) {
-                    //replaceImage(drawable)
+                    replaceImage(drawable)
                 }
 
                 override fun onImageLoading(drawable: Drawable?) {


### PR DESCRIPTION
This PR makes sure that image/video loading and error placeholders are drawn on the screen by using the `max-pictures-width` dimension set in Aztec. In this way placeholders are going to match the real dimension of the pictures much closer than before. This is a fix for https://github.com/wordpress-mobile/WordPress-Android/issues/6942, especially for failed image requests where the placeholder icon was so small.

cc @mzorz 

Note: I think a real fix for this is to patch `AztecDynamicImageSpan` and friends, and make sure that those will respect the `setBounds` values set with a simple `loadingDrawable.setBounds(0,0, maxImageWidthForVisualEditor, maxImageWidthForVisualEditor)`. That at the moment doesn't work fine. This patch works fine since it does convert it to a bitmap with the correct size, that are then drawn on the screen. 