### PR TITLE
Fix order of multiple media

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -174,7 +174,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
 
         // We need to be sure the cursor is placed correctly after media insertion
         // Note that media has '\n' around them when needed
-        val isLastItem = if (selectionEnd == EndOfBufferMarkerAdder.safeLength(editor)) { true } else false
+        val isLastItem = selectionEnd == EndOfBufferMarkerAdder.safeLength(editor)
         editableText.replace(selectionStart, selectionEnd, ssb)
 
         val newSelection = if (isLastItem) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -172,10 +172,17 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
                 Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
         )
 
+        // We need to be sure the cursor is placed correctly after media insertion
+        // Note that media has '\n' around them when needed
+        val isLastItem = if (selectionEnd == EndOfBufferMarkerAdder.safeLength(editor)) { true } else false
         editableText.replace(selectionStart, selectionEnd, ssb)
 
-        editor.setSelection(
-                if (selectionEnd < EndOfBufferMarkerAdder.safeLength(editor)) selectionEnd + 1 else selectionEnd)
+        val newSelection = if (isLastItem) {
+            EndOfBufferMarkerAdder.safeLength(editor)
+        } else {
+            if (selectionEnd < EndOfBufferMarkerAdder.safeLength(editor)) selectionEnd + 1 else selectionEnd
+        }
+        editor.setSelection(newSelection)
         editor.isMediaAdded = true
     }
 }


### PR DESCRIPTION
This PR fixes #627 by making sure the cursor is correctly placed in the editor when media is added to it.

Before this PR there was an issue where starting from an empty editor, and adding 2 media to it, resulting in a cursor placed between the 1st and the 2nd picture. Then if you added a 3rd picture to the editor, it was being added in between the two before. As reported in `wp-android`.


**Before this PR**
-*Insert first media*
`newSelection` = 1 and text length=1 (correct, only one item in the editor, no new line at the end).

-*Insert second media*
`newSelection` = 2 1 and text length=3 (incorrect, the cursor is being placed in between the pictures). newSelection should be 3.

After this PR `newSelection` is being calculated correctly.



