### PR TITLE
making sure to make the toolbar's HTML button visible if there's a so…

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -376,6 +376,8 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
 
         if (sourceEditor == null) {
             htmlButton.visibility = View.GONE
+        } else {
+            htmlButton.visibility = View.VISIBLE
         }
     }
 


### PR DESCRIPTION
### Fix

Fixes a bug introduced in https://github.com/wordpress-mobile/AztecEditor-Android/pull/656/commits/5ca08f37cf6b2372cf4c454322ec47466c2bd033, where the toolbar's HTML button would never be shown even if a Source editor was present, because the code first runs the default constructor `init()` method (when the Source Editor has not been set yet), and sets the HTML button visibility to `GONE`, never getting it back to `VISIBLE` once the Source Editor is actually set (when `initToolbar()` is run again in [this constructor](https://github.com/wordpress-mobile/AztecEditor-Android/blob/develop/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt#L47)).

### Test
1. open the demo app
2. scroll the toolbar horizontally to the rightmost end of it
3. observe the HTML button is present and can be tapped.

### Review
@daniloercoli 