### PR TITLE
Fix Crash Report - IndexOutOfBoundsException in InlineFormatter

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -4,6 +4,7 @@ import android.graphics.Typeface
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
+import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecPart
 import org.wordpress.aztec.AztecText
@@ -159,7 +160,13 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle) : AztecFormat
         joinStyleSpans(start, end)
     }
 
-    fun applySpan(span: IAztecInlineSpan, start: Int, end: Int, type: Int) {
+    private fun applySpan(span: IAztecInlineSpan, start: Int, end: Int, type: Int) {
+        if (start > end) {
+            AppLog.w(AppLog.T.EDITOR, "InlineFormatter.applySpan - setSpan has end before start." +
+                    " Start:" + start + " End:" + end)
+            AppLog.w(AppLog.T.EDITOR, "Logging the whole content" + editor.toPlainHtml())
+            return
+        }
         editableText.setSpan(span, start, end, type)
         span.applyInlineStyleAttributes(editableText, start, end)
     }


### PR DESCRIPTION
This PR fixes #600 by making sure start > end before applying the span.
We're just logging the error, and the whole content, for now. 

In a further PR will try to add a way to report this kind of error to the 3rd party apps that integrated Aztec, so it will be easy for us in wp-android to call Crashlytics and log the error without crashing the app. Maybe this way we can provide a real fix for this, since we will have the text that causes the problem and the indexes.

Btw, the original report was about an old version of the code, but it was easy to find the correct line where the crash happens in the current release. 