### PR TITLE
Add support for Touch Exploration

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
@@ -1,0 +1,100 @@
+package org.wordpress.aztec
+
+import android.os.Build
+import android.support.v4.view.accessibility.AccessibilityEventCompat
+import android.text.Selection
+import android.view.MotionEvent
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.widget.EditText
+import org.apache.commons.lang3.StringUtils
+
+/**
+ * Delegate which adds support for ExploreByTouch to an EditText. TalkBack reads each line as the user hovers over them.
+ */
+class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
+    private val ACCESSIBILITY_INVALID_LINE_ID = -1
+
+    private val mediaItemContentDescription = aztecText.getContext().getString(R.string.media_item_content_description)
+    private val cursorMovedText = aztecText.getContext().getString(R.string.cursor_moved)
+
+    /**
+     * Offset of most recently announced line.
+     */
+    private var lastLineAnnouncedForAccessibilityOffset = ACCESSIBILITY_INVALID_LINE_ID
+
+    fun onHoverEvent(event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_HOVER_ENTER) {
+            resetLastLineAnnouncedForAccessibilityOffset()
+        }
+        if (event.action == MotionEvent.ACTION_HOVER_EXIT) {
+            moveCursor(event.x, event.y)
+        }
+        return announceLineForAccessibility(event)
+    }
+
+    private fun resetLastLineAnnouncedForAccessibilityOffset() {
+        lastLineAnnouncedForAccessibilityOffset = ACCESSIBILITY_INVALID_LINE_ID
+    }
+
+    private fun moveCursor(x: Float, y: Float) {
+        // we need to remove the selection first, otherwise the TalkBack reads the text between old and new cursor position
+        Selection.removeSelection(aztecText.text)
+        aztecText.announceForAccessibility(cursorMovedText)
+        Selection.setSelection(aztecText.text, aztecText.getOffsetForPosition(x, y))
+    }
+
+    private fun announceLineForAccessibility(event: MotionEvent): Boolean {
+        (aztecText.parentForAccessibility as? View)?.let {
+            val lineOffset = getLineOffset(event.x, event.y)
+            if (lineOffset != ACCESSIBILITY_INVALID_LINE_ID && lastLineAnnouncedForAccessibilityOffset != lineOffset) {
+                updateContentDescription(it, lineOffset)
+            }
+            if (event.action == MotionEvent.ACTION_HOVER_EXIT) {
+                restoreContentDescription(it)
+            }
+            if (lineOffset != ACCESSIBILITY_INVALID_LINE_ID) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun updateContentDescription(parentForAccessibility: View, lineOffset: Int) {
+        // we can't use announceForAccessibility(..) as the announcement doesn't get interrupted as we move to another element
+        parentForAccessibility.contentDescription = getTextAtLine(lineOffset)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || !aztecText.isAccessibilityFocused) {
+            aztecText.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
+            aztecText.requestFocus()
+        } else {
+            parentForAccessibility.sendAccessibilityEvent(AccessibilityEventCompat.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
+        }
+        lastLineAnnouncedForAccessibilityOffset = lineOffset
+    }
+
+    private fun restoreContentDescription(parentForAccessibility: View) {
+            parentForAccessibility.contentDescription = aztecText.text
+    }
+
+    private fun getLineOffset(x: Float, y: Float): Int {
+        val charPos = aztecText.getOffsetForPosition(x, y)
+        var lineOffset = ACCESSIBILITY_INVALID_LINE_ID
+        if (charPos != -1) {
+            lineOffset = aztecText.layout.getLineForOffset(charPos)
+            // skip empty lines
+            if (isLineBlank(lineOffset)) lineOffset = ACCESSIBILITY_INVALID_LINE_ID
+        }
+        return lineOffset
+    }
+
+    private fun getTextAtLine(lineOffset: Int): String {
+        val lineStartOffset = aztecText.layout.getLineStart(lineOffset)
+        val lineEndOffset = aztecText.layout.getLineEnd(lineOffset)
+        return aztecText.text.substring(lineStartOffset, lineEndOffset)
+                .replace(Constants.IMG_STRING, mediaItemContentDescription)
+    }
+
+    private fun isLineBlank(lineOffset: Int): Boolean {
+        return StringUtils.isBlank(getTextAtLine(lineOffset).replace(Constants.MAGIC_STRING, ""))
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
@@ -68,8 +68,8 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
 
     private fun updateContentDescription(parentForAccessibility: View, lineOffset: Int) {
         // we can't use announceForAccessibility(..) as the announcement doesn't get interrupted as we move to another element
-        parentForAccessibility.contentDescription = getTextAtLine(lineOffset)
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || !aztecText.isAccessibilityFocused) {
+        parentForAccessibility.contentDescription = getTextAtLine(lineOffset).replace(Constants.IMG_STRING, mediaItemContentDescription)
+        if (!aztecText.isFocused ||  (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !aztecText.isAccessibilityFocused)) {
             aztecText.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
             aztecText.requestFocus()
         } else {
@@ -88,7 +88,9 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
         if (charPos != -1) {
             lineOffset = aztecText.layout.getLineForOffset(charPos)
             // skip empty lines
-            if (isLineBlank(lineOffset)) lineOffset = ACCESSIBILITY_INVALID_LINE_ID
+            if (isLineBlank(lineOffset)) {
+                lineOffset = ACCESSIBILITY_INVALID_LINE_ID
+            }
         }
         return lineOffset
     }
@@ -97,7 +99,6 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
         val lineStartOffset = aztecText.layout.getLineStart(lineOffset)
         val lineEndOffset = aztecText.layout.getLineEnd(lineOffset)
         return aztecText.text.substring(lineStartOffset, lineEndOffset)
-                .replace(Constants.IMG_STRING, mediaItemContentDescription)
     }
 
     private fun isLineBlank(lineOffset: Int): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
@@ -69,7 +69,7 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
     private fun updateContentDescription(parentForAccessibility: View, lineOffset: Int) {
         // we can't use announceForAccessibility(..) as the announcement doesn't get interrupted as we move to another element
         parentForAccessibility.contentDescription = getTextAtLine(lineOffset).replace(Constants.IMG_STRING, mediaItemContentDescription)
-        if (!aztecText.isFocused ||  (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !aztecText.isAccessibilityFocused)) {
+        if (!aztecText.isFocused || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !aztecText.isAccessibilityFocused)) {
             aztecText.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
             aztecText.requestFocus()
         } else {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
@@ -1,11 +1,13 @@
 package org.wordpress.aztec
 
+import android.content.Context
 import android.os.Build
 import android.support.v4.view.accessibility.AccessibilityEventCompat
 import android.text.Selection
 import android.view.MotionEvent
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityManager
 import android.widget.EditText
 import org.apache.commons.lang3.StringUtils
 
@@ -17,6 +19,7 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
 
     private val mediaItemContentDescription = aztecText.getContext().getString(R.string.media_item_content_description)
     private val cursorMovedText = aztecText.getContext().getString(R.string.cursor_moved)
+    private val accessibilityManager = aztecText.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
 
     /**
      * Offset of most recently announced line.
@@ -24,6 +27,9 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
     private var lastLineAnnouncedForAccessibilityOffset = ACCESSIBILITY_INVALID_LINE_ID
 
     fun onHoverEvent(event: MotionEvent): Boolean {
+        if (!accessibilityManager.isEnabled() || !accessibilityManager.isTouchExplorationEnabled) {
+            return false
+        }
         if (event.action == MotionEvent.ACTION_HOVER_ENTER) {
             resetLastLineAnnouncedForAccessibilityOffset()
         }
@@ -73,7 +79,7 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
     }
 
     private fun restoreContentDescription(parentForAccessibility: View) {
-            parentForAccessibility.contentDescription = aztecText.text
+        parentForAccessibility.contentDescription = aztecText.text
     }
 
     private fun getLineOffset(x: Float, y: Float): Int {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
@@ -2,10 +2,8 @@ package org.wordpress.aztec
 
 import android.content.Context
 import android.os.Build
-import android.support.v4.view.accessibility.AccessibilityEventCompat
 import android.text.Selection
 import android.view.MotionEvent
-import android.view.View
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityManager
 import android.widget.EditText
@@ -36,7 +34,7 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
         if (event.action == MotionEvent.ACTION_HOVER_EXIT) {
             moveCursor(event.x, event.y)
         }
-        return announceLineForAccessibility(event)
+        return announceForAccessibility(event)
     }
 
     private fun resetLastLineAnnouncedForAccessibilityOffset() {
@@ -50,10 +48,10 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
         Selection.setSelection(aztecText.text, aztecText.getOffsetForPosition(x, y))
     }
 
-    private fun announceLineForAccessibility(event: MotionEvent): Boolean {
+    private fun announceForAccessibility(event: MotionEvent): Boolean {
         val lineOffset = getLineOffset(event.x, event.y)
         if (lineOffset != ACCESSIBILITY_INVALID_LINE_ID && lastLineAnnouncedForAccessibilityOffset != lineOffset) {
-            updateContentDescription(lineOffset)
+            announceLine(lineOffset)
         }
         if (lineOffset != ACCESSIBILITY_INVALID_LINE_ID) {
             return true
@@ -61,7 +59,7 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
         return false
     }
 
-    private fun updateContentDescription(lineOffset: Int) {
+    private fun announceLine(lineOffset: Int) {
         if (!aztecText.isFocused || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !aztecText.isAccessibilityFocused)) {
             aztecText.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
             aztecText.requestFocus()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -12,8 +12,10 @@ import android.text.SpannableStringBuilder
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
 import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.AztecTextAccessibilityDelegate
 import org.wordpress.aztec.History
 import org.wordpress.aztec.R
 import org.wordpress.aztec.spans.AztecCursorSpan
@@ -39,6 +41,8 @@ class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatc
     var history: History? = null
 
     private var consumeEditEvent: Boolean = true
+
+    private var accessibilityDelegate = AztecTextAccessibilityDelegate(this)
 
     constructor(context: Context) : super(context) {
         init(null)
@@ -279,5 +283,9 @@ class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatc
             onImeBackListener?.onImeBack()
         }
         return super.onKeyPreIme(keyCode, event)
+    }
+
+    override fun dispatchHoverEvent(event: MotionEvent): Boolean {
+        return if (accessibilityDelegate.onHoverEvent(event)) true else super.dispatchHoverEvent(event)
     }
 }

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <resources>
 
+    <!-- GENERAL -->
+    <string name="cursor_moved">Cursor moved</string>
+
     <!-- LINK DIALOG -->
     <string name="link_dialog_title">Insert link</string>
     <string name="link_dialog_button_remove_link">Remove Link</string>
@@ -60,6 +63,7 @@
     <string name="media_popup_gallery_chose_video">Video from device</string>
     <string name="media_bar_description_gallery">Pick a media from gallery</string>
     <string name="media_bar_description_camera">Take Photo or Video with camera</string>
+    <string name="media_item_content_description">Media</string>
 
     <!-- SHORTCUTS -->
     <string name="header_edit">Edit</string>


### PR DESCRIPTION
Adds support for Touch Exploration to the AztecText and SourceViewEditText.

### Test
1. Enable TalkBack
2. Open the AztecApp
3. Hover over lines - each line should be read by talkback.
4. The cursor should be moved to the last position of your finger when you move up you finger.
5. Make sure that the TalkBack context menu contains "Cursor control/Editing" menu item(naming depends on the SDK version).

Issues
1. When we want to move the cursor to the new position, we need to remove the cursor first, otherwise the TalkBack reads the text between old and new cursor position.
The issues is that on SDK 27, TalkBack announces "selection cleared" when the ".removeSelection(...)" method is invoked.

2. It reads raw text ignoring spans. I wanted to add support for spans, but I run out of time. Some spans (eg. Comment, More, PageBreak) are in different modules, so I'm not even sure it's doable.


Note: The app sometimes crashed when I changed TalkBack navigation granularity (characters, words, lines, default etc..).  So I added if check into the getAppliedStyles(..) method, but tbh I'm not sure if it doesn't break something else. I've tested it and it seemed ok.... I just wanted to point it out.
Steps to reproduce (before the fix)
1. Enable TalkBack
2. Keep swiping right, after the editor view is focused (focused with talkback)
3. Swipe down to change TalkBack navigation granularity
4. Boom



