### PR TITLE
Only care for collecting TextWatcher events for the correct platforms

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -857,7 +857,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     private fun isEventObservableCandidate() : Boolean {
-        return (!bypassObservationQueue && (watchersNestingLevel == 1))
+        return (observationQueue.hasActiveBuckets() && !bypassObservationQueue && (watchersNestingLevel == 1))
     }
 
     override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/ObservationQueue.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/ObservationQueue.kt
@@ -18,6 +18,10 @@ class ObservationQueue(val injector: IEventInjector) : EventSequence<TextWatcher
          */
     }
 
+    fun hasActiveBuckets() : Boolean {
+        return buckets.size > 0
+    }
+
     override fun add(element: TextWatcherEvent): Boolean {
         synchronized(this@ObservationQueue) {
             val added: Boolean = super.add(element)


### PR DESCRIPTION
Good catch @daniloercoli - we were collecting events in the `ObservationQueue` on every platform, even when there were no active buckets for a specific platform per se.

This PR takes care of checking there are active buckets for the ObservationQueue before attempting to add a copy of the event to it.

### Test
On API < 26 (i.e. Android 7.x or anything less than 8)
1. put  a breakpoint in line 869 in `beforeTextChanged` in AztecText.kt
2. type something
3. notice it should never stop execution there

On API == 26/27
1. put  a breakpoint in line 869 in `beforeTextChanged` in AztecText.kt
2. type something
3. notice it should  stop execution there.

### Review
@daniloercoli 