### PR TITLE
Make sure big instance data is not stored to the default state/bundle

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -425,7 +425,6 @@ open class MainActivity : AppCompatActivity(),
     override fun onResume() {
         super.onResume()
 
-        aztec.visualEditor.onActivityResumed()
         showActionBarIfNeeded()
     }
 

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -425,6 +425,7 @@ open class MainActivity : AppCompatActivity(),
     override fun onResume() {
         super.onResume()
 
+        aztec.visualEditor.onActivityResumed()
         showActionBarIfNeeded()
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -562,6 +562,10 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         enableTextChangedListener()
     }
 
+    // Do not include the content of the editor when saving state to bundle.
+    // EditText has it `true` by default, and then the content was saved in bundle making the app crashing
+    // due to the TransactionTooLargeException Exception.
+    // The content is saved in tmp files in `onSaveInstanceState`. See: https://github.com/wordpress-mobile/AztecEditor-Android/pull/641
     override fun getFreezesText(): Boolean {
         return false
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -563,7 +563,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     override fun getFreezesText(): Boolean {
-        return false;
+        return false
     }
 
     override fun onSaveInstanceState(): Parcelable {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -135,8 +135,6 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val IS_MEDIA_ADDED_KEY = "IS_MEDIA_ADDED_KEY"
         val RETAINED_HTML_KEY = "RETAINED_HTML_KEY"
 
-        var retainedBundle = Bundle()
-
         val DEFAULT_IMAGE_WIDTH = 800
 
         var watchersNestingLevel: Int = 0
@@ -518,34 +516,18 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val savedState = state as SavedState
         super.onRestoreInstanceState(savedState.superState)
         val customState = savedState.state
-        restoreFromBundle(customState)
+        val array = InstanceStateUtils.readAndPurgeTempInstance<ArrayList<String>>(HISTORY_LIST_KEY, ArrayList<String>(), savedState.state)
+        val list = LinkedList<String>()
 
-        enableTextChangedListener()
-    }
+        list += array
 
-    private fun restoreFromBundle(customState: Bundle) {
-        if (customState.isEmpty) {
-            return
-        }
-        disableTextChangedListener()
-        val array = InstanceStateUtils.readAndPurgeTempInstance<ArrayList<String>>(HISTORY_LIST_KEY, ArrayList<String>(), customState)
-        if (array.size > 0) {
-            val list = LinkedList<String>()
-            list += array
-            history.historyList = list
-        }
-
+        history.historyList = list
         history.historyCursor = customState.getInt(HISTORY_CURSOR_KEY)
-        val lastInput = InstanceStateUtils.readAndPurgeTempInstance<String>(INPUT_LAST_KEY, "", customState)
-        if (!TextUtils.isEmpty(lastInput)) {
-            history.inputLast = lastInput
-        }
+        history.inputLast = InstanceStateUtils.readAndPurgeTempInstance<String>(INPUT_LAST_KEY, "", savedState.state)
         visibility = customState.getInt(VISIBILITY_KEY)
 
-        val retainedHtml = InstanceStateUtils.readAndPurgeTempInstance<String>(RETAINED_HTML_KEY, "", customState)
-        if (!TextUtils.isEmpty(retainedHtml)) {
-            fromHtml(retainedHtml)
-        }
+        val retainedHtml = InstanceStateUtils.readAndPurgeTempInstance<String>(RETAINED_HTML_KEY, "", savedState.state)
+        fromHtml(retainedHtml)
 
         val retainedSelectionStart = customState.getInt(SELECTION_START_KEY)
         val retainedSelectionEnd = customState.getInt(SELECTION_END_KEY)
@@ -569,22 +551,14 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
                 val unknownSpan = text.getSpans(retainedBlockHtmlIndex, retainedBlockHtmlIndex + 1, UnknownHtmlSpan::class.java).firstOrNull()
                 if (unknownSpan != null) {
                     val retainedBlockHtml = InstanceStateUtils.readAndPurgeTempInstance<String>(BLOCK_EDITOR_HTML_KEY, "",
-                            customState)
-                    if (!TextUtils.isEmpty(retainedBlockHtml)) {
-                        showBlockEditorDialog(unknownSpan, retainedBlockHtml)
-                    }
+                            savedState.state)
+                    showBlockEditorDialog(unknownSpan, retainedBlockHtml)
                 }
             }
         }
 
         isMediaAdded = customState.getBoolean(IS_MEDIA_ADDED_KEY)
-    }
 
-    // When the activity is resumed we need to make sure we've a fresh copy of the content
-    // since we've cleared it `onSaveInstance`.
-    fun onActivityResumed () {
-        disableTextChangedListener()
-        restoreFromBundle(retainedBundle)
         enableTextChangedListener()
     }
 
@@ -597,12 +571,9 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         InstanceStateUtils.writeTempInstance(context, externalLogger, RETAINED_HTML_KEY, toHtml(false), bundle)
         bundle.putInt(SELECTION_START_KEY, selectionStart)
         bundle.putInt(SELECTION_END_KEY, selectionEnd)
-        retainedBundle.putAll(bundle)
-
         // disable text listeners and clear the content, otherwise TTL Exception may occur again
         disableTextChangedListener()
         setText("")
-        enableTextChangedListener()
 
         val superState = super.onSaveInstanceState()
         val savedState = SavedState(superState)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -85,6 +85,7 @@ import org.wordpress.aztec.spans.UnknownClickableSpan
 import org.wordpress.aztec.spans.UnknownHtmlSpan
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.util.AztecLog
+import org.wordpress.aztec.util.InstanceStateUtils
 import org.wordpress.aztec.util.SpanWrapper
 import org.wordpress.aztec.util.coerceToHtmlText
 import org.wordpress.aztec.watchers.BlockElementWatcher
@@ -108,12 +109,6 @@ import org.wordpress.aztec.watchers.event.text.BeforeTextChangedEventData
 import org.wordpress.aztec.watchers.event.text.OnTextChangedEventData
 import org.wordpress.aztec.watchers.event.text.TextWatcherEvent
 import org.xml.sax.Attributes
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.io.IOException
-import java.io.ObjectInputStream
-import java.io.ObjectOutputStream
 import java.util.ArrayList
 import java.util.Arrays
 import java.util.LinkedList
@@ -521,17 +516,17 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         val savedState = state as SavedState
         super.onRestoreInstanceState(savedState.superState)
         val customState = savedState.state
-        val array = readAndPurgeTempInstance<ArrayList<String>>(HISTORY_LIST_KEY, ArrayList<String>(), savedState.state)
+        val array = InstanceStateUtils.readAndPurgeTempInstance<ArrayList<String>>(HISTORY_LIST_KEY, ArrayList<String>(), savedState.state)
         val list = LinkedList<String>()
 
         list += array
 
         history.historyList = list
         history.historyCursor = customState.getInt(HISTORY_CURSOR_KEY)
-        history.inputLast = readAndPurgeTempInstance<String>(INPUT_LAST_KEY, "", savedState.state)
+        history.inputLast = InstanceStateUtils.readAndPurgeTempInstance<String>(INPUT_LAST_KEY, "", savedState.state)
         visibility = customState.getInt(VISIBILITY_KEY)
 
-        val retainedHtml = readAndPurgeTempInstance<String>(RETAINED_HTML_KEY, "", savedState.state)
+        val retainedHtml = InstanceStateUtils.readAndPurgeTempInstance<String>(RETAINED_HTML_KEY, "", savedState.state)
         fromHtml(retainedHtml)
 
         val retainedSelectionStart = customState.getInt(SELECTION_START_KEY)
@@ -555,7 +550,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
             if (retainedBlockHtmlIndex != -1) {
                 val unknownSpan = text.getSpans(retainedBlockHtmlIndex, retainedBlockHtmlIndex + 1, UnknownHtmlSpan::class.java).firstOrNull()
                 if (unknownSpan != null) {
-                    val retainedBlockHtml = readAndPurgeTempInstance<String>(BLOCK_EDITOR_HTML_KEY, "",
+                    val retainedBlockHtml = InstanceStateUtils.readAndPurgeTempInstance<String>(BLOCK_EDITOR_HTML_KEY, "",
                             savedState.state)
                     showBlockEditorDialog(unknownSpan, retainedBlockHtml)
                 }
@@ -568,16 +563,20 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
     }
 
     override fun onSaveInstanceState(): Parcelable {
-        val superState = super.onSaveInstanceState()
-        val savedState = SavedState(superState)
         val bundle = Bundle()
-        writeTempInstance(HISTORY_LIST_KEY, ArrayList<String>(history.historyList), bundle)
+        InstanceStateUtils.writeTempInstance(context, externalLogger, HISTORY_LIST_KEY, ArrayList<String>(history.historyList), bundle)
         bundle.putInt(HISTORY_CURSOR_KEY, history.historyCursor)
-        writeTempInstance(INPUT_LAST_KEY, history.inputLast, bundle)
+        InstanceStateUtils.writeTempInstance(context, externalLogger, INPUT_LAST_KEY, history.inputLast, bundle)
         bundle.putInt(VISIBILITY_KEY, visibility)
-        writeTempInstance(RETAINED_HTML_KEY, toHtml(false), bundle)
+        InstanceStateUtils.writeTempInstance(context, externalLogger, RETAINED_HTML_KEY, toHtml(false), bundle)
         bundle.putInt(SELECTION_START_KEY, selectionStart)
         bundle.putInt(SELECTION_END_KEY, selectionEnd)
+        // disable text listeners and clear the content, otherwise TTL Exception may occur again
+        disableTextChangedListener()
+        setText("")
+
+        val superState = super.onSaveInstanceState()
+        val savedState = SavedState(superState)
 
         if (addLinkDialog != null && addLinkDialog!!.isShowing) {
             bundle.putBoolean(LINK_DIALOG_VISIBLE_KEY, true)
@@ -594,76 +593,13 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
 
             bundle.putBoolean(BLOCK_DIALOG_VISIBLE_KEY, true)
             bundle.putInt(BLOCK_EDITOR_START_INDEX_KEY, unknownBlockSpanStart)
-            writeTempInstance(BLOCK_EDITOR_HTML_KEY, source?.getPureHtml(false), bundle)
+            InstanceStateUtils.writeTempInstance(context, externalLogger, BLOCK_EDITOR_HTML_KEY, source?.getPureHtml(false), bundle)
         }
 
         bundle.putBoolean(IS_MEDIA_ADDED_KEY, isMediaAdded)
 
         savedState.state = bundle
         return savedState
-    }
-
-    private fun cacheFilenameKey(varName: String): String {
-        return "CACHEFILENAMEKEY_$varName"
-    }
-
-    private fun logCacheWriteException(varName: String, e: Exception) {
-        AppLog.w(AppLog.T.EDITOR, "Error trying to write cache for $varName. Exception: ${e.message}")
-        externalLogger?.logException(e, "Error trying to write cache for $varName.")
-    }
-
-    private fun writeTempInstance(varName: String, obj: Any?, bundle: Bundle) {
-        try {
-            with(File.createTempFile(varName, ".inst", context.getCacheDir())) {
-                deleteOnExit() // just make sure if we miss deleting this cache file the VM will eventually do it
-
-                FileOutputStream(this).use { output ->
-                    ObjectOutputStream(output).use { objectOutput ->
-                        objectOutput.writeObject(obj)
-
-                        // keep the filename in the bundle to use it to read the object back
-                        bundle.putString(cacheFilenameKey(varName), this.path)
-                    }
-                }
-            }
-        } catch (e: IOException) {
-            logCacheWriteException(varName, e)
-        } catch (e: SecurityException) {
-            logCacheWriteException(varName, e)
-        } catch (e: NullPointerException) {
-            logCacheWriteException(varName, e)
-        }
-    }
-
-    private fun <T> readAndPurgeTempInstance(varName: String, defaultValue: T, bundle: Bundle): T {
-        // the full path is kept in the bundle so, get it from there
-        val filename = bundle.getString(cacheFilenameKey(varName))
-
-        if (TextUtils.isEmpty(filename)) {
-            return defaultValue
-        }
-
-        val file = File(filename)
-
-        if (!file.exists()) {
-            return defaultValue
-        }
-
-        var obj: T = defaultValue
-
-        with(file) {
-            FileInputStream(this).use { input ->
-                ObjectInputStream(input).use { objectInput ->
-                    val r: Any? = objectInput.readObject()
-
-                    @Suppress("UNCHECKED_CAST")
-                    obj = (r ?: defaultValue) as T
-                }
-            }
-            delete() // eagerly delete the cache file. If any is missed the VM will delete it on reboot.
-        }
-
-        return obj
     }
 
     internal class SavedState : BaseSavedState {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -92,10 +92,17 @@ class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatc
         setText(retainedContent)
     }
 
+    // Do not include the content of the editor when saving state to bundle.
+    // EditText has it `true` by default, and then the content was saved in bundle making the app crashing
+    // due to the TransactionTooLargeException Exception.
+    // The content is saved in tmp files in `onSaveInstanceState`. See: https://github.com/wordpress-mobile/AztecEditor-Android/pull/641
+    override fun getFreezesText(): Boolean {
+        return false
+    }
+
     override fun onSaveInstanceState(): Parcelable {
         val bundle = Bundle()
         InstanceStateUtils.writeTempInstance(context, null, RETAINED_CONTENT_KEY, text.toString(), bundle)
-        setText("")
         val superState = super.onSaveInstanceState()
         val savedState = SavedState(superState)
         bundle.putInt("visibility", visibility)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -17,9 +17,13 @@ import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.History
 import org.wordpress.aztec.R
 import org.wordpress.aztec.spans.AztecCursorSpan
+import org.wordpress.aztec.util.InstanceStateUtils
 
 @SuppressLint("SupportAnnotationUsage")
 class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatcher {
+    companion object {
+        val RETAINED_CONTENT_KEY = "RETAINED_CONTENT_KEY"
+    }
 
     @ColorInt var tagColor = ContextCompat.getColor(context, R.color.html_tag)
         internal set
@@ -84,12 +88,16 @@ class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatc
         super.onRestoreInstanceState(savedState.superState)
         val customState = savedState.state
         visibility = customState.getInt("visibility")
+        val retainedContent = InstanceStateUtils.readAndPurgeTempInstance<String>(RETAINED_CONTENT_KEY, "", savedState.state)
+        setText(retainedContent)
     }
 
     override fun onSaveInstanceState(): Parcelable {
+        val bundle = Bundle()
+        InstanceStateUtils.writeTempInstance(context, null, RETAINED_CONTENT_KEY, text.toString(), bundle)
+        setText("")
         val superState = super.onSaveInstanceState()
         val savedState = SavedState(superState)
-        val bundle = Bundle()
         bundle.putInt("visibility", visibility)
         savedState.state = bundle
         return savedState

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
@@ -1,0 +1,80 @@
+package org.wordpress.aztec.util
+
+import android.content.Context
+import android.os.Bundle
+import android.text.TextUtils
+import org.wordpress.android.util.AppLog
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+class InstanceStateUtils {
+    companion object {
+
+        private fun cacheFilenameKey(varName: String): String {
+            return "CACHEFILENAMEKEY_$varName"
+        }
+
+        private fun logCacheWriteException(externalLogger: AztecLog.ExternalLogger?, varName: String, e: Exception) {
+            AppLog.w(AppLog.T.EDITOR, "Error trying to write cache for $varName. Exception: ${e.message}")
+            externalLogger?.logException(e, "Error trying to write cache for $varName.")
+        }
+
+        open fun writeTempInstance(context: Context, externalLogger: AztecLog.ExternalLogger?, varName: String, obj: Any?, bundle: Bundle) {
+            try {
+                with(File.createTempFile(varName, ".inst", context.getCacheDir())) {
+                    deleteOnExit() // just make sure if we miss deleting this cache file the VM will eventually do it
+
+                    FileOutputStream(this).use { output ->
+                        ObjectOutputStream(output).use { objectOutput ->
+                            objectOutput.writeObject(obj)
+
+                            // keep the filename in the bundle to use it to read the object back
+                            bundle.putString(cacheFilenameKey(varName), this.path)
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                logCacheWriteException(externalLogger, varName, e)
+            } catch (e: SecurityException) {
+                logCacheWriteException(externalLogger, varName, e)
+            } catch (e: NullPointerException) {
+                logCacheWriteException(externalLogger, varName, e)
+            }
+        }
+
+        open fun <T> readAndPurgeTempInstance(varName: String, defaultValue: T, bundle: Bundle): T {
+            // the full path is kept in the bundle so, get it from there
+            val filename = bundle.getString(cacheFilenameKey(varName))
+
+            if (TextUtils.isEmpty(filename)) {
+                return defaultValue
+            }
+
+            val file = File(filename)
+
+            if (!file.exists()) {
+                return defaultValue
+            }
+
+            var obj: T = defaultValue
+
+            with(file) {
+                FileInputStream(this).use { input ->
+                    ObjectInputStream(input).use { objectInput ->
+                        val r: Any? = objectInput.readObject()
+
+                        @Suppress("UNCHECKED_CAST")
+                        obj = (r ?: defaultValue) as T
+                    }
+                }
+                delete() // eagerly delete the cache file. If any is missed the VM will delete it on reboot.
+            }
+
+            return obj
+        }
+    }
+}


### PR DESCRIPTION
### Fix
In order to fix #561 we've introduced the ability to save big instance data in files, instead of saving them to the default state/bundle. See #641.
Unfortunately we were still saving part of the data (the content) to the default bundle (`superState` variable) and still having TTL exception in crash reports.

We also needed to do the same for the HTML raw editor (`SourceViewEditText`), but we missed it.  In the demo app I see the html editor instantiated even if not active. Not sure if wp-android always instantiate it, or keep it off until the user switch to it. In the doubt I replicated the same fix there.

### Test
See steps in #641

### Review
@hypest @0nko  