### PR TITLE
Prepare Aztec for integration in React Native - step 1

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -7,10 +7,11 @@ import org.wordpress.aztec.plugins.IAztecPlugin
 import org.wordpress.aztec.plugins.IToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.toolbar.IAztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
 import java.util.ArrayList
 
-open class Aztec private constructor(val visualEditor: AztecText, val toolbar: AztecToolbar,
+open class Aztec private constructor(val visualEditor: AztecText, val toolbar: IAztecToolbar,
                                      private val toolbarClickListener: IAztecToolbarClickListener) {
     private var imageGetter: Html.ImageGetter? = null
     private var videoThumbnailGetter: Html.VideoThumbnailGetter? = null

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -84,7 +84,7 @@ import org.wordpress.aztec.spans.IAztecAttributedSpan
 import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.spans.UnknownClickableSpan
 import org.wordpress.aztec.spans.UnknownHtmlSpan
-import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.toolbar.IAztecToolbar
 import org.wordpress.aztec.util.AztecLog
 import org.wordpress.aztec.util.InstanceStateUtils
 import org.wordpress.aztec.util.SpanWrapper
@@ -191,7 +191,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private var unknownBlockSpanStart = -1
 
-    private var formatToolbar: AztecToolbar? = null
+    private var formatToolbar: IAztecToolbar? = null
 
     val selectedStyles = ArrayList<ITextFormat>()
 
@@ -862,7 +862,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
-    fun setToolbar(toolbar: AztecToolbar) {
+    fun setToolbar(toolbar: IAztecToolbar) {
         formatToolbar = toolbar
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -115,7 +115,7 @@ import java.util.Arrays
 import java.util.LinkedList
 
 @Suppress("UNUSED_PARAMETER")
-class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlTappedListener, IEventInjector {
+open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlTappedListener, IEventInjector {
     companion object {
         val BLOCK_EDITOR_HTML_KEY = "RETAINED_BLOCK_HTML_KEY"
         val BLOCK_EDITOR_START_INDEX_KEY = "BLOCK_EDITOR_START_INDEX_KEY"
@@ -1192,7 +1192,7 @@ class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlT
         return consumeSelectionChangedEvent
     }
 
-    fun refreshText() {
+    open fun refreshText() {
         disableTextChangedListener()
         val selStart = selectionStart
         val selEnd = selectionEnd

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -866,6 +866,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         formatToolbar = toolbar
     }
 
+    fun getToolbar() : IAztecToolbar? {
+        return formatToolbar
+    }
+
     private fun addWatcherNestingLevel() : Int {
         watchersNestingLevel++
         return watchersNestingLevel

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -36,7 +36,7 @@ import java.util.Locale
  * Contains both Styling and Media toolbars.
  * Supports RTL layout direction on API 19+
  */
-class AztecToolbar : FrameLayout, OnMenuItemClickListener {
+class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private var aztecToolbarListener: IAztecToolbarClickListener? = null
     private var editor: AztecText? = null
     private var headingMenu: PopupMenu? = null
@@ -85,7 +85,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         initView(attrs)
     }
 
-    fun setToolbarListener(listener: IAztecToolbarClickListener) {
+    override fun setToolbarListener(listener: IAztecToolbarClickListener) {
         aztecToolbarListener = listener
     }
 
@@ -357,7 +357,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         return editor != null && editor is AztecText
     }
 
-    fun setEditor(editor: AztecText, sourceEditor: SourceViewEditText?) {
+    override fun setEditor(editor: AztecText, sourceEditor: SourceViewEditText?) {
         this.sourceEditor = sourceEditor
         this.editor = editor
 
@@ -396,7 +396,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         }
     }
 
-    fun addButton(buttonPlugin: IToolbarButton) {
+    override fun addButton(buttonPlugin: IToolbarButton) {
         val pluginContainer = if (buttonPlugin is IMediaToolbarButton) {
             findViewById(R.id.media_toolbar)
         } else {
@@ -546,7 +546,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         }
     }
 
-    fun toggleEditorMode() {
+    override fun toggleEditorMode() {
         // only allow toggling if sourceEditor is present
         if (sourceEditor == null) return
 
@@ -989,7 +989,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         isMediaToolbarVisible = true
     }
 
-    fun toggleMediaToolbar() {
+    override fun toggleMediaToolbar() {
         if (isMediaToolbarVisible) {
             hideMediaToolbar()
         } else {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -46,6 +46,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private var sourceEditor: SourceViewEditText? = null
     private var dialogShortcuts: AlertDialog? = null
     private var isAdvanced: Boolean = false
+    private var isMediaToolbarAvailable: Boolean = false
     private var isExpanded: Boolean = false
     private var isMediaToolbarVisible: Boolean = false
     private var isMediaModeEnabled: Boolean = false
@@ -375,6 +376,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private fun initView(attrs: AttributeSet?) {
         val styles = context.obtainStyledAttributes(attrs, R.styleable.AztecToolbar, 0, R.style.AztecToolbarStyle)
         isAdvanced = styles.getBoolean(R.styleable.AztecToolbar_advanced, false)
+        isMediaToolbarAvailable = styles.getBoolean(R.styleable.AztecToolbar_mediaToolbarAvailable, true)
         styles.recycle()
 
         val layout = if (isAdvanced) R.layout.aztec_format_bar_advanced else R.layout.aztec_format_bar_basic
@@ -738,6 +740,10 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     }
 
     private fun setupMediaToolbar() {
+        val mediaToolbarContainer : LinearLayout = findViewById(R.id.media_button_container)
+        mediaToolbarContainer.visibility = if (isMediaToolbarAvailable) View.VISIBLE else View.GONE
+        if (!isMediaToolbarAvailable) return
+
         mediaToolbar = findViewById(R.id.media_toolbar)
         stylingToolbar = findViewById(R.id.styling_toolbar)
 
@@ -760,6 +766,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     }
 
     private fun setupMediaToolbarAnimations() {
+        if (!isMediaToolbarAvailable) return
         layoutMediaTranslateInEnd = AnimationUtils.loadAnimation(context, R.anim.translate_in_end)
 
         layoutMediaTranslateOutEnd = AnimationUtils.loadAnimation(context, R.anim.translate_out_end)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/IAztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/IAztecToolbar.kt
@@ -1,0 +1,15 @@
+package org.wordpress.aztec.toolbar
+
+import android.view.KeyEvent
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.plugins.IToolbarButton
+import org.wordpress.aztec.source.SourceViewEditText
+
+interface IAztecToolbar {
+    fun onKeyUp(keyCode: Int, keyEvent: KeyEvent): Boolean
+    fun addButton(buttonPlugin: IToolbarButton)
+    fun setEditor(editor: AztecText, sourceEditor: SourceViewEditText?)
+    fun setToolbarListener(listener: IAztecToolbarClickListener)
+    fun toggleMediaToolbar()
+    fun toggleEditorMode()
+}

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -36,6 +36,7 @@
 
     <declare-styleable name="AztecToolbar">
         <attr name="advanced" format="reference|boolean" />
+        <attr name="mediaToolbarAvailable" format="reference|boolean" />
     </declare-styleable>
 
     <declare-styleable name="SourceViewEditText">


### PR DESCRIPTION
This PR is the beginning of required changes to Aztec to be integrated in a RN component.

Aztec was already in a good shape for integration in a RN component, in this PR we just refactored small things and added the ability to disable the media toolbar.

In details:
- Added the ability to completely disable the media toolbar. The `+` button is not shown on the screen.
- Introduced an interface that Toolbars need to implement.
- Made a couple of methods public, since we needed to extends AztecText in order to properly calculate the height in RN.

### Review
@mzorz @0nko 