### PR TITLE
Make sure all OS-originated .DS_Store files are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ annotations/
 !/.idea/externalDependencies.xml
 
 # OS generated
-/.DS_Store
+.DS_Store
 
 # Kotlin lint
 ktlint


### PR DESCRIPTION
This PR just makes sure that OS-generated files `.DS_Store` in any directory (not just project root) are ignored in git.