### PR TITLE
External logger for applySpan bug: using logException instead of log

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -165,14 +165,16 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle) : AztecFormat
             // If an external logger is available log the error there.
             val extLogger = editor.externalLogger
             if (extLogger != null) {
-                extLogger.log("InlineFormatter.applySpan - setSpan has end before start." +
-                        " Start:" + start + " End:" + end)
-                extLogger.log("Logging the whole content" + editor.toPlainHtml())
+                // logging all the data in 1 exception to reduce possibility of information not travelling to Crashlytics
+                extLogger.logException(Exception("InlineFormatter.applySpan - setSpan has end before start." +
+                        " Start: " + start + " End: " + end))
+
+                extLogger.logException(Exception("InlineFormatter.applySpan - Logging the whole content: " + editor.toPlainHtml()))
             }
             // Now log in the default log
             AppLog.w(AppLog.T.EDITOR, "InlineFormatter.applySpan - setSpan has end before start." +
-                    " Start:" + start + " End:" + end)
-            AppLog.w(AppLog.T.EDITOR, "Logging the whole content" + editor.toPlainHtml())
+                    " Start: " + start + " End: " + end)
+            AppLog.w(AppLog.T.EDITOR, "Logging the whole content: " + editor.toPlainHtml())
             return
         }
         editableText.setSpan(span, start, end, type)


### PR DESCRIPTION
This is something I've been checking while testing https://github.com/wordpress-mobile/WordPress-Android/pull/7119

According to Crashlytics docs, it seems that just adding a normal logging only enqueues the log to be sent in batch to Crashlytics the next time the app crashes at some point.

https://docs.fabric.io/android/crashlytics/enhanced-reports.html?#custom-logging

`In addition to writing to the next crash report…`

I believe we should be doing something like the following thing instead:
https://docs.fabric.io/android/crashlytics/caught-exceptions.html?caught%20exceptions#caught-exceptions

Also note these two notes:

`For any individual app session, only the most recent 8 logged exceptions are stored.` (in https://docs.fabric.io/android/crashlytics/caught-exceptions.html?caught%20exceptions#caught-exceptions)

and

`To make sure that sending crash reports has the smallest impact on your user’s devices, Crashlytics logs have a maximum size of 64 KB. When a log exceeds 64 KB, the earliest logged values will be dropped in order to maintain this threshold.` (https://docs.fabric.io/android/crashlytics/enhanced-reports.html?#custom-logging)


This makes me think we should probably change the approach and, given that a single Post could potentially be larger than 64 kb, and given we can’t store many logs but need to make the app crash (or catch an exception and log it manually with Crashlytics.logException for the info to be sent), something like this change in this PR would probably be more useful for the case at hand in AztecText.

What do you think @daniloercoli ? Hope that makes sense, let’s chat otherwise :thumbsup: 


