### PR TITLE
Try to fix - Missing padding between blocks

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -135,7 +135,7 @@ open class MainActivity : AppCompatActivity(),
         private val VIDEOPRESS = "[wpvideo OcobLTqC]"
         private val VIDEOPRESS_2 = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true3]"
 
-        private val EXAMPLE =
+        /*private val EXAMPLE =
                 IMG +
                 HEADING +
                 BOLD +
@@ -161,7 +161,8 @@ open class MainActivity : AppCompatActivity(),
                 VIDEOPRESS +
                 VIDEOPRESS_2 +
                 AUDIO +
-                GUTENBERG_CODE_BLOCK
+                GUTENBERG_CODE_BLOCK*/
+        private val EXAMPLE = PREFORMAT + "Hello" + ORDERED + ORDERED + QUOTE + ORDERED + QUOTE + UNORDERED + QUOTE
 
         private val isRunningTest: Boolean by lazy {
             try {

--- a/app/src/main/res/layout-v17/activity_main.xml
+++ b/app/src/main/res/layout-v17/activity_main.xml
@@ -37,7 +37,7 @@
                 android:scrollbars="vertical"
                 android:imeOptions="flagNoExtractUi"
                 android:fontFamily="serif"
-                aztec:historyEnable="true"
+                aztec:historyEnable="false"
                 aztec:historySize="10"/>
 
             <org.wordpress.aztec.source.SourceViewEditText

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
                 android:paddingTop="16dp"
                 android:scrollbars="vertical"
                 android:imeOptions="flagNoExtractUi"
-                aztec:historyEnable="true"
+                aztec:historyEnable="false"
                 aztec:historySize="10"/>
 
             <org.wordpress.aztec.source.SourceViewEditText

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -20,14 +20,37 @@ abstract class AztecListSpan(override var nestingLevel: Int,
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
+        // Edge lines are made longer during the drawing phase
+        val topDelta = getTopMarginDelta(text, start)
         if (start == spanStart || start < spanStart) {
-            fm.ascent -= verticalPadding
-            fm.top -= verticalPadding
+            fm.ascent -= (verticalPadding + topDelta)
+            fm.top -= (verticalPadding + topDelta)
         }
+        val bottomDelta = getBottomMarginDelta(text, end)
         if (end == spanEnd || spanEnd < end) {
-            fm.descent += verticalPadding
-            fm.bottom += verticalPadding
+            fm.descent += (verticalPadding + bottomDelta)
+            fm.bottom += (verticalPadding + bottomDelta)
         }
+    }
+
+    private fun getTopMarginDelta(text: CharSequence?, start: Int) : Int {
+        if (text == null) return 0
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        if (start == spanStart || start < spanStart) {
+            return 20
+        }
+        return 0
+    }
+
+    private fun getBottomMarginDelta(text: CharSequence?, end: Int) : Int {
+        if (text == null) return 0
+        val spanned = text as Spanned
+        val spanEnd = spanned.getSpanEnd(this)
+        if (end == spanEnd || spanEnd < end) {
+            return 20
+        }
+        return 0
     }
 
     fun getIndexOfProcessedLine(text: CharSequence, end: Int): Int {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -33,15 +33,38 @@ class AztecPreformatSpan(
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
+        // Edge lines are made longer during the drawing phase
+        val topDelta = getTopMarginDelta(text, start)
         if (start == spanStart || start < spanStart) {
-            fm.ascent -= preformatStyle.verticalPadding
-            fm.top -= preformatStyle.verticalPadding
+            fm.ascent -= (preformatStyle.verticalPadding + topDelta)
+            fm.top -= (preformatStyle.verticalPadding + topDelta)
         }
 
+        val bottomDelta = getBottomMarginDelta(text, end)
         if (end == spanEnd || spanEnd < end) {
-            fm.descent += preformatStyle.verticalPadding
-            fm.bottom += preformatStyle.verticalPadding
+            fm.descent += (preformatStyle.verticalPadding + bottomDelta)
+            fm.bottom += (preformatStyle.verticalPadding + bottomDelta)
         }
+    }
+
+    private fun getTopMarginDelta(text: CharSequence?, start: Int) : Int {
+        if (text == null) return 0
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        if (start == spanStart || start < spanStart) {
+            return 10
+        }
+        return 0
+    }
+
+    private fun getBottomMarginDelta(text: CharSequence?, end: Int) : Int {
+        if (text == null) return 0
+        val spanned = text as Spanned
+        val spanEnd = spanned.getSpanEnd(this)
+        if (end == spanEnd || spanEnd < end) {
+            return 10
+        }
+        return 0
     }
 
     override fun drawBackground(canvas: Canvas, paint: Paint, left: Int, right: Int, top: Int, baseline: Int, bottom: Int, text: CharSequence?, start: Int, end: Int, lnum: Int) {
@@ -53,7 +76,7 @@ class AztecPreformatSpan(
                 Color.green(preformatStyle.preformatBackground),
                 Color.blue(preformatStyle.preformatBackground)
         )
-        rect.set(left, top, right, bottom)
+        rect.set(left, top + getTopMarginDelta(text, start), right, bottom - getBottomMarginDelta(text, end))
         canvas.drawRect(rect, paint)
         paint.color = color
     }
@@ -65,7 +88,8 @@ class AztecPreformatSpan(
         paint.style = Paint.Style.FILL
         paint.color = preformatStyle.preformatColor
 
-        canvas.drawRect(x.toFloat() + MARGIN, top.toFloat(), (x + MARGIN).toFloat(), bottom.toFloat(), paint)
+        canvas.drawRect(x.toFloat() + MARGIN, top.toFloat() + + getTopMarginDelta(text, start),
+                (x + MARGIN).toFloat(), bottom.toFloat() - getBottomMarginDelta(text, end), paint)
 
         paint.style = style
         paint.color = color

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -50,6 +50,7 @@ class AztecQuoteSpan(
             fm.ascent -= (quoteStyle.verticalPadding + topDelta)
             fm.top -= (quoteStyle.verticalPadding + topDelta)
         }
+
         val bottomDelta = getBottomMarginDelta(text, end)
         if (bottomDelta != 0) {
             fm.descent += (quoteStyle.verticalPadding + bottomDelta)
@@ -85,7 +86,7 @@ class AztecQuoteSpan(
         if (text == null) return 0
         val spanned = text as Spanned
         val spanEnd = spanned.getSpanEnd(this)
-        if (end == spanEnd || spanEnd-1 == end  || spanEnd < end) {
+        if (end == spanEnd || spanEnd - 1 == end || spanEnd < end) {
             return 10
         }
         return 0

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -44,22 +44,51 @@ class AztecQuoteSpan(
     override val TAG: String = "blockquote"
 
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
-        val spanned = text as Spanned
-        val spanStart = spanned.getSpanStart(this)
-        val spanEnd = spanned.getSpanEnd(this)
-
-        if (start == spanStart || start < spanStart) {
-            fm.ascent -= quoteStyle.verticalPadding
-            fm.top -= quoteStyle.verticalPadding
+        // Edge lines are made longer during the drawing phase
+        val topDelta = getTopMarginDelta(text, start)
+        if (topDelta != 0) {
+            fm.ascent -= (quoteStyle.verticalPadding + topDelta)
+            fm.top -= (quoteStyle.verticalPadding + topDelta)
         }
-        if (end == spanEnd || spanEnd < end) {
-            fm.descent += quoteStyle.verticalPadding
-            fm.bottom += quoteStyle.verticalPadding
+        val bottomDelta = getBottomMarginDelta(text, end)
+        if (bottomDelta != 0) {
+            fm.descent += (quoteStyle.verticalPadding + bottomDelta)
+            fm.bottom += (quoteStyle.verticalPadding + bottomDelta)
         }
     }
 
     override fun getLeadingMargin(first: Boolean): Int {
         return quoteStyle.quoteMargin + quoteStyle.quoteWidth + quoteStyle.quotePadding
+    }
+
+    private fun getTopMarginDelta(text: CharSequence?, start: Int) : Int {
+        if (text == null) return 0
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        if (start == spanStart || start < spanStart) {
+            return 10
+        }
+        return 0
+    }
+
+    private fun getBottomMarginDelta(text: CharSequence?, end: Int) : Int {
+        if (text == null) return 0
+        val spanned = text as Spanned
+        val spanEnd = spanned.getSpanEnd(this)
+        if (end == spanEnd || spanEnd < end) {
+            return 10
+        }
+        return 0
+    }
+
+    private fun getBottomMarginDeltaForMargin(text: CharSequence?, end: Int) : Int {
+        if (text == null) return 0
+        val spanned = text as Spanned
+        val spanEnd = spanned.getSpanEnd(this)
+        if (end == spanEnd || spanEnd-1 == end  || spanEnd < end) {
+            return 10
+        }
+        return 0
     }
 
     override fun drawLeadingMargin(c: Canvas, p: Paint, x: Int, dir: Int,
@@ -71,8 +100,10 @@ class AztecQuoteSpan(
 
         p.style = Paint.Style.FILL
         p.color = quoteStyle.quoteColor
-        c.drawRect(x.toFloat() + quoteStyle.quoteMargin, top.toFloat(),
-                (x + quoteStyle.quoteMargin + dir * quoteStyle.quoteWidth).toFloat(), bottom.toFloat(), p)
+        c.drawRect(x.toFloat() + quoteStyle.quoteMargin,
+                top.toFloat() + getTopMarginDelta(text, start),
+                (x + quoteStyle.quoteMargin + dir * quoteStyle.quoteWidth).toFloat(),
+                bottom.toFloat() - getBottomMarginDeltaForMargin(text, end), p)
 
         p.style = style
         p.color = color
@@ -90,7 +121,8 @@ class AztecQuoteSpan(
                 Color.red(quoteStyle.quoteBackground),
                 Color.green(quoteStyle.quoteBackground),
                 Color.blue(quoteStyle.quoteBackground))
-        rect.set(left + quoteStyle.quoteMargin, top, right, bottom)
+        rect.set(left + quoteStyle.quoteMargin, top + getTopMarginDelta(text, start),
+                right, bottom - getBottomMarginDelta(text, end))
 
         c.drawRect(rect, p)
         p.color = paintColor


### PR DESCRIPTION
This PR tries to fix the missing margins between blocks (#565) by making edge lines slightly taller, and adapt the background and the leading margin when necessary, during the drawing phase.

Note these are only visual artifacts to simulate top and bottom margins. Unfortunately the cursor heigh is set by the system by using the line height. The drawback of this, is that edge lines also get a slightly taller cursor, that is noticeable on quote and pre-format (not in lists) since there is a BG color applied to them.

This PR is not ready to be merged, the code needs to be refactored avoiding duplicate code, and will do this if we think this is an acceptable solution to fix the issue.

cc @0nko 

The other possible fix to the issue would be adding a new type of visual only span, that just adds spaces between 2 blocks, but it's not easy to do that when inserting new content, or when parsing from HTML. It would complicate the TextWatchers chain even more.