### PR TITLE
overloaded AztecParser constructor for optional params

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -55,7 +55,8 @@ import java.util.ArrayList
 import java.util.Collections
 import java.util.Comparator
 
-class AztecParser(val plugins: List<IAztecPlugin> = listOf(), private val ignoredTags: List<String> = listOf("body", "html")) {
+class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = listOf(),
+                                            private val ignoredTags: List<String> = listOf("body", "html")) {
 
     fun fromHtml(source: String, context: Context): Spanned {
         val tidySource = tidy(source)


### PR DESCRIPTION
This PR just adds the Java overloads to `AztecParser` constructor so it can be called from Java without the optional parameters

cc @hypest @daniloercoli 