### PR TITLE
Fix formatting disappears on API25 when inserting space before formatted text

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/buckets/API25Bucket.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/buckets/API25Bucket.kt
@@ -2,7 +2,7 @@ package org.wordpress.aztec.watchers.event.buckets
 
 import org.wordpress.aztec.watchers.event.sequence.known.space.API25InWordSpaceInsertionEvent
 
-class API26Bucket : Bucket() {
+class API25Bucket : Bucket() {
     init {
         // constructor - here add all identified sequences for this bucket
         userOperations.add(API25InWordSpaceInsertionEvent())

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/ObservationQueue.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/ObservationQueue.kt
@@ -2,6 +2,7 @@ package org.wordpress.aztec.watchers.event.sequence
 
 import android.os.Build
 import org.wordpress.aztec.watchers.event.IEventInjector
+import org.wordpress.aztec.watchers.event.buckets.API25Bucket
 import org.wordpress.aztec.watchers.event.buckets.API26Bucket
 import org.wordpress.aztec.watchers.event.buckets.Bucket
 import org.wordpress.aztec.watchers.event.text.TextWatcherEvent
@@ -12,6 +13,8 @@ class ObservationQueue(val injector: IEventInjector) : EventSequence<TextWatcher
     init {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             buckets.add(API26Bucket())
+        } else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N_MR1) {
+            buckets.add(API25Bucket())
         }
         /*
             remember to add here any other buckets and init logic as suitable, depending on the context

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/known/space/API25InWordSpaceInsertionEvent.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/known/space/API25InWordSpaceInsertionEvent.kt
@@ -11,7 +11,7 @@ import org.wordpress.aztec.watchers.event.text.TextWatcherEvent
 /*
  This case implements the behavior observed in https://github.com/wordpress-mobile/AztecEditor-Android/issues/555
  */
-class API26InWordSpaceInsertionEvent : UserOperationEvent() {
+class API25InWordSpaceInsertionEvent : UserOperationEvent() {
     private val SPACE = ' '
     private val SPACE_STRING = "" + SPACE
     private val MAXIMUM_TIME_BETWEEN_EVENTS_IN_PATTERN_MS = 50
@@ -35,7 +35,7 @@ class API26InWordSpaceInsertionEvent : UserOperationEvent() {
         val builderStep4 = TextWatcherEventInsertText.Builder()
         val step4 = builderStep4.build()
 
-        // add each of the steps that make up for the identified API26InWordSpaceInsertionEvent here
+        // add each of the steps that make up for the identified API25InWordSpaceInsertionEvent here
         clear()
         addSequenceStep(step1)
         addSequenceStep(step2)


### PR DESCRIPTION
This PR fixes #530 (Formatting disappears when inserting space before formatted text) for API25 platform.

Previously it was enabled on API26+ only.

### Test
- In the editor
- Type "a"
- Toggle bold style
- Type "b"
- Place cursor between "a" and "b"
- Add a space
- Note that the bold formatting is preserved

### Review
@0nko 