### PR TITLE
[Crash Report] Fix Cut & Paste IndexOutOfBoundsException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0.1) - 2018-01-22
+### Fixed
+- Crash when pasting certain text
+
 ## [1.0](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0) - 2018-01-11
 ### Fixed
 - Various problems when editing captions

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -886,12 +886,16 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     // Helper ======================================================================================
 
     fun consumeCursorPosition(text: SpannableStringBuilder): Int {
-        var cursorPosition = Math.min(selectionStart, length())
+        var cursorPosition = Math.min(selectionStart, text.length)
 
         text.getSpans(0, text.length, AztecCursorSpan::class.java).forEach {
             cursorPosition = text.getSpanStart(it)
             text.removeSpan(it)
         }
+
+        // Make sure the cursor position is a valid one
+        cursorPosition = Math.min(cursorPosition, text.length)
+        cursorPosition = Math.max(0, cursorPosition)
 
         return cursorPosition
     }
@@ -912,10 +916,12 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             it.textView = this
         }
 
+        val cursorPosition = consumeCursorPosition(builder)
+        setSelection(0)
+
         setTextKeepState(builder)
         enableTextChangedListener()
 
-        val cursorPosition = consumeCursorPosition(builder)
         setSelection(cursorPosition)
 
         loadImages()


### PR DESCRIPTION
This PR fixes #612 by making sure a correct cursor position is set when pasting content. 

Actually the new code is used in the `fromHTML` method, so it's used in a lot of places and not only when pasting new content. This PR keeps a reference to the correct cursor position, reset it to 0, refreshes the text by calling `setTextKeepState`, and set again the correct cursor position.

For the reference I was not able to reproduce the issue reported in the ticket.