### PR TITLE
Issue/659 gutenberg fix preformatted closing delimiter

### DIFF
--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
@@ -12,6 +12,11 @@ import java.util.regex.Pattern
 
 class HiddenGutenbergPlugin : IHtmlCommentHandler, IInlineSpanHandler {
 
+    private val REGEX_PREFORMATTED_BLOCK_ENDING =
+            "<\\/pre>((?:(?!<\\/pre>|<!-- \\/wp:preformatted -->).)*?)<!-- \\/wp:preformatted -->"
+    private val REGEX_CODE_BLOCK_ENDING =
+            "<\\/pre>((?:(?!<\\/pre>|<!-- \\/wp:code -->).)*?)<!-- \\/wp:code -->"
+
     override fun handleComment(text: String, output: Editable, nestingLevel: Int): Boolean {
         if (text.trimStart().startsWith("wp:", true) ||
                 text.trimStart().startsWith("/wp:", true)) {
@@ -71,12 +76,8 @@ class HiddenGutenbergPlugin : IHtmlCommentHandler, IInlineSpanHandler {
             // as handleSpanStart() gets called
 
             when (gutenbergSpan.content) {
-                " /wp:preformatted " ->
-                    handleGutenbergBlockEnclosingTags(html, span,
-                            "<\\/pre>((?:(?!<\\/pre>|<!-- \\/wp:preformatted -->).)*?)<!-- \\/wp:preformatted -->")
-                " /wp:code " ->
-                    handleGutenbergBlockEnclosingTags(html, span,
-                            "<\\/pre>((?:(?!<\\/pre>|<!-- \\/wp:code -->).)*?)<!-- \\/wp:code -->")
+                " /wp:preformatted " -> handleGutenbergBlockEnclosingTags(html, span, REGEX_PREFORMATTED_BLOCK_ENDING)
+                " /wp:code " -> handleGutenbergBlockEnclosingTags(html, span, REGEX_CODE_BLOCK_ENDING)
             }
         }
     }

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
@@ -37,7 +37,43 @@ class HiddenGutenbergPlugin : IHtmlCommentHandler, IInlineSpanHandler {
 
     override fun handleSpanStart(html: StringBuilder, span: CharacterStyle) {
         val gutenbergSpan = span as GutenbergCommentSpan
+        // Note on special case handling for closing </pre> (preformatted) spans:
+        // Gutenberg expects to find nothing there between the closing </pre> tag and its proper block end delimiter.
+        // Therefore, we need to check here whether this was a preformatted block, and shift <br> position if present,
+        // so the ending Gutenberg delimiter is just right after the </pre> ending tag
+        // check whether we're just about to process the Gutenberg block ending tag.
+        //
+        // For example, feed the following code into Aztec:
+        //        <!-- wp:preformatted -->
+        //        <pre class=\"wp-block-preformatted\">bla bla bla</pre>
+        //        <!-- /wp:preformatted -->
+        //
+        // In visual editor, placing the cursor at the end and hitting ENTER twice to exit the block would end up
+        // with this code:
+        //        <!-- wp:preformatted -->
+        //        <pre class=\"wp-block-preformatted\">bla bla bla</pre><br>
+        //        <!-- /wp:preformatted -->
+        // Note the misplaced <br> tag, which Gutenberg expects to be after the block end delimiter.
+        //
+        // As another example, same thing happens with Gutenberg Code blocks:
+        // <!-- wp:code -->
+        // <pre class="wp-block-code"><code> javascript code here </code></pre>
+        // <!-- /wp:code -->
+        var foundBreakAfterClosingPreTag = -1
+        if (gutenbergSpan.content.trimStart().startsWith("/wp:")) {
+            // now, strip the <br> after the last HTML closing </pre> tag if such a thing is found
+            foundBreakAfterClosingPreTag = html.lastIndexOf("</pre><br>")
+            if (foundBreakAfterClosingPreTag > -1) {
+                html.delete(foundBreakAfterClosingPreTag + 6, foundBreakAfterClosingPreTag + 6 + 4)
+            }
+        }
+
         html.append("<!--${gutenbergSpan.content}-->")
+
+        if (foundBreakAfterClosingPreTag > -1) {
+            // re-attach the <br> tag
+            html.append("<br>")
+        }
     }
 
     override fun handleSpanEnd(html: StringBuilder, span: CharacterStyle) {

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
@@ -17,6 +17,9 @@ class HiddenGutenbergPlugin : IHtmlCommentHandler, IInlineSpanHandler {
     private val REGEX_CODE_BLOCK_ENDING =
             "<\\/pre>((?:(?!<\\/pre>|<!-- \\/wp:code -->).)*?)<!-- \\/wp:code -->"
 
+    private val patternPreformattedBlock = Pattern.compile(REGEX_PREFORMATTED_BLOCK_ENDING)
+    private val patternCodeBlock = Pattern.compile(REGEX_CODE_BLOCK_ENDING)
+
     override fun handleComment(text: String, output: Editable, nestingLevel: Int): Boolean {
         if (text.trimStart().startsWith("wp:", true) ||
                 text.trimStart().startsWith("/wp:", true)) {
@@ -76,8 +79,8 @@ class HiddenGutenbergPlugin : IHtmlCommentHandler, IInlineSpanHandler {
             // as handleSpanStart() gets called
 
             when (gutenbergSpan.content) {
-                " /wp:preformatted " -> handleGutenbergBlockEnclosingTags(html, span, REGEX_PREFORMATTED_BLOCK_ENDING)
-                " /wp:code " -> handleGutenbergBlockEnclosingTags(html, span, REGEX_CODE_BLOCK_ENDING)
+                " /wp:preformatted " -> handleGutenbergBlockEnclosingTags(html, span, patternPreformattedBlock)
+                " /wp:code " -> handleGutenbergBlockEnclosingTags(html, span, patternCodeBlock)
             }
         }
     }
@@ -85,8 +88,7 @@ class HiddenGutenbergPlugin : IHtmlCommentHandler, IInlineSpanHandler {
     override fun handleSpanEnd(html: StringBuilder, span: CharacterStyle) {
     }
 
-    fun handleGutenbergBlockEnclosingTags(html: StringBuilder, gutenbergSpan: GutenbergCommentSpan, regex: String) {
-        val pattern : Pattern = Pattern.compile(regex)
+    fun handleGutenbergBlockEnclosingTags(html: StringBuilder, gutenbergSpan: GutenbergCommentSpan, pattern: Pattern) {
         val matcher : Matcher = pattern.matcher(html)
         var tmpFoundGroup : String
         while (matcher.find()) {


### PR DESCRIPTION
### Fix

This PR fixes #659 as it tries to re-accomodate content in between closing HTML `</pre>` and GB `<!-- /wp:preformatted -->` or HTML `</pre>` and GB `<!-- /wp:code -->` tags, shifting it below the Gutenberg block end delimiter to keep the `</pre>` tag and GB block end delimiter together.

See it in action (test steps below):

![gutenenter](https://user-images.githubusercontent.com/6597771/39598611-80877352-4eef-11e8-8e32-323b4e3ef33d.gif)


In order to cope with this:
- the mechanism is coded in the `HiddenGutenbergPlugin`, serving itself of the Aztec plugin architecture to encapsulate the Gutenberg logic outside of Aztec itself.
- I chose to only trigger the mechanism every time an _ending_ Gutenberg comment span is processed, so to minimize the amount of times this is checked for. Also, this is good as we know for sure the content passed to `handleSpanStart()` should have the newly added content right before the span (shortest path possible).
- while it would normally be possible to use `RegEx.replace()` once a matching expression is found, this method only returns a new `String` object, which can be memory consuming, so in this implementation we're operating on the passed `StringBuffer` itself, to avoid having to keep up with copies of content unnecessarily

### Test
1. Initialize Aztec with the following html content, and set Calypso mode off
```
<!-- wp:preformatted -->﻿<pre class="wp-block-preformatted">bla bla bla</pre><!-- /wp:preformatted -->
<!-- wp:code --><pre class="wp-block-code"><code> javascript code here </code></pre><!-- /wp:code -->
```
2. in the visual mode, place the cursor right aftr the end of the first block, right after `bla bla bla`.
3. tap enter once, and then tap enter again to exit the block
4. switch to HTML and observe the `<br>` was added _after_ the GB block end delimiter `<!-- /wp:preformatted -->` 
5. switch back to visual editor
6. position the cursor at the end of the code block, right after `javascript code here`.
7. Tap `enter` twice to exit the code block, and enter some content, optionally hitting `enter` as well
8. switch to HTML mode and observe the content has been added  _after_ the GB block end delimiter `<!-- /wp:code -->` 

### Review
@daniloercoli 