### PR TITLE
Log Aztec details when HTML is not available

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -1,6 +1,7 @@
 package org.wordpress.aztec
 
 import org.wordpress.android.util.AppLog
+import org.wordpress.aztec.util.AztecLog
 import java.lang.Thread.UncaughtExceptionHandler
 
 class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, private val visualEditor: AztecText) : UncaughtExceptionHandler {
@@ -31,7 +32,8 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, priv
             try {
                 AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash " + visualEditor.toPlainHtml(false))
             } catch (e: Throwable) {
-                AppLog.e(AppLog.T.EDITOR, "Visual Content of Aztec Editor before the crash " + visualEditor.text)
+                AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash is unavailable, log the details instead")
+                AztecLog.logEditorContentDetails(visualEditor)
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1047,8 +1047,8 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             output = SpannableStringBuilder(text)
         } catch (e: java.lang.ArrayIndexOutOfBoundsException) {
             // FIXME: Remove this log once we've data to replicate the issue, and fix it in some way.
-            AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 for details. " +
-                    "Following is the text that caused the issue " + text)
+            AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 for details.")
+            // No need to log the exception here. There is the ExceptionHandler that does this for us.
             throw e
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1048,7 +1048,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         } catch (e: java.lang.ArrayIndexOutOfBoundsException) {
             // FIXME: Remove this log once we've data to replicate the issue, and fix it in some way.
             AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 for details.")
-            // No need to log the exception here. There is the ExceptionHandler that does this for us.
+            // No need to log the exception here. The ExceptionHandler does this for us.
             throw e
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
@@ -1,9 +1,42 @@
 package org.wordpress.aztec.util
 
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import org.wordpress.android.util.AppLog
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.spans.IAztecAttributedSpan
+
 class AztecLog {
     interface ExternalLogger {
         fun log(message : String)
         fun logException(tr : Throwable)
         fun logException(tr : Throwable, message : String)
+    }
+
+    companion object {
+        fun logEditorContentDetails(aztecText: AztecText) {
+            try {
+                val logContentJSON = JSONObject()
+                logContentJSON.put("content", aztecText.text.toString())
+                logContentJSON.put("length", aztecText.text.length)
+                val spansJSON = JSONArray()
+                val spans = aztecText.text.getSpans(0, aztecText.text.length, IAztecAttributedSpan::class.java)
+                spans.forEach {
+                    val currenSpanJSON = JSONObject()
+                    currenSpanJSON.put("clasz", it.javaClass.name)
+                    currenSpanJSON.put("start", aztecText.text.getSpanStart(it))
+                    currenSpanJSON.put("end", aztecText.text.getSpanEnd(it))
+                    currenSpanJSON.put("flags", aztecText.text.getSpanFlags(it))
+                    spansJSON.put(currenSpanJSON)
+                }
+                logContentJSON.put("spans", spansJSON)
+                AppLog.d(AppLog.T.EDITOR, "Below are the details of the content in the editor:")
+                AppLog.d(AppLog.T.EDITOR, logContentJSON.toString())
+            } catch (e: JSONException) {
+                AppLog.e(AppLog.T.EDITOR, "Uhh ohh! There was an error logging the content of the Editor. This should" +
+                        "never happen.", e)
+            }
+        }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
@@ -5,7 +5,6 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.AztecText
-import org.wordpress.aztec.spans.IAztecAttributedSpan
 
 class AztecLog {
     interface ExternalLogger {
@@ -21,7 +20,7 @@ class AztecLog {
                 logContentJSON.put("content", aztecText.text.toString())
                 logContentJSON.put("length", aztecText.text.length)
                 val spansJSON = JSONArray()
-                val spans = aztecText.text.getSpans(0, aztecText.text.length, IAztecAttributedSpan::class.java)
+                val spans = aztecText.text.getSpans(0, aztecText.text.length, Any::class.java)
                 spans.forEach {
                     val currenSpanJSON = JSONObject()
                     currenSpanJSON.put("clasz", it.javaClass.name)


### PR DESCRIPTION
Adds the ability to log details of the editor when HTML representation of content is not available. This could happen in case of errors in `toHTML` method of `AztecText`, that is used to get the HTML code of the content.

### Review
@0nko 