### PR TITLE
Add the ability to log the content in case of crashes

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -364,6 +364,7 @@ open class MainActivity : AppCompatActivity(),
                 .setOnAudioTappedListener(this)
                 .setOnMediaDeletedListener(this)
                 .setOnVideoInfoRequestedListener(this)
+                .enableCrashLogging(this)
                 .addPlugin(WordPressCommentsPlugin(visualEditor))
                 .addPlugin(MoreToolbarButton(visualEditor))
                 .addPlugin(PageToolbarButton(visualEditor))

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -407,6 +407,11 @@ open class MainActivity : AppCompatActivity(),
         showActionBarIfNeeded()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        aztec.visualEditor.disableCrashLogging()
+    }
+
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecExceptionHandler
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Html
 import org.wordpress.aztec.IHistoryListener
@@ -375,7 +376,11 @@ open class MainActivity : AppCompatActivity(),
 
         // initialize the text & HTML
         if (!isRunningTest) {
-            aztec.visualEditor.enableCrashLogging(this)
+            aztec.visualEditor.enableCrashLogging(object : AztecExceptionHandler.ExceptionHandlerHelper {
+                override fun shouldLog(ex: Throwable): Boolean {
+                    return true
+                }
+            })
             aztec.visualEditor.setCalypsoMode(false)
             aztec.sourceEditor?.setCalypsoMode(false)
 

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -364,7 +364,6 @@ open class MainActivity : AppCompatActivity(),
                 .setOnAudioTappedListener(this)
                 .setOnMediaDeletedListener(this)
                 .setOnVideoInfoRequestedListener(this)
-                .enableCrashLogging(this)
                 .addPlugin(WordPressCommentsPlugin(visualEditor))
                 .addPlugin(MoreToolbarButton(visualEditor))
                 .addPlugin(PageToolbarButton(visualEditor))
@@ -376,6 +375,7 @@ open class MainActivity : AppCompatActivity(),
 
         // initialize the text & HTML
         if (!isRunningTest) {
+            aztec.visualEditor.enableCrashLogging(this)
             aztec.visualEditor.setCalypsoMode(false)
             aztec.sourceEditor?.setCalypsoMode(false)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -23,6 +23,8 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     private var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener? = null
     private var plugins: ArrayList<IAztecPlugin> = visualEditor.plugins
+    private var uncaughtExceptionHandler: AztecExceptionHandler? = null
+
     var sourceEditor: SourceViewEditText? = null
 
     init {
@@ -67,8 +69,13 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     }
 
     fun enableCrashLogging(act: Activity) : Aztec {
-        AztecExceptionHandler(act, visualEditor)
+        this.uncaughtExceptionHandler = AztecExceptionHandler(act, visualEditor)
         return this
+    }
+
+    fun disableCrashLogging(act: Activity) {
+        this.uncaughtExceptionHandler?.restoreDefault()
+        this.uncaughtExceptionHandler = null
     }
 
     fun setImageGetter(imageGetter: Html.ImageGetter): Aztec {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -66,6 +66,11 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
         }
     }
 
+    fun enableCrashLogging(act: Activity) : Aztec {
+        AztecExceptionHandler(act, visualEditor)
+        return this
+    }
+
     fun setImageGetter(imageGetter: Html.ImageGetter): Aztec {
         this.imageGetter = imageGetter
         initImageGetter()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -23,8 +23,6 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
     private var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener? = null
     private var plugins: ArrayList<IAztecPlugin> = visualEditor.plugins
-    private var uncaughtExceptionHandler: AztecExceptionHandler? = null
-
     var sourceEditor: SourceViewEditText? = null
 
     init {
@@ -66,16 +64,6 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: A
         fun with(visualEditor: AztecText, toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener): Aztec {
             return Aztec(visualEditor, toolbar, toolbarClickListener)
         }
-    }
-
-    fun enableCrashLogging(act: Activity) : Aztec {
-        this.uncaughtExceptionHandler = AztecExceptionHandler(act, visualEditor)
-        return this
-    }
-
-    fun disableCrashLogging(act: Activity) {
-        this.uncaughtExceptionHandler?.restoreDefault()
-        this.uncaughtExceptionHandler = null
     }
 
     fun setImageGetter(imageGetter: Html.ImageGetter): Aztec {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -24,4 +24,8 @@ class AztecExceptionHandler(private val activity: Activity, private val visualEd
 
         rootHandler?.uncaughtException(thread, ex)
     }
+
+    fun restoreDefault() {
+        Thread.setDefaultUncaughtExceptionHandler(rootHandler)
+    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -1,10 +1,13 @@
 package org.wordpress.aztec
 
-import android.app.Activity
 import org.wordpress.android.util.AppLog
 import java.lang.Thread.UncaughtExceptionHandler
 
-class AztecExceptionHandler(private val activity: Activity, private val visualEditor: AztecText) : UncaughtExceptionHandler {
+class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper, private val visualEditor: AztecText) : UncaughtExceptionHandler {
+
+    interface ExceptionHandlerHelper {
+        fun shouldLog(ex: Throwable) : Boolean
+    }
 
     // Store the current exception handler
     private val rootHandler: Thread.UncaughtExceptionHandler? = Thread.getDefaultUncaughtExceptionHandler()
@@ -15,11 +18,21 @@ class AztecExceptionHandler(private val activity: Activity, private val visualEd
     }
 
     override fun uncaughtException(thread: Thread, ex: Throwable) {
-        // Try to report the HTML code of the content, but do not report exceptions that can occur logging the content
+        // Check if we should log the content or not
+        var shouldLog = true
         try {
-            AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash " + visualEditor?.toPlainHtml(false))
+            shouldLog = logHelper.shouldLog(ex)
         } catch (e: Throwable) {
-            AppLog.e(AppLog.T.EDITOR, "Visual Content of Aztec Editor before the crash " + visualEditor?.text)
+            AppLog.w(AppLog.T.EDITOR, "There was an exception in the Logger Helper. Set the logging to true" )
+        }
+
+        if (shouldLog) {
+            // Try to report the HTML code of the content, but do not report exceptions that can occur logging the content
+            try {
+                AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash " + visualEditor.toPlainHtml(false))
+            } catch (e: Throwable) {
+                AppLog.e(AppLog.T.EDITOR, "Visual Content of Aztec Editor before the crash " + visualEditor.text)
+            }
         }
 
         rootHandler?.uncaughtException(thread, ex)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -3,7 +3,7 @@ package org.wordpress.aztec
 import org.wordpress.android.util.AppLog
 import java.lang.Thread.UncaughtExceptionHandler
 
-class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper, private val visualEditor: AztecText) : UncaughtExceptionHandler {
+class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, private val visualEditor: AztecText) : UncaughtExceptionHandler {
 
     interface ExceptionHandlerHelper {
         fun shouldLog(ex: Throwable) : Boolean
@@ -21,7 +21,7 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper, priva
         // Check if we should log the content or not
         var shouldLog = true
         try {
-            shouldLog = logHelper.shouldLog(ex)
+            shouldLog = logHelper?.shouldLog(ex) ?: true
         } catch (e: Throwable) {
             AppLog.w(AppLog.T.EDITOR, "There was an exception in the Logger Helper. Set the logging to true" )
         }
@@ -38,7 +38,7 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper, priva
         rootHandler?.uncaughtException(thread, ex)
     }
 
-    fun restoreDefault() {
+    fun restoreDefaultHandler() {
         Thread.setDefaultUncaughtExceptionHandler(rootHandler)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -1,0 +1,27 @@
+package org.wordpress.aztec
+
+import android.app.Activity
+import org.wordpress.android.util.AppLog
+import java.lang.Thread.UncaughtExceptionHandler
+
+class AztecExceptionHandler(private val activity: Activity, private val visualEditor: AztecText) : UncaughtExceptionHandler {
+
+    // Store the current exception handler
+    private val rootHandler: Thread.UncaughtExceptionHandler? = Thread.getDefaultUncaughtExceptionHandler()
+
+    init {
+        // we replace the exception handler now with us -- we will properly dispatch the exceptions ...
+        Thread.setDefaultUncaughtExceptionHandler(this)
+    }
+
+    override fun uncaughtException(thread: Thread, ex: Throwable) {
+        // Try to report the HTML code of the content, but do not report exceptions that can occur logging the content
+        try {
+            AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash " + visualEditor?.toPlainHtml(false))
+        } catch (e: Throwable) {
+            AppLog.e(AppLog.T.EDITOR, "Visual Content of Aztec Editor before the crash " + visualEditor?.text)
+        }
+
+        rootHandler?.uncaughtException(thread, ex)
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -18,7 +18,6 @@
 package org.wordpress.aztec
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -1533,8 +1532,8 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         enableObservationQueue()
     }
 
-    fun enableCrashLogging(act: Activity) {
-        this.uncaughtExceptionHandler = AztecExceptionHandler(act, this)
+    fun enableCrashLogging(helper: AztecExceptionHandler.ExceptionHandlerHelper) {
+        this.uncaughtExceptionHandler = AztecExceptionHandler(helper, this)
     }
 
     fun disableCrashLogging() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -18,6 +18,7 @@
 package org.wordpress.aztec
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -215,6 +216,8 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     var observationQueue: ObservationQueue = ObservationQueue(this)
     var textWatcherEventBuilder: TextWatcherEvent.Builder = TextWatcherEvent.Builder()
+
+    private var uncaughtExceptionHandler: AztecExceptionHandler? = null
 
     interface OnSelectionChangedListener {
         fun onSelectionChanged(selStart: Int, selEnd: Int)
@@ -1528,5 +1531,14 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         }
 
         enableObservationQueue()
+    }
+
+    fun enableCrashLogging(act: Activity) {
+        this.uncaughtExceptionHandler = AztecExceptionHandler(act, this)
+    }
+
+    fun disableCrashLogging() {
+        this.uncaughtExceptionHandler?.restoreDefault()
+        this.uncaughtExceptionHandler = null
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1537,7 +1537,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     fun disableCrashLogging() {
-        this.uncaughtExceptionHandler?.restoreDefault()
+        this.uncaughtExceptionHandler?.restoreDefaultHandler()
         this.uncaughtExceptionHandler = null
     }
 }


### PR DESCRIPTION
Fixes #558 by adding a global exception handler that logs all the content of the editor in case of crashes.
Also adds an interface that can be used by 3rd party apps, to enable/disable log on a per case basis. The global exception handler, before logging the content, asks if it should be logged or not.

### Test
- Force an exception in MainActivity, and check Logcat. It should contains the content of the editor.

