### PR TITLE
Fix IOOB in AztecText.onTextContextMenuItem -> paste

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1238,7 +1238,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         when (id) {
-            android.R.id.paste -> paste(text, min, max)
+            android.R.id.paste,
+            android.R.id.pasteAsPlainText -> paste(text, min, max)
             android.R.id.copy -> {
                 copy(text, min, max)
                 clearFocus() // hide text action menu


### PR DESCRIPTION
This PR tries to fix #651 by making sure the "paste as plain text" menu item is handled the same way of the classic "paste" case.

As I mentioned in the ticket, looking at the stack trace, seems that the code is calling `onTextContextMenuItem` of the base class `TextView`, that in turn calls its `paste` method. Our `paste`method instead is not called at all, meaning that our `switch` case is missing a catch and redirecting to `return super.onTextContextMenuItem(id) `.

Looking at `TextView` implementation the only case that we're missing and that can cause the issue is `ID_PASTE_AS_PLAIN_TEXT`. I then added this other check to our switch statement, and let's see if this fix the problem.

### Test
No steps sorry.

cc @0nko 