### PR TITLE
Fix Video/Image error placeholder size when Aztec is used in apps

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -864,15 +864,15 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     private fun loadImages() {
-        val maxDimension = maxImagesWidth
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
-        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxDimension)
+        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
 
+        val maxDimension = maxImagesWidth
         spans.forEach {
             val callbacks = object : Html.ImageGetter.Callbacks {
                 override fun onImageFailed() {
                     replaceImage(
-                            AztecText.getPlaceholderDrawableFromResID(context, drawableFailed, maxDimension)
+                            AztecText.getPlaceholderDrawableFromResID(context, drawableFailed, maxImagesWidth)
                     )
                 }
 
@@ -891,16 +891,16 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            imageGetter?.loadImage(it.getSource(), callbacks, maxDimension, maxDimension)
+            imageGetter?.loadImage(it.getSource(), callbacks, maxDimension, minImagesWidth)
         }
     }
 
     private fun loadVideos() {
-        val maxDimension = maxImagesWidth
         val spans = this.text.getSpans(0, text.length, AztecVideoSpan::class.java)
-        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxDimension)
+        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
         val videoListenerRef = this.onVideoInfoRequestedListener
 
+        val maxDimension = maxImagesWidth
         spans.forEach {
             val callbacks = object : Html.VideoThumbnailGetter.Callbacks {
                 override fun onThumbnailFailed() {
@@ -922,7 +922,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, maxDimension, maxDimension)
+            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, maxImagesWidth, minImagesWidth)
 
             // Call the Video listener and ask for more info about the current video
             videoListenerRef?.onVideoInfoRequested(it.attributes)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -864,14 +864,15 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     private fun loadImages() {
+        val maxDimension = maxImagesWidth
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
-        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
+        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxDimension)
 
         spans.forEach {
             val callbacks = object : Html.ImageGetter.Callbacks {
                 override fun onImageFailed() {
                     replaceImage(
-                            AztecText.getPlaceholderDrawableFromResID(context, drawableFailed, maxImagesWidth)
+                            AztecText.getPlaceholderDrawableFromResID(context, drawableFailed, maxDimension)
                     )
                 }
 
@@ -890,19 +891,20 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            imageGetter?.loadImage(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)
+            imageGetter?.loadImage(it.getSource(), callbacks, maxDimension, maxDimension)
         }
     }
 
     private fun loadVideos() {
+        val maxDimension = maxImagesWidth
         val spans = this.text.getSpans(0, text.length, AztecVideoSpan::class.java)
-        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
+        val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxDimension)
         val videoListenerRef = this.onVideoInfoRequestedListener
 
         spans.forEach {
             val callbacks = object : Html.VideoThumbnailGetter.Callbacks {
                 override fun onThumbnailFailed() {
-                    AztecText.getPlaceholderDrawableFromResID(context, drawableFailed, maxImagesWidth)
+                    AztecText.getPlaceholderDrawableFromResID(context, drawableFailed, maxDimension)
                 }
 
                 override fun onThumbnailLoaded(drawable: Drawable?) {
@@ -920,7 +922,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                     }
                 }
             }
-            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, this@AztecText.maxImagesWidth, this@AztecText.minImagesWidth)
+            videoThumbnailGetter?.loadVideoThumbnail(it.getSource(), callbacks, maxDimension, maxDimension)
 
             // Call the Video listener and ask for more info about the current video
             videoListenerRef?.onVideoInfoRequested(it.attributes)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -867,6 +867,8 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
         val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
 
+        // Make sure to keep a reference to the maxWidth, otherwise in the Callbacks there is
+        // the wrong value when used in 3rd party app
         val maxDimension = maxImagesWidth
         spans.forEach {
             val callbacks = object : Html.ImageGetter.Callbacks {
@@ -900,6 +902,8 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val loadingDrawable = AztecText.getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
         val videoListenerRef = this.onVideoInfoRequestedListener
 
+        // Make sure to keep a reference to the maxWidth, otherwise in the Callbacks there is
+        // the wrong value when used in 3rd party app
         val maxDimension = maxImagesWidth
         spans.forEach {
             val callbacks = object : Html.VideoThumbnailGetter.Callbacks {


### PR DESCRIPTION
This PR fixes an issue where the error placeholder was always created at default 48DP dimensions, even though a different dimension was set fine by 3rd part app.

I bet it's something going wrong the way the value was referenced inside the `forEach` loop. It was reading the value of `maxImagesWidth` set during `init`. 

## To Test
- Update `wp-android` and reference this hash
```
    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:d9f1926f63d48c83da2405725410977a97064fb7')
    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:d9f1926f63d48c83da2405725410977a97064fb7')
    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:d9f1926f63d48c83da2405725410977a97064fb7')
```
- On the web, create a new post with a 404 picture on it. EX `src="https://eritreocazzulati.files.wordpress.com/2018/01/img_20180107_141620.std.jpg`
- Start wp-android and edit the post
- The error placeholder should appear in the correct dimensions and not too small 

### Review
@mzorz 
  