### PR TITLE
Issue/662 keep focus on copy

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1242,7 +1242,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             android.R.id.pasteAsPlainText -> paste(text, min, max)
             android.R.id.copy -> {
                 copy(text, min, max)
-                clearFocus() // hide text action menu
+                setSelection(max)
             }
             android.R.id.cut -> {
                 copy(text, min, max)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1242,7 +1242,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             android.R.id.pasteAsPlainText -> paste(text, min, max)
             android.R.id.copy -> {
                 copy(text, min, max)
-                setSelection(max)
+                setSelection(max) // dismiss the selection to make the action menu hide
             }
             android.R.id.cut -> {
                 copy(text, min, max)


### PR DESCRIPTION
### Fix #662 

This PR revises what happens right after copying some text to the clipboard. Instead of clearing the focus, it tries to emulate what the parent component (EditText) does and just sets the cursor position to the end of the selection. That has the desired effect of dismissing the action menu.

### Test
1. Select some text
2. Tap on "Copy" on the popup action menu
3. Notice the cursor moving to the end of the selected text

### Review
@daniloercoli / @0nko