### PR TITLE
Changes to <hr> tag handling

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/HistoryMixedTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/HistoryMixedTests.kt
@@ -24,7 +24,7 @@ class HistoryMixedTests : BaseHistoryTest() {
             "\t<li></li>\n" +
             "</ol>\n" +
             "\n" +
-            "<hr>\n" +
+            "<hr/>\n" +
             "\n" +
             "<ul>\n" +
             "\t<li>Unordered</li>\n" +

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/HistoryMixedTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/HistoryMixedTests.kt
@@ -24,7 +24,7 @@ class HistoryMixedTests : BaseHistoryTest() {
             "\t<li></li>\n" +
             "</ol>\n" +
             "\n" +
-            "<hr/>\n" +
+            "<hr />\n" +
             "\n" +
             "<ul>\n" +
             "\t<li>Unordered</li>\n" +

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -91,7 +91,7 @@ open class MainActivity : AppCompatActivity(),
         private val UNDERLINE = "<u style=\"color:lime\">Underline</u><br>"
         private val STRIKETHROUGH = "<s style=\"color:#ff666666\" class=\"test\">Strikethrough</s><br>" // <s> or <strike> or <del>
         private val ORDERED = "<ol style=\"color:green\"><li>Ordered</li><li>should have color</li></ol>"
-        private val LINE = "<hr>"
+        private val LINE = "<hr/>"
         private val UNORDERED = "<ul><li style=\"color:darkred\">Unordered</li><li>Should not have color</li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"
         private val LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a><br>"

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -91,7 +91,7 @@ open class MainActivity : AppCompatActivity(),
         private val UNDERLINE = "<u style=\"color:lime\">Underline</u><br>"
         private val STRIKETHROUGH = "<s style=\"color:#ff666666\" class=\"test\">Strikethrough</s><br>" // <s> or <strike> or <del>
         private val ORDERED = "<ol style=\"color:green\"><li>Ordered</li><li>should have color</li></ol>"
-        private val LINE = "<hr/>"
+        private val LINE = "<hr />"
         private val UNORDERED = "<ul><li style=\"color:darkred\">Unordered</li><li>Should not have color</li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"
         private val LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a><br>"

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -473,7 +473,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
                         }
 
                 if (span is AztecHorizontalRuleSpan) {
-                    out.append("<${span.startTag}>")
+                    out.append("<${span.startTag}/>")
                     i = next
                 }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -473,7 +473,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = ArrayList()) {
                         }
 
                 if (span is AztecHorizontalRuleSpan) {
-                    out.append("<${span.startTag}/>")
+                    out.append("<${span.startTag} />")
                     i = next
                 }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -116,7 +116,8 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
             LINE -> {
                 if (opening) {
                     // Add an extra newline above the line to prevent weird typing on the line above
-                    start(output, AztecHorizontalRuleSpan(context, ContextCompat.getDrawable(context, R.drawable.img_hr), nestingLevel))
+                    start(output, AztecHorizontalRuleSpan(context, ContextCompat.getDrawable(context, R.drawable.img_hr),
+                            nestingLevel, AztecAttributes(attributes)))
                     output.append(Constants.MAGIC_CHAR)
                 } else {
                     end(output, AztecHorizontalRuleSpan::class.java)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -106,6 +106,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
                 editor.context,
                 ContextCompat.getDrawable(editor.context, R.drawable.img_hr),
                 nestingLevel,
+                AztecAttributes(),
                 editor
         )
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
@@ -6,7 +6,7 @@ import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 
 class AztecHorizontalRuleSpan(context: Context, drawable: Drawable, override var nestingLevel: Int,
-                              editor: AztecText? = null, override var attributes: AztecAttributes = AztecAttributes()) :
+                              override var attributes: AztecAttributes = AztecAttributes(), editor: AztecText? = null) :
         AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan, IAztecSpan {
     init {
         textView = editor

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -52,7 +52,7 @@ class AttributeTest {
         private val BIG = "<big b=\"B\">Big</big>"
         private val SMALL = "<small s=\"S\">Small</small>"
         private val P = "<p p=\"P\">Paragraph</p>"
-        private val LINE = "<hr h=\"H\"/>"
+        private val LINE = "<hr h=\"H\" />"
         private val MIXED = HEADING + BOLD + ITALIC + UNDERLINE + STRIKETHROUGH + ORDERED +
                 UNORDERED + QUOTE + LINK + COMMENT + COMMENT_MORE + COMMENT_PAGE +
                 UNKNOWN + LIST + SUB + SUP + FONT + TT + BIG + SMALL + P

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -52,6 +52,7 @@ class AttributeTest {
         private val BIG = "<big b=\"B\">Big</big>"
         private val SMALL = "<small s=\"S\">Small</small>"
         private val P = "<p p=\"P\">Paragraph</p>"
+        private val LINE = "<hr h=\"H\">Ruler</hr>"
         private val MIXED = HEADING + BOLD + ITALIC + UNDERLINE + STRIKETHROUGH + ORDERED +
                 UNORDERED + QUOTE + LINK + COMMENT + COMMENT_MORE + COMMENT_PAGE +
                 UNKNOWN + LIST + SUB + SUP + FONT + TT + BIG + SMALL + P
@@ -235,6 +236,15 @@ class AttributeTest {
     @Throws(Exception::class)
     fun smallAttributes() {
         val input = SMALL
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun rulerAttributes() {
+        val input = LINE
         editText.fromHtml(input)
         val output = editText.toHtml()
         Assert.assertEquals(input, output)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -52,7 +52,7 @@ class AttributeTest {
         private val BIG = "<big b=\"B\">Big</big>"
         private val SMALL = "<small s=\"S\">Small</small>"
         private val P = "<p p=\"P\">Paragraph</p>"
-        private val LINE = "<hr h=\"H\">Ruler</hr>"
+        private val LINE = "<hr h=\"H\"/>"
         private val MIXED = HEADING + BOLD + ITALIC + UNDERLINE + STRIKETHROUGH + ORDERED +
                 UNORDERED + QUOTE + LINK + COMMENT + COMMENT_MORE + COMMENT_PAGE +
                 UNKNOWN + LIST + SUB + SUP + FONT + TT + BIG + SMALL + P

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -960,11 +960,11 @@ class AztecToolbarTest {
     @Throws(Exception::class)
     fun orderedListMultiselectAlignment() {
         editText.fromHtml("<ol><li>item 1</li><li style=\"text-align: center;\">item 2</li></ol>" +
-                "<hr/><ol><li>item 3</li><li>item 4</li></ol>")
+                "<hr /><ol><li>item 3</li><li>item 4</li></ol>")
 
         editText.setSelection(editText.text.indexOf("2"), editText.text.indexOf("3"))
         alignRightButton.performClick()
-        Assert.assertEquals("<ol><li>item 1</li><li style=\"text-align: right;\">item 2</li></ol><hr/>" +
+        Assert.assertEquals("<ol><li>item 1</li><li style=\"text-align: right;\">item 2</li></ol><hr />" +
                 "<ol><li style=\"text-align: right;\">item 3</li><li>item 4</li></ol>",
                 editText.toHtml())
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -960,11 +960,11 @@ class AztecToolbarTest {
     @Throws(Exception::class)
     fun orderedListMultiselectAlignment() {
         editText.fromHtml("<ol><li>item 1</li><li style=\"text-align: center;\">item 2</li></ol>" +
-                "<hr><ol><li>item 3</li><li>item 4</li></ol>")
+                "<hr/><ol><li>item 3</li><li>item 4</li></ol>")
 
         editText.setSelection(editText.text.indexOf("2"), editText.text.indexOf("3"))
         alignRightButton.performClick()
-        Assert.assertEquals("<ol><li>item 1</li><li style=\"text-align: right;\">item 2</li></ol><hr>" +
+        Assert.assertEquals("<ol><li>item 1</li><li style=\"text-align: right;\">item 2</li></ol><hr/>" +
                 "<ol><li style=\"text-align: right;\">item 3</li><li>item 4</li></ol>",
                 editText.toHtml())
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -26,7 +26,7 @@ class ClipboardTest {
     private val UNDERLINE = "<u>Underline</u><br>"
     private val STRIKETHROUGH = "<s class=\"test\">Strikethrough</s>" // <s> or <strike> or <del>
     private val ORDERED = "<ol><li>Ordered</li><li></li></ol>"
-    private val LINE = "<hr/>"
+    private val LINE = "<hr />"
     private val UNORDERED = "<ul><li>Unordered</li><li></li></ul>"
     private val QUOTE = "<blockquote>Quote</blockquote>"
     private val LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a><br>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -26,7 +26,7 @@ class ClipboardTest {
     private val UNDERLINE = "<u>Underline</u><br>"
     private val STRIKETHROUGH = "<s class=\"test\">Strikethrough</s>" // <s> or <strike> or <del>
     private val ORDERED = "<ol><li>Ordered</li><li></li></ol>"
-    private val LINE = "<hr>"
+    private val LINE = "<hr/>"
     private val UNORDERED = "<ul><li>Unordered</li><li></li></ul>"
     private val QUOTE = "<blockquote>Quote</blockquote>"
     private val LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a><br>"


### PR DESCRIPTION
### Fix
This PR fixes #660, in which `<hr class="something">` tags would miss the class attribute when re-constructed back from Aztec to HTML.

1. Added a new test named `rulerAttributes` in `Attributestest` set in d082e80. 
2. now attributes for `<hr>` are retained, addressed in 1f51c88
3. **IMPORTANT** reflecting changes to cope with the `<hr/>`  style, which is supposed to be both valid HTML and XHTML as it's an enclosing tag, addressed in 572d200.

For point 3 above, I've based my decision in this https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr and  https://stackoverflow.com/questions/6428184/can-a-hr-element-have-a-closing-tag.  Given I consider myself no expert in HTML, please chime in with any reflections you may have on this.

### Test
You can either run the included new test and verify it passes, or:

1. Set an instance of `Aztec` with the following content (you can try setting this in the example app):
```
<!-- wp:separator --><hr class="wp-block-separator" /><!-- /wp:separator -->
```
2. run the following code:
```
            var pureHtml = aztec.sourceEditor?.getPureHtml()
            aztec.visualEditor.fromHtml(pureHtml!!)
            var htmlobtained = aztec.visualEditor.toHtml(false)
```
3. Observe `htmlobtained` now results in the following, matching the original content:
```
<!-- wp:separator --><hr class="wp-block-separator" /><!-- /wp:separator -->
```


### Review
@daniloercoli  @0nko 