### PR TITLE
Keep media inside BlockSpan when at buffer end

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -363,7 +363,7 @@ class AztecParser(val plugins: List<IAztecPlugin> = listOf(), private val ignore
             i = next
         } while (i < end)
 
-        consumeCursorIfInInput(out, text, text.length)
+        consumeCursorIfInInput(out, text, i)
     }
 
     private fun withinUnknown(out: StringBuilder, text: Spanned, start: Int, end: Int, unknownHtmlSpan: UnknownHtmlSpan) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -144,7 +144,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
 
         val spanAfterMedia = editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java)
                 .firstOrNull {
-                    selectionStart == editableText.getSpanStart(it)
+                    (selectionStart == editableText.getSpanStart(it)) && (selectionStart != 0)
                 }
 
         if (spanAfterMedia != null) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -137,24 +137,6 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
     }
 
     private fun insertMedia(span: AztecMediaSpan) {
-        val spanBeforeMedia = editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java)
-                .firstOrNull {
-                    (selectionStart == editableText.getSpanEnd(it)) && (selectionStart != editableText.length)
-                }
-
-        val spanAfterMedia = editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java)
-                .firstOrNull {
-                    (selectionStart == editableText.getSpanStart(it)) && (selectionStart != 0)
-                }
-
-        if (spanAfterMedia != null) {
-            editableText.setSpan(spanAfterMedia, selectionStart, editableText.getSpanEnd(spanAfterMedia), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-
-        if (spanBeforeMedia != null) {
-            editableText.setSpan(spanBeforeMedia, editableText.getSpanStart(spanBeforeMedia), selectionEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-
         editor.removeInlineStylesFromRange(selectionStart, selectionEnd)
 
         val ssb = SpannableStringBuilder(Constants.IMG_STRING)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -139,7 +139,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
     private fun insertMedia(span: AztecMediaSpan) {
         val spanBeforeMedia = editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java)
                 .firstOrNull {
-                    selectionStart == editableText.getSpanEnd(it)
+                    (selectionStart == editableText.getSpanEnd(it)) && (selectionStart != editableText.length)
                 }
 
         val spanAfterMedia = editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java)


### PR DESCRIPTION
Additional PR to fix the issue reported at https://github.com/wordpress-mobile/AztecEditor-Android/pull/666#issuecomment-387121262

It seems that the media insertion code doesn't properly account for the buffer end position and ends up appending the media _outside_ the BlockSpan. This PR adds a check for the buffer end.

While at it, added a fix for the cursor position issue when switching between html and visual mode [as mentioned by Mario](https://github.com/wordpress-mobile/AztecEditor-Android/pull/666#issuecomment-387134347). BTW, that cursor issue is present in current `develop` too.

cc @daniloercoli , @mzorz 