### PR TITLE
Feature/awesome accessibility toggle button

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -31,6 +31,7 @@ import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupMenu
+import android.widget.ToggleButton
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.PermissionUtils
@@ -59,7 +60,6 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
-import org.wordpress.aztec.toolbar.RippleToggleButton
 import org.wordpress.aztec.util.AztecLog
 import org.xml.sax.Attributes
 import java.io.File
@@ -139,32 +139,32 @@ open class MainActivity : AppCompatActivity(),
 
         private val EXAMPLE =
                 IMG +
-                HEADING +
-                BOLD +
-                ITALIC +
-                UNDERLINE +
-                STRIKETHROUGH +
-                ORDERED +
-                LINE +
-                UNORDERED +
-                QUOTE +
-                PREFORMAT +
-                LINK +
-                HIDDEN +
-                COMMENT +
-                COMMENT_MORE +
-                COMMENT_PAGE +
-                CODE +
-                UNKNOWN +
-                EMOJI +
-                NON_LATIN_TEXT +
-                LONG_TEXT +
-                VIDEO +
-                VIDEOPRESS +
-                VIDEOPRESS_2 +
-                AUDIO +
-                GUTENBERG_CODE_BLOCK +
-                QUOTE_RTL
+                        HEADING +
+                        BOLD +
+                        ITALIC +
+                        UNDERLINE +
+                        STRIKETHROUGH +
+                        ORDERED +
+                        LINE +
+                        UNORDERED +
+                        QUOTE +
+                        PREFORMAT +
+                        LINK +
+                        HIDDEN +
+                        COMMENT +
+                        COMMENT_MORE +
+                        COMMENT_PAGE +
+                        CODE +
+                        UNKNOWN +
+                        EMOJI +
+                        NON_LATIN_TEXT +
+                        LONG_TEXT +
+                        VIDEO +
+                        VIDEOPRESS +
+                        VIDEOPRESS_2 +
+                        AUDIO +
+                        GUTENBERG_CODE_BLOCK +
+                        QUOTE_RTL
 
         private val isRunningTest: Boolean by lazy {
             try {
@@ -347,8 +347,10 @@ open class MainActivity : AppCompatActivity(),
         visualEditor.externalLogger = object : AztecLog.ExternalLogger {
             override fun log(message: String) {
             }
+
             override fun logException(tr: Throwable) {
             }
+
             override fun logException(tr: Throwable, message: String) {
             }
         }
@@ -360,7 +362,7 @@ open class MainActivity : AppCompatActivity(),
                 mediaMenu?.setOnMenuItemClickListener(this@MainActivity)
                 mediaMenu?.inflate(R.menu.menu_gallery)
                 mediaMenu?.show()
-                if(view is RippleToggleButton){
+                if (view is ToggleButton) {
                     view.isChecked = false
                 }
             }
@@ -373,32 +375,32 @@ open class MainActivity : AppCompatActivity(),
                 mediaMenu?.setOnMenuItemClickListener(this@MainActivity)
                 mediaMenu?.inflate(R.menu.menu_camera)
                 mediaMenu?.show()
-                if(view is RippleToggleButton){
+                if (view is ToggleButton) {
                     view.isChecked = false
                 }
             }
         })
 
         aztec = Aztec.with(visualEditor, sourceEditor, toolbar, this)
-            .setImageGetter(GlideImageLoader(this))
-            .setVideoThumbnailGetter(GlideVideoThumbnailLoader(this))
-            .setOnImeBackListener(this)
-            .setOnTouchListener(this)
-            .setHistoryListener(this)
-            .setOnImageTappedListener(this)
-            .setOnVideoTappedListener(this)
-            .setOnAudioTappedListener(this)
-            .setOnMediaDeletedListener(this)
-            .setOnVideoInfoRequestedListener(this)
-            .addPlugin(WordPressCommentsPlugin(visualEditor))
-            .addPlugin(MoreToolbarButton(visualEditor))
-            .addPlugin(PageToolbarButton(visualEditor))
-            .addPlugin(CaptionShortcodePlugin(visualEditor))
-            .addPlugin(VideoShortcodePlugin())
-            .addPlugin(AudioShortcodePlugin())
-            .addPlugin(HiddenGutenbergPlugin())
-            .addPlugin(galleryButton)
-            .addPlugin(cameraButton)
+                .setImageGetter(GlideImageLoader(this))
+                .setVideoThumbnailGetter(GlideVideoThumbnailLoader(this))
+                .setOnImeBackListener(this)
+                .setOnTouchListener(this)
+                .setHistoryListener(this)
+                .setOnImageTappedListener(this)
+                .setOnVideoTappedListener(this)
+                .setOnAudioTappedListener(this)
+                .setOnMediaDeletedListener(this)
+                .setOnVideoInfoRequestedListener(this)
+                .addPlugin(WordPressCommentsPlugin(visualEditor))
+                .addPlugin(MoreToolbarButton(visualEditor))
+                .addPlugin(PageToolbarButton(visualEditor))
+                .addPlugin(CaptionShortcodePlugin(visualEditor))
+                .addPlugin(VideoShortcodePlugin())
+                .addPlugin(AudioShortcodePlugin())
+                .addPlugin(HiddenGutenbergPlugin())
+                .addPlugin(galleryButton)
+                .addPlugin(cameraButton)
 
         // initialize the plugins, text & HTML
         if (!isRunningTest) {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -59,6 +59,7 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
+import org.wordpress.aztec.toolbar.RippleToggleButton
 import org.wordpress.aztec.util.AztecLog
 import org.xml.sax.Attributes
 import java.io.File
@@ -359,6 +360,9 @@ open class MainActivity : AppCompatActivity(),
                 mediaMenu?.setOnMenuItemClickListener(this@MainActivity)
                 mediaMenu?.inflate(R.menu.menu_gallery)
                 mediaMenu?.show()
+                if(view is RippleToggleButton){
+                    view.isChecked = false
+                }
             }
         })
 
@@ -369,6 +373,9 @@ open class MainActivity : AppCompatActivity(),
                 mediaMenu?.setOnMenuItemClickListener(this@MainActivity)
                 mediaMenu?.inflate(R.menu.menu_camera)
                 mediaMenu?.show()
+                if(view is RippleToggleButton){
+                    view.isChecked = false
+                }
             }
         })
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -816,6 +816,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                         buttonMediaCollapsed.visibility = View.GONE
                         buttonMediaExpanded.visibility = View.VISIBLE
                         buttonMediaExpanded.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
+                        buttonMediaExpanded.isChecked = true
                     }
 
                     override fun onAnimationRepeat(animation: Animation) {
@@ -834,6 +835,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                         buttonMediaCollapsed.visibility = View.VISIBLE
                         buttonMediaExpanded.visibility = View.GONE
                         buttonMediaCollapsed.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
+                        buttonMediaCollapsed.isChecked = false
                     }
 
                     override fun onAnimationRepeat(animation: Animation) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -854,6 +854,8 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         headingMenu?.setOnDismissListener({
             if (getSelectedHeadingMenuItem() == null || getSelectedHeadingMenuItem() == AztecTextFormat.FORMAT_PARAGRAPH) {
                 findViewById<ToggleButton>(ToolbarAction.HEADING.buttonId).isChecked = false
+            } else {
+                findViewById<ToggleButton>(ToolbarAction.HEADING.buttonId).isChecked = true
             }
         })
     }
@@ -865,6 +867,8 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         listMenu?.setOnDismissListener({
             if (getSelectedListMenuItem() == null) {
                 findViewById<ToggleButton>(ToolbarAction.LIST.buttonId).isChecked = false
+            } else {
+                findViewById<ToggleButton>(ToolbarAction.LIST.buttonId).isChecked = true
             }
         })
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -13,6 +13,7 @@ import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.FrameLayout
@@ -817,6 +818,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                     override fun onAnimationEnd(animation: Animation) {
                         buttonMediaCollapsed.visibility = View.GONE
                         buttonMediaExpanded.visibility = View.VISIBLE
+                        buttonMediaExpanded.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
                     }
 
                     override fun onAnimationRepeat(animation: Animation) {
@@ -834,6 +836,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                     override fun onAnimationEnd(animation: Animation) {
                         buttonMediaCollapsed.visibility = View.VISIBLE
                         buttonMediaExpanded.visibility = View.GONE
+                        buttonMediaCollapsed.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
                     }
 
                     override fun onAnimationRepeat(animation: Animation) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -256,7 +256,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
     override fun onMenuItemClick(item: MenuItem?): Boolean {
         val checked = (item?.isChecked == false)
         item?.isChecked = checked
-        val headingButton = findViewById<ToggleButton>(R.id.format_bar_button_heading)
+        val headingButton = findViewById<ToggleButton>(ToolbarAction.HEADING.buttonId)
 
         when (item?.itemId) {
         // Heading Menu
@@ -625,42 +625,39 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
     }
 
     private fun selectHeadingMenuItem(textFormats: ArrayList<ITextFormat>) {
-        val headingButton = findViewById<ToggleButton>(R.id.format_bar_button_heading)
+        val headingButton = findViewById<ToggleButton>(ToolbarAction.HEADING.buttonId)
         // Use unnumbered heading selector by default.
         updateHeadingMenuItem(AztecTextFormat.FORMAT_PARAGRAPH, headingButton)
         headingMenu?.menu?.findItem(R.id.paragraph)?.isChecked = true
-        if (textFormats.size != 0) {
-            foreach@ for (it in textFormats) {
-                when (it) {
-                    AztecTextFormat.FORMAT_HEADING_1 -> headingMenu?.menu?.findItem(R.id.heading_1)?.isChecked = true
-                    AztecTextFormat.FORMAT_HEADING_2 -> headingMenu?.menu?.findItem(R.id.heading_2)?.isChecked = true
-                    AztecTextFormat.FORMAT_HEADING_3 -> headingMenu?.menu?.findItem(R.id.heading_3)?.isChecked = true
-                    AztecTextFormat.FORMAT_HEADING_4 -> headingMenu?.menu?.findItem(R.id.heading_4)?.isChecked = true
-                    AztecTextFormat.FORMAT_HEADING_5 -> headingMenu?.menu?.findItem(R.id.heading_5)?.isChecked = true
-                    AztecTextFormat.FORMAT_HEADING_6 -> headingMenu?.menu?.findItem(R.id.heading_6)?.isChecked = true
-    //                    TODO: Uncomment when Preformat is to be added back as a feature
-    //                    AztecTextFormat.FORMAT_PREFORMAT -> headingMenu?.menu?.findItem(R.id.preformat)?.isChecked = true
-                    else -> continue@foreach
-                }
-
-                updateHeadingMenuItem(it, headingButton)
+        foreach@ for (it in textFormats) {
+            when (it) {
+                AztecTextFormat.FORMAT_HEADING_1 -> headingMenu?.menu?.findItem(R.id.heading_1)?.isChecked = true
+                AztecTextFormat.FORMAT_HEADING_2 -> headingMenu?.menu?.findItem(R.id.heading_2)?.isChecked = true
+                AztecTextFormat.FORMAT_HEADING_3 -> headingMenu?.menu?.findItem(R.id.heading_3)?.isChecked = true
+                AztecTextFormat.FORMAT_HEADING_4 -> headingMenu?.menu?.findItem(R.id.heading_4)?.isChecked = true
+                AztecTextFormat.FORMAT_HEADING_5 -> headingMenu?.menu?.findItem(R.id.heading_5)?.isChecked = true
+                AztecTextFormat.FORMAT_HEADING_6 -> headingMenu?.menu?.findItem(R.id.heading_6)?.isChecked = true
+            //                    TODO: Uncomment when Preformat is to be added back as a feature
+            //                    AztecTextFormat.FORMAT_PREFORMAT -> headingMenu?.menu?.findItem(R.id.preformat)?.isChecked = true
+                else -> continue@foreach
             }
+
+            updateHeadingMenuItem(it, headingButton)
         }
     }
 
     private fun selectListMenuItem(textFormats: ArrayList<ITextFormat>) {
-        val listButton = findViewById<ToggleButton>(R.id.format_bar_button_list)
+        val listButton = findViewById<ToggleButton>(ToolbarAction.LIST.buttonId)
         updateListMenuItem(AztecTextFormat.FORMAT_NONE, listButton)
         listMenu?.menu?.findItem(R.id.list_none)?.isChecked = true
-        if (textFormats.size != 0) {
-            foreach@ for (it in textFormats) {
-                when (it) {
-                    AztecTextFormat.FORMAT_UNORDERED_LIST -> listMenu?.menu?.findItem(R.id.list_unordered)?.isChecked = true
-                    AztecTextFormat.FORMAT_ORDERED_LIST -> listMenu?.menu?.findItem(R.id.list_ordered)?.isChecked = true
-                    else -> continue@foreach
-                }
-                updateListMenuItem(it, listButton)
+        foreach@ for (it in textFormats) {
+            when (it) {
+                AztecTextFormat.FORMAT_UNORDERED_LIST -> listMenu?.menu?.findItem(R.id.list_unordered)?.isChecked = true
+                AztecTextFormat.FORMAT_ORDERED_LIST -> listMenu?.menu?.findItem(R.id.list_ordered)?.isChecked = true
+                else -> continue@foreach
             }
+            updateListMenuItem(it, listButton)
+
         }
     }
 
@@ -852,12 +849,22 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         headingMenu = PopupMenu(context, view)
         headingMenu?.setOnMenuItemClickListener(this)
         headingMenu?.inflate(R.menu.heading)
+        headingMenu?.setOnDismissListener({
+            if (getSelectedHeadingMenuItem() == null || getSelectedHeadingMenuItem() == AztecTextFormat.FORMAT_PARAGRAPH) {
+                findViewById<ToggleButton>(ToolbarAction.HEADING.buttonId).isChecked = false
+            }
+        })
     }
 
     private fun setListMenu(view: View) {
         listMenu = PopupMenu(context, view)
         listMenu?.setOnMenuItemClickListener(this)
         listMenu?.inflate(R.menu.list)
+        listMenu?.setOnDismissListener({
+            if (getSelectedListMenuItem() == null) {
+                findViewById<ToggleButton>(ToolbarAction.LIST.buttonId).isChecked = false
+            }
+        })
     }
 
     private fun updateListMenuItem(textFormat: ITextFormat, listButton: ToggleButton) {
@@ -957,7 +964,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
     }
 
     private fun toggleListMenuSelection(listMenuItemId: Int, isChecked: Boolean) {
-        val listButton = findViewById<ToggleButton>(R.id.format_bar_button_list)
+        val listButton = findViewById<ToggleButton>(ToolbarAction.LIST.buttonId)
         if (isChecked) {
             listMenu?.menu?.findItem(listMenuItemId)?.isChecked = true
 

--- a/aztec/src/main/res/layout/aztec_format_bar_advanced.xml
+++ b/aztec/src/main/res/layout/aztec_format_bar_advanced.xml
@@ -48,7 +48,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:background="@drawable/format_bar_button_media_collapsed_selector"
-                    android:contentDescription="@string/format_bar_description_media">
+                    android:contentDescription="@string/format_bar_description_media_normal">
                 </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
@@ -57,7 +57,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:background="@drawable/format_bar_button_media_expanded_selector"
-                    android:contentDescription="@string/format_bar_description_media"
+                    android:contentDescription="@string/format_bar_description_media_expanded"
                     android:visibility="gone">
                 </org.wordpress.aztec.toolbar.RippleToggleButton>
 

--- a/aztec/src/main/res/layout/aztec_format_bar_basic.xml
+++ b/aztec/src/main/res/layout/aztec_format_bar_basic.xml
@@ -46,7 +46,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:background="@drawable/format_bar_button_media_collapsed_selector"
-                    android:contentDescription="@string/format_bar_description_media">
+                    android:contentDescription="@string/format_bar_description_media_normal">
                 </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
@@ -55,7 +55,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:background="@drawable/format_bar_button_media_expanded_selector"
-                    android:contentDescription="@string/format_bar_description_media"
+                    android:contentDescription="@string/format_bar_description_media_expanded"
                     android:visibility="gone">
                 </org.wordpress.aztec.toolbar.RippleToggleButton>
 

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -26,7 +26,8 @@
     <string name="format_bar_description_quote">Block quote</string>
     <string name="format_bar_description_link">Link</string>
     <string name="format_bar_description_horizontal_rule">Horizontal Rule</string>
-    <string name="format_bar_description_media">Media</string>
+    <string name="format_bar_description_media_normal">Show Media Options</string>
+    <string name="format_bar_description_media_expanded">Hide Media Options</string>
     <string name="format_bar_description_list">List</string>
     <string name="format_bar_description_html">HTML</string>
     <string name="format_bar_description_ellipsis_collapse">Collapse Toolbar</string>


### PR DESCRIPTION
This PR fixes the issue with `ToggleButton` with menus (like Heading, List and media buttons) being checked even when nothing in the in the menu is selected. 

1. Enable TalkBack.
2. When no heading style is selected, focus on Headin button.
3. Make sure announcement says it's "not checked"
4. Open the Headin menu.
5. Without selecting anything (the Default option is OK) press back button and close the menu.
6. Focus on the Heading button and make sure it's announced as "not checked"

Same should apply to List and buttons inside Media toolbar.

In addition, I added correct checked/unchecked logic to Media button. When Media toolbar is invisible the button is unchecked when it's visible the button is checked.
