### PR TITLE
Video - Make sure to show the correct bitmap once loaded from the network

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -906,7 +906,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 }
 
                 override fun onThumbnailLoaded(drawable: Drawable?) {
-                    //replaceImage(drawable)
+                    replaceImage(drawable)
                 }
 
                 override fun onThumbnailLoading(drawable: Drawable?) {


### PR DESCRIPTION
This was an issue introduced in #593 where I left commented the line of code that actually replaces the placeholder with the correct bitmap.

cc @mzorz 