### PR TITLE
"Fix" IOOB handling newline in Headings

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -33,7 +33,7 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, priv
                 AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash " + visualEditor.toPlainHtml(false))
             } catch (e: Throwable) {
                 AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash is unavailable, log the details instead")
-                AztecLog.logEditorContentDetails(visualEditor)
+                AztecLog.logContentDetails(visualEditor)
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
@@ -103,6 +103,10 @@ abstract class BlockHandler<SpanType : IAztecBlockSpan>(val clazz: Class<SpanTyp
             return PositionType.BUFFER_END
         }
 
+        if (atEndOfBlock) {
+            return PositionType.BUFFER_END
+        }
+
         // no special case applied so, newline is in the "body" of the block
         return PositionType.BODY
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
@@ -2,9 +2,11 @@ package org.wordpress.aztec.handlers
 
 import android.text.Spannable
 import android.text.Spanned
+import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.Constants
 import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.spans.IAztecNestable
+import org.wordpress.aztec.util.AztecLog
 import org.wordpress.aztec.util.SpanWrapper
 import org.wordpress.aztec.watchers.BlockElementWatcher.TextChangeHandler
 
@@ -115,6 +117,13 @@ abstract class BlockHandler<SpanType : IAztecBlockSpan>(val clazz: Class<SpanTyp
 
     companion object {
         fun set(text: Spannable, block: IAztecBlockSpan, start: Int, end: Int) {
+            if (start > end) {
+                AppLog.w(AppLog.T.EDITOR, "BlockHandler.set static method called with start > end. Start: " + start + " End: " + end)
+                AppLog.w(AppLog.T.EDITOR, "Invoked with block type of " + block.javaClass.canonicalName)
+                AztecLog.logContentDetails(text)
+                return
+            }
+
             val flags = Spanned.SPAN_PARAGRAPH
             if (SpanWrapper.isInvalidParagraph(text, start, end, flags)) return
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
@@ -103,10 +103,6 @@ abstract class BlockHandler<SpanType : IAztecBlockSpan>(val clazz: Class<SpanTyp
             return PositionType.BUFFER_END
         }
 
-        if (atEndOfBlock) {
-            return PositionType.BUFFER_END
-        }
-
         // no special case applied so, newline is in the "body" of the block
         return PositionType.BODY
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
@@ -1,6 +1,7 @@
 package org.wordpress.aztec.handlers
 
 import android.text.Spannable
+import org.wordpress.aztec.Constants
 import org.wordpress.aztec.spans.AztecHeadingSpan
 import org.wordpress.aztec.watchers.TextDeleter
 
@@ -26,13 +27,25 @@ class HeadingHandler : BlockHandler<AztecHeadingSpan>(AztecHeadingSpan::class.ja
         TextDeleter.mark(text, newlineIndex, newlineIndex + 1)
     }
 
-    override fun handleNewlineAtTextEnd() {
-        block.end = newlineIndex + 1
-    }
+    // fun handleNewlineAtTextEnd()
+    // got a newline while being at the end-of-text. We'll let the current list item engulf it and will wait
+    //  for the end-of-text marker event in order to attach the new list item to it when that happens.
 
     override fun handleNewlineInBody() {
-        // newline added at some position inside the block. Let's split the block into two
-        cloneHeading(text, block.span, newlineIndex + 1, block.end)
+        // if the new newline is the second-last character of the block and the last one is a newline (which
+        // is a visual newline) or the end-of-buffer marker, or it's the last character of the text then it's the last
+        // actual character of the block
+        val atEndOfBlock = (newlineIndex == block.end - 2 &&
+                (text[block.end - 1] == Constants.NEWLINE || text[block.end - 1] == Constants.END_OF_BUFFER_MARKER)) ||
+                newlineIndex == text.length - 1
+
+        if (atEndOfBlock) {
+            // newline added at the end of the block (right before its visual newline) so, just end the block and
+            //  not add a new block after it
+        } else {
+            // newline added at some position inside the block. Let's split the block into two
+            cloneHeading(text, block.span, newlineIndex + 1, block.end)
+        }
 
         block.end = newlineIndex + 1
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
@@ -1,6 +1,7 @@
 package org.wordpress.aztec.handlers
 
 import android.text.Spannable
+import org.wordpress.aztec.Constants
 import org.wordpress.aztec.spans.AztecHeadingSpan
 import org.wordpress.aztec.watchers.TextDeleter
 
@@ -31,7 +32,22 @@ class HeadingHandler : BlockHandler<AztecHeadingSpan>(AztecHeadingSpan::class.ja
     //  for the end-of-text marker event in order to attach the new list item to it when that happens.
 
     override fun handleNewlineInBody() {
-        cloneHeading(text, block.span, newlineIndex + 1, block.end)
+
+        // if the new newline is the second-last character of the block and the last one is a newline (which
+        // is a visual newline) or the end-of-buffer marker, or it's the last character of the text then it's the last
+        // actual character of the block
+        val atEndOfBlock = (newlineIndex == block.end - 2 &&
+                (text[block.end - 1] == Constants.NEWLINE || text[block.end - 1] == Constants.END_OF_BUFFER_MARKER)) ||
+                newlineIndex == text.length - 1
+
+        if (atEndOfBlock) {
+            // newline added at the end of the block (right before its visual newline) so, just end the block and
+            //  not add a new block after it
+        } else {
+            // newline added at some position inside the block. Let's split the block into two
+            cloneHeading(text, block.span, newlineIndex + 1, block.end)
+        }
+
         block.end = newlineIndex + 1
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
@@ -27,8 +27,8 @@ class HeadingHandler : BlockHandler<AztecHeadingSpan>(AztecHeadingSpan::class.ja
     }
 
     override fun handleNewlineAtTextEnd() {
-         block.end = newlineIndex + 1
-     }
+        block.end = newlineIndex + 1
+    }
 
     override fun handleNewlineInBody() {
         // newline added at some position inside the block. Let's split the block into two

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
@@ -1,7 +1,6 @@
 package org.wordpress.aztec.handlers
 
 import android.text.Spannable
-import org.wordpress.aztec.Constants
 import org.wordpress.aztec.spans.AztecHeadingSpan
 import org.wordpress.aztec.watchers.TextDeleter
 
@@ -27,26 +26,13 @@ class HeadingHandler : BlockHandler<AztecHeadingSpan>(AztecHeadingSpan::class.ja
         TextDeleter.mark(text, newlineIndex, newlineIndex + 1)
     }
 
-    // fun handleNewlineAtTextEnd()
-    // got a newline while being at the end-of-text. We'll let the current list item engulf it and will wait
-    //  for the end-of-text marker event in order to attach the new list item to it when that happens.
+    override fun handleNewlineAtTextEnd() {
+         block.end = newlineIndex + 1
+     }
 
     override fun handleNewlineInBody() {
-
-        // if the new newline is the second-last character of the block and the last one is a newline (which
-        // is a visual newline) or the end-of-buffer marker, or it's the last character of the text then it's the last
-        // actual character of the block
-        val atEndOfBlock = (newlineIndex == block.end - 2 &&
-                (text[block.end - 1] == Constants.NEWLINE || text[block.end - 1] == Constants.END_OF_BUFFER_MARKER)) ||
-                newlineIndex == text.length - 1
-
-        if (atEndOfBlock) {
-            // newline added at the end of the block (right before its visual newline) so, just end the block and
-            //  not add a new block after it
-        } else {
-            // newline added at some position inside the block. Let's split the block into two
-            cloneHeading(text, block.span, newlineIndex + 1, block.end)
-        }
+        // newline added at some position inside the block. Let's split the block into two
+        cloneHeading(text, block.span, newlineIndex + 1, block.end)
 
         block.end = newlineIndex + 1
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
@@ -31,14 +31,7 @@ class HeadingHandler : BlockHandler<AztecHeadingSpan>(AztecHeadingSpan::class.ja
     //  for the end-of-text marker event in order to attach the new list item to it when that happens.
 
     override fun handleNewlineInBody() {
-        if (newlineIndex == block.end - 2) {
-            // newline added at the end of the block (right before its visual newline) so, just end the block and
-            //  not add a new block after it
-        } else {
-            // newline added at some position inside the block. Let's split the block into two
-            cloneHeading(text, block.span, newlineIndex + 1, block.end)
-        }
-
+        cloneHeading(text, block.span, newlineIndex + 1, block.end)
         block.end = newlineIndex + 1
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
@@ -1,5 +1,6 @@
 package org.wordpress.aztec.util
 
+import android.text.Spannable
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -14,23 +15,27 @@ class AztecLog {
     }
 
     companion object {
-        fun logEditorContentDetails(aztecText: AztecText) {
+        fun logContentDetails(aztecText: AztecText) {
+            AppLog.d(AppLog.T.EDITOR, "Below are the details of the content in the editor:")
+            logContentDetails(aztecText.text)
+        }
+
+        fun logContentDetails(text: Spannable) {
             try {
                 val logContentJSON = JSONObject()
-                logContentJSON.put("content", aztecText.text.toString())
-                logContentJSON.put("length", aztecText.text.length)
+                logContentJSON.put("content", text.toString())
+                logContentJSON.put("length", text.length)
                 val spansJSON = JSONArray()
-                val spans = aztecText.text.getSpans(0, aztecText.text.length, Any::class.java)
+                val spans = text.getSpans(0, text.length, Any::class.java)
                 spans.forEach {
                     val currenSpanJSON = JSONObject()
-                    currenSpanJSON.put("clasz", it.javaClass.name)
-                    currenSpanJSON.put("start", aztecText.text.getSpanStart(it))
-                    currenSpanJSON.put("end", aztecText.text.getSpanEnd(it))
-                    currenSpanJSON.put("flags", aztecText.text.getSpanFlags(it))
+                    currenSpanJSON.put("clazz", it.javaClass.name)
+                    currenSpanJSON.put("start", text.getSpanStart(it))
+                    currenSpanJSON.put("end", text.getSpanEnd(it))
+                    currenSpanJSON.put("flags", text.getSpanFlags(it))
                     spansJSON.put(currenSpanJSON)
                 }
                 logContentJSON.put("spans", spansJSON)
-                AppLog.d(AppLog.T.EDITOR, "Below are the details of the content in the editor:")
                 AppLog.d(AppLog.T.EDITOR, logContentJSON.toString())
             } catch (e: JSONException) {
                 AppLog.e(AppLog.T.EDITOR, "Uhh ohh! There was an error logging the content of the Editor. This should" +


### PR DESCRIPTION
I was not able to reproduce the issue reported in #629. In this PR I've just added log of the content, and avoided the crash.

I think we can change this behavior, and let the app crash, if we think it will be more useful to replicate the issue, since there now in place an exceptions logger, that bumps the content of the  editor into the log.

While "fixing" this I also noticed there was a check over the position of the text, that I think it should not be there, since the method `handleNewlineInBody` is only called when a new line is added "in body".

cc @0nko 