### PR TITLE
Gutenberg block plugin fix

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -1,0 +1,261 @@
+package org.wordpress.aztec.demo.tests
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.support.test.espresso.intent.Intents
+import android.support.test.espresso.intent.matcher.IntentMatchers
+import android.support.test.espresso.intent.rule.IntentsTestRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.demo.BaseTest
+import org.wordpress.aztec.demo.MainActivity
+import org.wordpress.aztec.demo.R
+import org.wordpress.aztec.demo.pages.EditorPage
+import org.wordpress.aztec.source.SourceViewEditText
+import java.io.File
+import java.io.FileOutputStream
+
+class GutenbergCompatTests : BaseTest() {
+
+    @Rule
+    @JvmField
+    val mActivityIntentsTestRule = IntentsTestRule<MainActivity>(MainActivity::class.java)
+
+    @Before
+    fun init() {
+        val aztecText = mActivityIntentsTestRule.activity.findViewById<AztecText>(R.id.aztec)
+        val sourceText = mActivityIntentsTestRule.activity.findViewById<SourceViewEditText>(R.id.source)
+
+        aztecText.setCalypsoMode(false)
+        sourceText.setCalypsoMode(false)
+    }
+
+    @Test
+    fun testRetainGutenbergPostContent() {
+        val html = "<!-- wp:paragraph --><p>Blue is not a color</p><!-- /wp:paragraph -->" +
+                "<!-- wp:list --><ul><li>item 1</li><li>item2</li></ul><!-- /wp:list -->" +
+                "<!-- wp:heading --><h2>H2</h2><!-- /wp:heading -->"
+
+        EditorPage().toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testRetainGutenbergCommentsOnAddingText() {
+        val htmlStart = "<!-- wp:paragraph --><p>Blue is not</p><!-- /wp:paragraph -->"
+        val appendText = " a beautiful color"
+        val htmlVerify = "<!-- wp:paragraph --><p>Blue is not$appendText</p><!-- /wp:paragraph -->"
+
+        val editorPage = EditorPage()
+
+        // insert starter text
+        editorPage
+                .toggleHtml()
+                .insertHTML(htmlStart)
+                .toggleHtml()
+
+        // append text
+        editorPage
+                .setCursorPositionAtEnd()
+                .insertText(appendText)
+
+        // verify html
+        editorPage
+                .toggleHtml()
+                .verifyHTML(htmlVerify)
+    }
+
+    @Test
+    fun testAddPhotoAtBeginningOfGutenberParagraph() {
+        val htmlStart = "<!-- wp:paragraph --><p>"
+        val htmlEnd = "Blue is not a color</p><!-- /wp:paragraph -->"
+        val imagePlaceholder = "<img src=.+>"
+
+        val contentBeforeImageInsertion = htmlStart + htmlEnd
+        val contentAfterImageInsertion = htmlStart + imagePlaceholder + htmlEnd
+        val regex = Regex(contentAfterImageInsertion, RegexOption.DOT_MATCHES_ALL)
+        val editorPage = EditorPage()
+
+        // insert starter text
+        editorPage
+                .toggleHtml()
+                .insertHTML(contentBeforeImageInsertion)
+                .toggleHtml()
+
+        // insert image
+        editorPage
+                .moveCursorLeftAsManyTimes(contentBeforeImageInsertion.length)
+        createImageIntentFilter()
+        editorPage
+                .insertMedia()
+
+        // Must wait for simulated upload
+        Thread.sleep(10000)
+
+        editorPage
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
+
+    @Test
+    fun testAddPhotoAtEndOfGutenberParagraph() {
+        val htmlStart = "<!-- wp:paragraph --><p>Blue is not"
+        val htmlEnd = "</p><!-- /wp:paragraph -->"
+        val imagePlaceholder = "<img src=.+>"
+
+        val contentBeforeImageInsertion = htmlStart + htmlEnd
+        val contentAfterImageInsertion = htmlStart + imagePlaceholder + htmlEnd
+        val regex = Regex(contentAfterImageInsertion, RegexOption.DOT_MATCHES_ALL)
+        val editorPage = EditorPage()
+
+        // insert starter text
+        editorPage
+                .toggleHtml()
+                .insertHTML(contentBeforeImageInsertion)
+                .toggleHtml()
+
+        // insert image
+        editorPage
+                .setCursorPositionAtEnd()
+        createImageIntentFilter()
+        editorPage
+                .insertMedia()
+
+        // Must wait for simulated upload
+        Thread.sleep(10000)
+
+        editorPage
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
+
+    @Test
+    fun testAddPhotoAtEndOfGutenberFirstParagraph() {
+        val htmlStart = "<!-- wp:paragraph --><p>Blue is not a color"
+        val htmlEnd = "</p><!-- /wp:paragraph -->"
+        val imagePlaceholder = "<img src=.+>"
+        val secondParagraphContent = "Red is a color"
+        val htmlSecondParagraph = "<!-- wp:paragraph --><p>$secondParagraphContent</p><!-- /wp:paragraph -->"
+
+        val contentBeforeImageInsertion = htmlStart + htmlEnd + htmlSecondParagraph
+        val contentAfterImageInsertion = htmlStart + imagePlaceholder + htmlEnd + htmlSecondParagraph
+        val regex = Regex(contentAfterImageInsertion, RegexOption.DOT_MATCHES_ALL)
+        val editorPage = EditorPage()
+
+        // insert starter text
+        editorPage
+                .toggleHtml()
+                .insertHTML(contentBeforeImageInsertion)
+                .toggleHtml()
+
+        // insert image
+        editorPage
+                .setCursorPositionAtEnd()
+                .moveCursorLeftAsManyTimes(secondParagraphContent.length + 1)
+        createImageIntentFilter()
+        editorPage
+                .insertMedia()
+
+        // Must wait for simulated upload
+        Thread.sleep(10000)
+
+        editorPage
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
+
+    @Test
+    fun testAddPhotoAtStartOfGutenberSecondParagraph() {
+        val firstParagraphHTML = "<!-- wp:paragraph --><p>Blue is not a color</p><!-- /wp:paragraph -->"
+        val secondParagraphContent = "Red is a color"
+        val htmlStart = "<!-- wp:paragraph --><p>"
+        val htmlEnd = "$secondParagraphContent</p><!-- /wp:paragraph -->"
+        val imagePlaceholder = "<img src=.+>"
+
+        val contentBeforeImageInsertion = firstParagraphHTML + htmlStart + htmlEnd
+        val contentAfterImageInsertion = firstParagraphHTML + htmlStart + imagePlaceholder + htmlEnd
+        val regex = Regex(contentAfterImageInsertion, RegexOption.DOT_MATCHES_ALL)
+        val editorPage = EditorPage()
+
+        // insert starter text
+        editorPage
+                .toggleHtml()
+                .insertHTML(contentBeforeImageInsertion)
+                .toggleHtml()
+
+        // insert image
+        editorPage
+                .setCursorPositionAtEnd()
+                .moveCursorLeftAsManyTimes(secondParagraphContent.length)
+        createImageIntentFilter()
+        editorPage.insertMedia()
+
+        // Must wait for simulated upload
+        Thread.sleep(10000)
+
+        editorPage
+                .toggleHtml()
+                .verifyHTML(regex)
+    }
+
+    @Test
+    fun testSimpleAddItemToOrderedList() {
+        val htmlStart = "<!-- wp:list --><ul><li>item 1</li><li>item2</li></ul><!-- /wp:list -->"
+        val newItem = "item3"
+        val html = "<!-- wp:list --><ul><li>item 1</li><li>item2</li><li>$newItem</li></ul><!-- /wp:list -->"
+
+        val editorPage = EditorPage()
+
+        // insert starter text
+        editorPage
+                .toggleHtml()
+                .insertHTML(htmlStart)
+                .toggleHtml()
+
+        // insert new item
+        editorPage
+                .setCursorPositionAtEnd()
+                .insertText("\n" + newItem)
+
+        editorPage
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testDeleteAllItemsFromList() {
+        val html = "<!-- wp:list --><ul><li>item 1</li><li>item2</li></ul><!-- /wp:list -->"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+                .setCursorPositionAtEnd()
+                .delete(html.length-1)
+                .toggleHtml()
+                .verifyHTML("")
+    }
+
+    private fun createImageIntentFilter() {
+        val file = File(mActivityIntentsTestRule.activity.filesDir, "aztec.png")
+        val outputStream = FileOutputStream(file)
+        val bitmap = BitmapFactory.decodeResource(mActivityIntentsTestRule.activity.resources, R.drawable.aztec)
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        outputStream.close()
+
+        val intent = Intent()
+        intent.data = Uri.fromFile(file)
+        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_OPEN_DOCUMENT))
+                .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, intent))
+    }
+
+}

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -398,7 +398,7 @@ open class MainActivity : AppCompatActivity(),
                 .addPlugin(CaptionShortcodePlugin(visualEditor))
                 .addPlugin(VideoShortcodePlugin())
                 .addPlugin(AudioShortcodePlugin())
-                .addPlugin(HiddenGutenbergPlugin())
+                .addPlugin(HiddenGutenbergPlugin(visualEditor))
                 .addPlugin(galleryButton)
                 .addPlugin(cameraButton)
 

--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -807,7 +807,14 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
         if (plugins != null) {
             for (IAztecPlugin plugin : plugins) {
                 if (plugin instanceof IHtmlCommentHandler) {
-                    wasCommentHandled = ((IHtmlCommentHandler) plugin).handleComment(comment, spannableStringBuilder, nestingLevel);
+                    wasCommentHandled = ((IHtmlCommentHandler) plugin).handleComment(comment, spannableStringBuilder,
+                            nestingLevel, new Function1<Integer, Unit>() {
+                        @Override
+                        public Unit invoke(Integer newNesting) {
+                            nestingLevel = newNesting;
+                            return Unit.INSTANCE;
+                        }
+                    });
                     if (wasCommentHandled) {
                         break;
                     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -55,7 +55,8 @@ import java.util.ArrayList
 import java.util.Collections
 import java.util.Comparator
 
-class AztecParser(val plugins: List<IAztecPlugin> = listOf(), private val ignoredTags: List<String> = listOf("body", "html")) {
+class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = listOf(),
+                                            private val ignoredTags: List<String> = listOf("body", "html")) {
 
     fun fromHtml(source: String, context: Context): Spanned {
         val tidySource = tidy(source)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -363,7 +363,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = listOf(), private val ignore
             i = next
         } while (i < end)
 
-        consumeCursorIfInInput(out, text, text.length)
+        consumeCursorIfInInput(out, text, i)
     }
 
     private fun withinUnknown(out: StringBuilder, text: Spanned, start: Int, end: Int, unknownHtmlSpan: UnknownHtmlSpan) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -137,24 +137,6 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
     }
 
     private fun insertMedia(span: AztecMediaSpan) {
-        val spanBeforeMedia = editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java)
-                .firstOrNull {
-                    selectionStart == editableText.getSpanEnd(it)
-                }
-
-        val spanAfterMedia = editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java)
-                .firstOrNull {
-                    selectionStart == editableText.getSpanStart(it)
-                }
-
-        if (spanAfterMedia != null) {
-            editableText.setSpan(spanAfterMedia, selectionStart, editableText.getSpanEnd(spanAfterMedia), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-
-        if (spanBeforeMedia != null) {
-            editableText.setSpan(spanBeforeMedia, editableText.getSpanStart(spanBeforeMedia), selectionEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-
         editor.removeInlineStylesFromRange(selectionStart, selectionEnd)
 
         val ssb = SpannableStringBuilder(Constants.IMG_STRING)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -19,7 +19,6 @@ import org.wordpress.aztec.spans.AztecImageSpan
 import org.wordpress.aztec.spans.AztecMediaClickableSpan
 import org.wordpress.aztec.spans.AztecMediaSpan
 import org.wordpress.aztec.spans.AztecVideoSpan
-import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.spans.IAztecNestable
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
 import org.xml.sax.Attributes

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/html2visual/IHtmlCommentHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/html2visual/IHtmlCommentHandler.kt
@@ -1,10 +1,12 @@
 package org.wordpress.aztec.plugins.html2visual
 
+import android.annotation.SuppressLint
 import android.text.Editable
 
 /**
  * An interface for HTML comment processing plugins.
  */
+@SuppressLint("NewApi")
 interface IHtmlCommentHandler {
     /**
      * A plugin handler used by [org.wordpress.aztec.Html] parser during HTML-to-span parsing.
@@ -17,7 +19,7 @@ interface IHtmlCommentHandler {
      *
      * @return true if this plugin handled the comment and no other handler should be called, false otherwise.
      */
-    fun handleComment(text: String, output: Editable, nestingLevel: Int): Boolean {
+    fun handleComment(text: String, output: Editable, nestingLevel: Int, updateNesting: (Int) -> Unit): Boolean {
         return true
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/visual2html/IBlockSpanHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/visual2html/IBlockSpanHandler.kt
@@ -1,23 +1,14 @@
 package org.wordpress.aztec.plugins.visual2html
 
 import android.annotation.SuppressLint
-import android.text.style.CharacterStyle
 import org.wordpress.aztec.plugins.IAztecPlugin
+import org.wordpress.aztec.spans.IAztecParagraphStyle
 
 /**
- * An interface for processing inline spans during visual-to-HTML.
+ * An interface for processing block spans during visual-to-HTML.
  */
 @SuppressLint("NewApi")
-interface IInlineSpanHandler : IAztecPlugin {
-    /**
-     * Determines, whether the content of a span (text, if any) should be parsed/rendered by [org.wordpress.aztec.AztecParser]
-     *
-     * @return true if content should be parsed, false otherwise.
-     */
-    fun shouldParseContent(): Boolean {
-        return true
-    }
-
+interface IBlockSpanHandler : IAztecPlugin {
     /**
      * Determines, whether the plugin can handle a particular [span] type.
      *
@@ -25,7 +16,7 @@ interface IInlineSpanHandler : IAztecPlugin {
      *
      * @return true for compatible spans, false otherwise.
      */
-    fun canHandleSpan(span: CharacterStyle): Boolean
+    fun canHandleSpan(span: IAztecParagraphStyle): Boolean
 
     /**
      * A plugin handler used by [org.wordpress.aztec.AztecParser] during span-to-HTML parsing.
@@ -35,7 +26,7 @@ interface IInlineSpanHandler : IAztecPlugin {
      * @param html the resulting HTML string output.
      * @param span the encountered span.
      */
-    fun handleSpanStart(html: StringBuilder, span: CharacterStyle)
+    fun handleSpanStart(html: StringBuilder, span: IAztecParagraphStyle)
 
     /**
      * A plugin handler used by [org.wordpress.aztec.AztecParser] during span-to-HTML parsing.
@@ -45,5 +36,5 @@ interface IInlineSpanHandler : IAztecPlugin {
      * @param html the resulting HTML string output.
      * @param span the encountered span.
      */
-    fun handleSpanEnd(html: StringBuilder, span: CharacterStyle)
+    fun handleSpanEnd(html: StringBuilder, span: IAztecParagraphStyle)
 }

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
@@ -2,44 +2,63 @@ package org.wordpress.aztec.plugins.wpcomments
 
 import android.text.Editable
 import android.text.Spannable
-import android.text.style.CharacterStyle
-import org.wordpress.aztec.Constants
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.plugins.IAztecPlugin
 import org.wordpress.aztec.plugins.html2visual.IHtmlCommentHandler
-import org.wordpress.aztec.plugins.visual2html.IInlineSpanHandler
+import org.wordpress.aztec.plugins.visual2html.IBlockSpanHandler
+import org.wordpress.aztec.plugins.wpcomments.handlers.GutenbergCommentHandler
 import org.wordpress.aztec.plugins.wpcomments.spans.GutenbergCommentSpan
+import org.wordpress.aztec.spans.IAztecParagraphStyle
+import org.wordpress.aztec.util.getLast
+import org.wordpress.aztec.watchers.BlockElementWatcher
 
-class HiddenGutenbergPlugin : IHtmlCommentHandler, IInlineSpanHandler {
+class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: AztecText? = null)  :
+        IAztecPlugin, IHtmlCommentHandler, IBlockSpanHandler {
 
-    override fun handleComment(text: String, output: Editable, nestingLevel: Int): Boolean {
-        if (text.trimStart().startsWith("wp:", true) ||
-                text.trimStart().startsWith("/wp:", true)) {
+    init {
+        aztecText?.let {
+            BlockElementWatcher(aztecText)
+                    .add(GutenbergCommentHandler())
+                    .install(aztecText)
+        }
+    }
+
+    override fun handleComment(text: String, output: Editable, nestingLevel: Int, updateNesting: (Int) -> Unit): Boolean {
+        if (text.trimStart().startsWith("wp:", true)) {
             val spanStart = output.length
-            output.append(Constants.MAGIC_CHAR)
-
             output.setSpan(
-                    GutenbergCommentSpan(text),
+                    GutenbergCommentSpan(text, nestingLevel + 1),
                     spanStart,
                     output.length,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                    Spannable.SPAN_MARK_MARK
             )
+            updateNesting(nestingLevel + 1)
+
+            return true
+        } else if (text.trimStart().startsWith("/wp:", true)) {
+            val span = output.getLast<GutenbergCommentSpan>()
+            span?.let {
+                span.endTag = text
+                output.setSpan(span, output.getSpanStart(span), output.length,
+                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+            updateNesting(nestingLevel - 1)
+
             return true
         }
+
         return false
     }
 
-    override fun canHandleSpan(span: CharacterStyle): Boolean {
+    override fun canHandleSpan(span: IAztecParagraphStyle): Boolean {
         return span is GutenbergCommentSpan
     }
 
-    override fun shouldParseContent(): Boolean {
-        return true
+    override fun handleSpanStart(html: StringBuilder, span: IAztecParagraphStyle) {
+        html.append("<!--${span.startTag}-->")
     }
 
-    override fun handleSpanStart(html: StringBuilder, span: CharacterStyle) {
-        val gutenbergSpan = span as GutenbergCommentSpan
-        html.append("<!--${gutenbergSpan.content}-->")
-    }
-
-    override fun handleSpanEnd(html: StringBuilder, span: CharacterStyle) {
+    override fun handleSpanEnd(html: StringBuilder, span: IAztecParagraphStyle) {
+        html.append("<!--${span.endTag}-->")
     }
 }

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
@@ -12,7 +12,7 @@ import org.wordpress.aztec.spans.IAztecParagraphStyle
 import org.wordpress.aztec.util.getLast
 import org.wordpress.aztec.watchers.BlockElementWatcher
 
-class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: AztecText? = null)  :
+class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: AztecText? = null) :
         IAztecPlugin, IHtmlCommentHandler, IBlockSpanHandler {
 
     init {

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
@@ -29,7 +29,7 @@ class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpan
         html.append("-->")
     }
 
-    override fun handleComment(text: String, output: Editable, nestingLevel: Int): Boolean {
+    override fun handleComment(text: String, output: Editable, nestingLevel: Int, updateNesting: (Int) -> Unit): Boolean {
 
         val spanStart = output.length
 

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/handlers/GutenbergCommentHandler.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/handlers/GutenbergCommentHandler.kt
@@ -1,0 +1,6 @@
+package org.wordpress.aztec.plugins.wpcomments.handlers
+
+import org.wordpress.aztec.handlers.GenericBlockHandler
+import org.wordpress.aztec.plugins.wpcomments.spans.GutenbergCommentSpan
+
+class GutenbergCommentHandler : GenericBlockHandler<GutenbergCommentSpan>(GutenbergCommentSpan::class.java)

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
@@ -1,9 +1,23 @@
 package org.wordpress.aztec.plugins.wpcomments.spans
 
-import android.text.TextPaint
-import android.text.style.CharacterStyle
+import android.text.Layout
+import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.spans.IAztecBlockSpan
 
-class GutenbergCommentSpan(var content: String) : CharacterStyle() {
-    override fun updateDrawState(tp: TextPaint) {
-    }
+class GutenbergCommentSpan(
+        override val startTag: String,
+        override var nestingLevel: Int,
+        override var attributes: AztecAttributes = AztecAttributes()
+) : IAztecBlockSpan {
+    override val TAG: String = "wp:"
+    override var align: Layout.Alignment? = null
+    override var startBeforeCollapse: Int = -1
+    override var endBeforeBleed: Int = -1
+
+    private var _endTag: String = super.endTag
+    override var endTag: String
+        get() = _endTag
+        set(value) {
+            _endTag = value
+        }
 }


### PR DESCRIPTION
Fixes #659.

I was curious how difficult it would be to parse GB comments as a block. I had to add a new plugin type `IBlockSpanHandler` because we only had one for inline spans. 

There were a couple of issues along the way, like broken nesting because of extra `<html>` and `<body>` being inserted by the TagSoup parser. But it seems like this could be the right approach and the result looks promising.

![gb_block](https://user-images.githubusercontent.com/1522856/39664680-f5638682-5086-11e8-90b1-b01418980b96.gif)