### PR TITLE
Add the ability for apps to set an external logger

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -56,6 +56,7 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
+import org.wordpress.aztec.util.AztecLog
 import org.xml.sax.Attributes
 import java.io.File
 import java.util.Random
@@ -332,6 +333,15 @@ open class MainActivity : AppCompatActivity(),
         val visualEditor = findViewById<AztecText>(R.id.aztec)
         val sourceEditor = findViewById<SourceViewEditText>(R.id.source)
         val toolbar = findViewById<AztecToolbar>(R.id.formatting_toolbar)
+
+        visualEditor.externalLogger = object : AztecLog.ExternalLogger {
+            override fun log(message: String) {
+            }
+            override fun logException(tr: Throwable) {
+            }
+            override fun logException(tr: Throwable, message: String) {
+            }
+        }
 
         val galleryButton = MediaToolbarGalleryButton(toolbar)
         galleryButton.setMediaToolbarButtonClickListener(object : IMediaToolbarButton.IMediaToolbarClickListener {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -84,6 +84,7 @@ import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.spans.UnknownClickableSpan
 import org.wordpress.aztec.spans.UnknownHtmlSpan
 import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.util.AztecLog
 import org.wordpress.aztec.util.SpanWrapper
 import org.wordpress.aztec.util.coerceToHtmlText
 import org.wordpress.aztec.watchers.BlockElementWatcher
@@ -171,6 +172,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     private var onAudioTappedListener: OnAudioTappedListener? = null
     private var onMediaDeletedListener: OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: OnVideoInfoRequestedListener? = null
+    var externalLogger: AztecLog.ExternalLogger? = null
 
     private var isViewInitialized = false
     private var isLeadingStyleRemoved = false

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -162,6 +162,14 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle) : AztecFormat
 
     private fun applySpan(span: IAztecInlineSpan, start: Int, end: Int, type: Int) {
         if (start > end) {
+            // If an external logger is available log the error there.
+            val extLogger = editor.externalLogger
+            if (extLogger != null) {
+                extLogger.log("InlineFormatter.applySpan - setSpan has end before start." +
+                        " Start:" + start + " End:" + end)
+                extLogger.log("Logging the whole content" + editor.toPlainHtml())
+            }
+            // Now log in the default log
             AppLog.w(AppLog.T.EDITOR, "InlineFormatter.applySpan - setSpan has end before start." +
                     " Start:" + start + " End:" + end)
             AppLog.w(AppLog.T.EDITOR, "Logging the whole content" + editor.toPlainHtml())

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
@@ -1,0 +1,9 @@
+package org.wordpress.aztec.util
+
+class AztecLog {
+    interface ExternalLogger {
+        fun log(message : String)
+        fun logException(tr : Throwable)
+        fun logException(tr : Throwable, message : String)
+    }
+}


### PR DESCRIPTION
This PR adds the ability for apps that use Aztec to set an external logger on the editor.

The external logger should be used to track important errors and info only. In our case we should use it in wp-android to keep tracks of some exceptions and messages in Crashlytics.

This PR already adds the logger to track InlineFormatter span issues.