### PR TITLE
 Fix for History slowness

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -411,10 +411,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 setText("")
                 enableTextChangedListener()
             }
-
-            if (!consumeHistoryEvent) {
-                history.handleHistory(this@AztecText)
-            }
         }
         return wasStyleRemoved
     }
@@ -480,8 +476,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 if (consumeHistoryEvent) {
                     consumeHistoryEvent = false
                 }
-
-                history.handleHistory(this@AztecText)
             }
         }
         addTextChangedListener(historyLoggingWatcher)
@@ -816,8 +810,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                         .forEach { it.toggle() }
             }
         }
-
-        history.handleHistory(this)
     }
 
     fun contains(format: ITextFormat, selStart: Int = selectionStart, selEnd: Int = selectionEnd): Boolean {
@@ -1296,8 +1288,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste + "<" + AztecCursorSpan.AZTEC_CURSOR_TAG + ">")
 
                 fromHtml(newHtml)
-                history.handleHistory(this@AztecText)
-
                 inlineFormatter.joinStyleSpans(0, length())
             }
         }
@@ -1325,7 +1315,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         } else {
             linkFormatter.addLink(url, anchor, selectionStart, selectionEnd)
         }
-        history.handleHistory(this)
     }
 
     fun removeLink() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -397,7 +397,9 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         var wasStyleRemoved = false
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_DEL) {
             if (!consumeHistoryEvent) {
-                history.beforeTextChanged(toFormattedHtml())
+                if (historyEnable) {
+                    history.beforeTextChanged(this@AztecText)
+                }
             }
             wasStyleRemoved = blockFormatter.tryRemoveBlockStyleFromFirstLine()
 
@@ -464,7 +466,9 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
                 if (!isViewInitialized) return
                 if (!isTextChangedListenerDisabled() && !consumeHistoryEvent) {
-                    history.beforeTextChanged(toFormattedHtml())
+                    if (historyEnable) {
+                        history.beforeTextChanged(this@AztecText)
+                    }
                 }
             }
             override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
@@ -790,7 +794,9 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     fun toggleFormatting(textFormat: ITextFormat) {
-        history.beforeTextChanged(toFormattedHtml())
+        if (historyEnable) {
+            history.beforeTextChanged(this@AztecText)
+        }
 
         when (textFormat) {
             AztecTextFormat.FORMAT_PARAGRAPH,
@@ -1259,7 +1265,9 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val clip = clipboard.primaryClip
 
         if (clip != null) {
-            history.beforeTextChanged(toFormattedHtml())
+            if (historyEnable) {
+                history.beforeTextChanged(this@AztecText)
+            }
 
             disableTextChangedListener()
 
@@ -1311,7 +1319,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     fun link(url: String, anchor: String) {
-        history.beforeTextChanged(toFormattedHtml())
+        history.beforeTextChanged(this@AztecText)
         if (TextUtils.isEmpty(url) && linkFormatter.isUrlSelected()) {
             removeLink()
         } else if (linkFormatter.isUrlSelected()) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -397,9 +397,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         var wasStyleRemoved = false
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_DEL) {
             if (!consumeHistoryEvent) {
-                if (historyEnable) {
-                    history.beforeTextChanged(this@AztecText)
-                }
+                history.beforeTextChanged(this@AztecText)
             }
             wasStyleRemoved = blockFormatter.tryRemoveBlockStyleFromFirstLine()
 
@@ -466,9 +464,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
                 if (!isViewInitialized) return
                 if (!isTextChangedListenerDisabled() && !consumeHistoryEvent) {
-                    if (historyEnable) {
-                        history.beforeTextChanged(this@AztecText)
-                    }
+                    history.beforeTextChanged(this@AztecText)
                 }
             }
             override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
@@ -794,9 +790,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     fun toggleFormatting(textFormat: ITextFormat) {
-        if (historyEnable) {
-            history.beforeTextChanged(this@AztecText)
-        }
+        history.beforeTextChanged(this@AztecText)
 
         when (textFormat) {
             AztecTextFormat.FORMAT_PARAGRAPH,
@@ -1271,9 +1265,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val clip = clipboard.primaryClip
 
         if (clip != null) {
-            if (historyEnable) {
-                history.beforeTextChanged(this@AztecText)
-            }
+            history.beforeTextChanged(this@AztecText)
 
             disableTextChangedListener()
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -38,13 +38,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
             mainHandler.removeCallbacks(historyRunnable)
             if (!textChangedPending) {
                 textChangedPending = true
-                val text =
-                        when (editText) {
-                            is AztecText -> editText.toFormattedHtml()
-                            is SourceViewEditText -> editText.text.toString()
-                            else -> ""
-                        }
-                historyRunnable?.text = text
+                historyRunnable?.editText = editText
             }
             mainHandler.postDelayed(historyRunnable, historyThrottleTime)
         }
@@ -202,9 +196,20 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
      * Only updates the history stack after a present of milliseconds has passed.
      */
     inner class HistoryRunnable(val history: History) : Runnable {
-        var text: String = ""
+        var editText: EditText? =  null
 
         override fun run() {
+            if (editText == null) {
+                return
+            }
+            val myEditText = editText
+            val text =
+                    when (myEditText) {
+                        is AztecText -> myEditText.toFormattedHtml()
+                        is SourceViewEditText -> myEditText.text.toString()
+                        else -> ""
+                    }
+
             history.doHandleHistory(text)
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -33,11 +33,17 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
         }
     }
 
-    fun beforeTextChanged(text: String) {
+    fun beforeTextChanged(editText: EditText) {
         if (historyEnabled && !historyWorking) {
             mainHandler.removeCallbacks(historyRunnable)
             if (!textChangedPending) {
                 textChangedPending = true
+                val text =
+                        when (editText) {
+                            is AztecText -> editText.toFormattedHtml()
+                            is SourceViewEditText -> editText.text.toString()
+                            else -> ""
+                        }
                 historyRunnable?.text = text
             }
             mainHandler.postDelayed(historyRunnable, historyThrottleTime)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -196,8 +196,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
      * Only updates the history stack after a present of milliseconds has passed.
      */
     inner class HistoryRunnable(val history: History) : Runnable {
-        var editText: EditText? =  null
-
+        var editText: EditText? = null
         override fun run() {
             if (editText == null) {
                 return

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -22,7 +22,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
     private var textChangedPending = false
 
     // Time in ms to wait before applying change history to the stack
-    var historyThrottleTime = 900L
+    var historyThrottleTime = 500L
 
     init {
         if (historyEnabled) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -139,8 +139,6 @@ class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatc
             enableTextChangedListener()
             return
         }
-
-        history?.handleHistory(this)
         styleTextWatcher?.afterTextChanged(text)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -124,7 +124,7 @@ class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatc
 
     override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
         if (!isTextChangedListenerDisabled()) {
-            history?.beforeTextChanged(text.toString())
+            history?.beforeTextChanged(this)
         }
 
         styleTextWatcher?.beforeTextChanged(text, start, count, after)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/BlockElementWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/BlockElementWatcher.kt
@@ -36,7 +36,7 @@ open class BlockElementWatcher(aztecText: AztecText) : TextWatcher {
                     // save the text state before the funky business, then skip the history
                     val aztecText = aztecTextRef.get()
                     aztecText?.let {
-                        aztecText.history.beforeTextChanged(aztecText.toFormattedHtml())
+                        aztecText.history.beforeTextChanged(it)
                         aztecText.consumeHistoryEvent = false
 
                         spans.forEach {


### PR DESCRIPTION
This PR improves the way we're storing visual editor content in the History class (to be used later for undo/redo). 
Before this PR the visual editor stored its content into History almost on each key pressed, and the call to retrieve the HTML code from it required some time, resulting in UI lags on devices.

In details: 
- Postpone as later as possible all the calls to the visual editor method `toFormattedHtml()` in `AztecText.history.beforeTextChanged(toFormattedHtml())`. Before this PR `toFormattedHtml()` was called on every input, even if the resulting string was discarded due to History off, or being processed.
- Do not call `history.handleHistory` on each key pressed event, deleting event. But keep the runnable/handle in the history class to do the work

I run all the tests on this PR without any problem, but I guess the History now, that I changed the lag to 900ms, could be less reliable than before (since we're rely on the lag time only to execute the code that stores content in history stack).
In any case the lag on my devices is WAYYY less noticeable now.

cc @mzorz Ready fro review.