### PR TITLE
[Aztec for RN] Hide the HTML button if source editor is not set

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -22,7 +22,7 @@ import org.wordpress.aztec.spans.AztecCursorSpan
 import org.wordpress.aztec.util.InstanceStateUtils
 
 @SuppressLint("SupportAnnotationUsage")
-class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatcher {
+open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatcher {
     companion object {
         val RETAINED_CONTENT_KEY = "RETAINED_CONTENT_KEY"
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -58,6 +58,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private lateinit var layoutExpandedTranslateInEnd: Animation
     private lateinit var layoutExpandedTranslateOutStart: Animation
 
+    private lateinit var HTMLButton: RippleToggleButton
     private lateinit var buttonMediaCollapsed: RippleToggleButton
     private lateinit var buttonMediaExpanded: RippleToggleButton
 
@@ -372,6 +373,10 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
                 highlightAppliedStyles(selStart, selEnd)
             }
         })
+
+        if (sourceEditor == null) {
+            HTMLButton.visibility = View.GONE
+        }
     }
 
     private fun initView(attrs: AttributeSet?) {
@@ -384,6 +389,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         View.inflate(context, layout, this)
 
         toolbarScrolView = findViewById(R.id.format_bar_button_scroll)
+        HTMLButton = findViewById(R.id.format_bar_button_html)
 
         setAdvancedState()
         setupMediaToolbar()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -58,7 +58,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private lateinit var layoutExpandedTranslateInEnd: Animation
     private lateinit var layoutExpandedTranslateOutStart: Animation
 
-    private lateinit var HTMLButton: RippleToggleButton
+    private lateinit var htmlButton: RippleToggleButton
     private lateinit var buttonMediaCollapsed: RippleToggleButton
     private lateinit var buttonMediaExpanded: RippleToggleButton
 
@@ -375,7 +375,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         })
 
         if (sourceEditor == null) {
-            HTMLButton.visibility = View.GONE
+            htmlButton.visibility = View.GONE
         }
     }
 
@@ -389,7 +389,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         View.inflate(context, layout, this)
 
         toolbarScrolView = findViewById(R.id.format_bar_button_scroll)
-        HTMLButton = findViewById(R.id.format_bar_button_html)
+        htmlButton = findViewById(R.id.format_bar_button_html)
 
         setAdvancedState()
         setupMediaToolbar()


### PR DESCRIPTION
This PR hides the `HTML` button in `Toolbar` if the source editor was not set.

This is in required GB mobile side, since we don't need (yet?) the HTML editor bundled in Aztec.


Note: This PR also makes SourceViewEditText `open` to be used later in AztecRN if needed.
