### PR TITLE
Google chromebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ android:
     - extra-google-m2repository
     - platform-tools
     - tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-27.0.3
+    - android-27
 
 env:
   global:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "org.wordpress.aztec"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -292,7 +292,7 @@ open class MainActivity : AppCompatActivity(),
         aztec.visualEditor.setOverlay(predicate, 0, ColorDrawable(0x80000000.toInt()), Gravity.FILL)
         aztec.visualEditor.updateElementAttributes(predicate, attrs)
 
-        val progressDrawable = ContextCompat.getDrawable(this, android.R.drawable.progress_horizontal)
+        val progressDrawable = ContextCompat.getDrawable(this, android.R.drawable.progress_horizontal)!!
         // set the height of the progress bar to 2 (it's in dp since the drawable will be adjusted by the span)
         progressDrawable.setBounds(0, 0, 0, 4)
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionName "1.0"
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -54,7 +54,7 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
 
     init {
         val styles = context.obtainStyledAttributes(R.styleable.AztecText)
-        loadingDrawable = ContextCompat.getDrawable(context, styles.getResourceId(R.styleable.AztecText_drawableLoading, R.drawable.ic_image_loading))
+        loadingDrawable = ContextCompat.getDrawable(context, styles.getResourceId(R.styleable.AztecText_drawableLoading, R.drawable.ic_image_loading))!!
         styles.recycle()
     }
 
@@ -116,7 +116,7 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
             LINE -> {
                 if (opening) {
                     // Add an extra newline above the line to prevent weird typing on the line above
-                    start(output, AztecHorizontalRuleSpan(context, ContextCompat.getDrawable(context, R.drawable.img_hr),
+                    start(output, AztecHorizontalRuleSpan(context, ContextCompat.getDrawable(context, R.drawable.img_hr)!!,
                             nestingLevel, AztecAttributes(attributes)))
                     output.append(Constants.MAGIC_CHAR)
                 } else {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -104,7 +104,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
 
         val span = AztecHorizontalRuleSpan(
                 editor.context,
-                ContextCompat.getDrawable(editor.context, R.drawable.img_hr),
+                ContextCompat.getDrawable(editor.context, R.drawable.img_hr)!!,
                 nestingLevel,
                 AztecAttributes(),
                 editor

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         robolectricVersion = '3.5.1'
         jUnitVersion = '4.12'
         jSoupVersion = '1.10.3'
-        wordpressUtilsVersion = '1.18.1'
+        wordpressUtilsVersion = '1.21-beta1'
         espressoVersion = '3.0.1'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         gradlePluginVersion = '3.0.1'
-        kotlinVersion = '1.2.21'
+        kotlinVersion = '1.2.41'
         supportLibVersion = '26.1.0'
         tagSoupVersion = '1.2.1'
         glideVersion = '3.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         gradlePluginVersion = '3.0.1'
         kotlinVersion = '1.2.41'
-        supportLibVersion = '26.1.0'
+        supportLibVersion = '27.1.1'
         tagSoupVersion = '1.2.1'
         glideVersion = '3.7.0'
         picassoVersion = '2.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         robolectricVersion = '3.5.1'
         jUnitVersion = '4.12'
         jSoupVersion = '1.10.3'
-        wordpressUtilsVersion = '1.21-beta1'
+        wordpressUtilsVersion = '1.21'
         espressoVersion = '3.0.1'
     }
 

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri May 11 09:10:29 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionName "1.0"
     }
 

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     implementation "com.android.support:support-v4:$supportLibVersion"
     implementation "com.android.support:design:$supportLibVersion"
+    implementation "org.wordpress:utils:$wordpressUtilsVersion"
 
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
@@ -41,7 +41,7 @@ class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpan
                     WordPressCommentSpan(
                             text,
                             visualEditor.context,
-                            ContextCompat.getDrawable(visualEditor.context, R.drawable.img_more),
+                            ContextCompat.getDrawable(visualEditor.context, R.drawable.img_more)!!,
                             nestingLevel
                     ),
                     spanStart,
@@ -57,7 +57,7 @@ class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpan
                     WordPressCommentSpan(
                             text,
                             visualEditor.context,
-                            ContextCompat.getDrawable(visualEditor.context, R.drawable.img_page),
+                            ContextCompat.getDrawable(visualEditor.context, R.drawable.img_page)!!,
                             nestingLevel
                     ),
                     spanStart,

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -7,6 +7,7 @@ import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.ToggleButton
+import org.wordpress.android.util.DeviceUtils
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Constants
 import org.wordpress.aztec.plugins.IToolbarButton
@@ -45,11 +46,7 @@ class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
     }
 
     override fun matchesKeyShortcut(keyCode: Int, event: KeyEvent): Boolean {
-        return !isChromebook() && keyCode == KeyEvent.KEYCODE_T && event.isAltPressed && event.isCtrlPressed // Read More = Alt + Ctrl + T
-    }
-
-    fun isChromebook(): Boolean {
-        return context.packageManager.hasSystemFeature("org.chromium.arc.device_management")
+        return DeviceUtils.getInstance().isAppRuntimeForChrome(context) && keyCode == KeyEvent.KEYCODE_T && event.isAltPressed && event.isCtrlPressed // Read More = Alt + Ctrl + T
     }
 
     override fun inflateButton(parent: ViewGroup) {

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -46,7 +46,11 @@ class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
     }
 
     override fun matchesKeyShortcut(keyCode: Int, event: KeyEvent): Boolean {
-        return DeviceUtils.getInstance().isAppRuntimeForChrome(context) && keyCode == KeyEvent.KEYCODE_T && event.isAltPressed && event.isCtrlPressed // Read More = Alt + Ctrl + T
+        if (DeviceUtils.getInstance().isChromebook(context)) {
+            return false // This opens the terminal in Chromebooks
+        }
+
+        return keyCode == KeyEvent.KEYCODE_T && event.isAltPressed && event.isCtrlPressed // Read More = Alt + Ctrl + T
     }
 
     override fun inflateButton(parent: ViewGroup) {

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -45,7 +45,11 @@ class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
     }
 
     override fun matchesKeyShortcut(keyCode: Int, event: KeyEvent): Boolean {
-        return keyCode == KeyEvent.KEYCODE_T && event.isAltPressed && event.isCtrlPressed // Read More = Alt + Ctrl + T
+        return !isChromebook() && keyCode == KeyEvent.KEYCODE_T && event.isAltPressed && event.isCtrlPressed // Read More = Alt + Ctrl + T
+    }
+
+    fun isChromebook(): Boolean {
+        return context.packageManager.hasSystemFeature("org.chromium.arc.device_management")
     }
 
     override fun inflateButton(parent: ViewGroup) {

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -30,7 +30,7 @@ class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
         val span = WordPressCommentSpan(
                 WordPressCommentSpan.Comment.MORE.html,
                 visualEditor.context,
-                ContextCompat.getDrawable(visualEditor.context, R.drawable.img_more),
+                ContextCompat.getDrawable(visualEditor.context, R.drawable.img_more)!!,
                 nestingLevel,
                 visualEditor
         )

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
@@ -29,7 +29,7 @@ class PageToolbarButton(val visualEditor: AztecText) : IToolbarButton {
         val span = WordPressCommentSpan(
                 WordPressCommentSpan.Comment.PAGE.html,
                 visualEditor.context,
-                ContextCompat.getDrawable(visualEditor.context, R.drawable.img_page),
+                ContextCompat.getDrawable(visualEditor.context, R.drawable.img_page)!!,
                 nestingLevel,
                 visualEditor
         )

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionName "1.0"
     }
 


### PR DESCRIPTION
### Fix

On Chromebooks ctrl + alt + T is the shortcut for the terminal. This removes the more keyboard shortcut from being a duplicate shortcut with that.

### Test
1. Open the WP app and go into the editor
2. Press ctrl + alt + T and the terminal should open
3. Verify the more tag isn't added to the post

### Review
@maxme 