### PR TITLE
Add few other GB compatibility tests

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -76,7 +76,7 @@ class GutenbergCompatTests : BaseTest() {
     }
 
     @Test
-    fun testAddPhotoAtBeginningOfGutenberParagraph() {
+    fun testAddPhotoAtBeginningOfGutenbergParagraph() {
         val htmlStart = "<!-- wp:paragraph --><p>"
         val htmlEnd = "Blue is not a color</p><!-- /wp:paragraph -->"
         val imagePlaceholder = "<img src=.+>"
@@ -108,7 +108,7 @@ class GutenbergCompatTests : BaseTest() {
     }
 
     @Test
-    fun testAddPhotoAtEndOfGutenberParagraph() {
+    fun testAddPhotoAtEndOfGutenbergParagraph() {
         val htmlStart = "<!-- wp:paragraph --><p>Blue is not"
         val htmlEnd = "</p><!-- /wp:paragraph -->"
         val imagePlaceholder = "<img src=.+>"
@@ -140,7 +140,7 @@ class GutenbergCompatTests : BaseTest() {
     }
 
     @Test
-    fun testAddPhotoAtEndOfGutenberFirstParagraph() {
+    fun testAddPhotoAtEndOfGutenbergFirstParagraph() {
         val htmlStart = "<!-- wp:paragraph --><p>Blue is not a color"
         val htmlEnd = "</p><!-- /wp:paragraph -->"
         val imagePlaceholder = "<img src=.+>"
@@ -175,7 +175,7 @@ class GutenbergCompatTests : BaseTest() {
     }
 
     @Test
-    fun testAddPhotoAtStartOfGutenberSecondParagraph() {
+    fun testAddPhotoAtStartOfGutenbergSecondParagraph() {
         val firstParagraphHTML = "<!-- wp:paragraph --><p>Blue is not a color</p><!-- /wp:paragraph -->"
         val secondParagraphContent = "Red is a color"
         val htmlStart = "<!-- wp:paragraph --><p>"


### PR DESCRIPTION
Added a few other tests for GB compatibility. 

Had to set `ignore` on one of those, since it involves `img` tag, and the tag structure (closing tag actually) is not preserved by Aztec as seen in the original input doc.

