### PR TITLE
Save big instance data to files instead of the state bundle

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -602,16 +602,13 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     private fun writeTempInstance(filename: String, obj: Any?) {
-        with(File.createTempFile(filename, ".inst", context.getCacheDir())) {
-            deleteOnExit() // just make sure the file gets deleted if we don't do it ourselves
-            with(File(context.getCacheDir(), "$filename.inst")) {
-                with(FileOutputStream(this)) {
-                    with(ObjectOutputStream(this)) {
-                        writeObject(obj)
-                        close()
-                    }
+        with(File(context.getCacheDir(), "$filename.inst")) {
+            with(FileOutputStream(this)) {
+                with(ObjectOutputStream(this)) {
+                    writeObject(obj)
                     close()
                 }
+                close()
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -635,7 +635,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val filename = bundle.getString(cacheFilenameKey(varName))
 
         if (TextUtils.isEmpty(filename)) {
-            return defaultValue;
+            return defaultValue
         }
 
         val file = File(filename)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -603,7 +603,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     private fun writeTempInstance(filename: String, obj: Any?) {
         with(File(context.getCacheDir(), "$filename.inst")) {
-            with(FileOutputStream(this)) {
+            with(FileOutputStream(this, false)) {
                 with(ObjectOutputStream(this)) {
                     writeObject(obj)
                     close()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -605,10 +605,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         with(File.createTempFile(filename, ".inst", context.getCacheDir())) {
             deleteOnExit() // just make sure the file gets deleted if we don't do it ourselves
             with(File(context.getCacheDir(), "$filename.inst")) {
-                if (this.exists()) {
-                    this.createNewFile()
-                }
-
                 with(FileOutputStream(this)) {
                     with(ObjectOutputStream(this)) {
                         writeObject(obj)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -110,7 +110,6 @@ import org.wordpress.aztec.watchers.event.text.TextWatcherEvent
 import org.xml.sax.Attributes
 import java.io.File
 import java.io.FileInputStream
-import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.ObjectInputStream

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -631,12 +631,22 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     private fun <T> readAndPurgeTempInstance(varName: String, defaultValue: T, bundle: Bundle): T {
-        var obj: T = defaultValue
-
         // the full path is kept in the bundle so, get it from there
         val filename = bundle.getString(cacheFilenameKey(varName))
 
-        with(File(filename)) {
+        if (TextUtils.isEmpty(filename)) {
+            return defaultValue;
+        }
+
+        val file = File(filename)
+
+        if (!file.exists()) {
+            return defaultValue
+        }
+
+        var obj: T = defaultValue
+
+        with(file) {
             FileInputStream(this).use { input ->
                 ObjectInputStream(input).use { objectInput ->
                     val r: Any? = objectInput.readObject()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -110,7 +110,9 @@ import org.wordpress.aztec.watchers.event.text.TextWatcherEvent
 import org.xml.sax.Attributes
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.util.ArrayList
@@ -603,12 +605,20 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
     private fun writeTempInstance(filename: String, obj: Any?) {
         with(File(context.getCacheDir(), "$filename.inst")) {
-            with(FileOutputStream(this, false)) {
-                with(ObjectOutputStream(this)) {
-                    writeObject(obj)
+            try {
+                with(FileOutputStream(this, false)) {
+                    with(ObjectOutputStream(this)) {
+                        writeObject(obj)
+                        close()
+                    }
                     close()
                 }
-                close()
+            } catch (e: IOException) {
+                AppLog.w(AppLog.T.EDITOR, "Error trying to write cache file $filename. Exception: ${e.message}" )
+            } catch (e: SecurityException) {
+                AppLog.w(AppLog.T.EDITOR, "Error trying to write cache file $filename. Exception: ${e.message}" )
+            } catch (e: NullPointerException) {
+                AppLog.w(AppLog.T.EDITOR, "Error trying to write cache file $filename. Exception: ${e.message}" )
             }
         }
     }


### PR DESCRIPTION
### Fix
Instead of saving big instance data to the state/bundle, preserve them in files. On state restore, read the data from the files.

This addresses the cases where the system needs to save/restore the AztecText's state, possibly including the case in #561 

### Test
1. In the `MainActivity.kt` change the `EXAMPLE` variable to match [this gist](https://gist.github.com/hypest/def4601866be90b2386aa55b2e95bf37)
2. Run the demo app. The big text will populate the editor.
3. Add a couple of characters in the beginning of text
4. Tap "Home" to background the app
5. Resume the app by using the "Recent apps" button
6. Notice the editor having the text, including the small change introduced in step 3

Feel free to try the steps above without the the fix to observe the demo app crashing with `TransactionTooLargeException`.