### PR TITLE
Add the ability to check if changes have been made to the content of the editor

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -14,9 +14,12 @@ import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.KeyEvent
 import android.view.View
+import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.hasToString
+import org.hamcrest.TypeSafeMatcher
+import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage
 import org.wordpress.aztec.demo.Matchers
@@ -364,6 +367,25 @@ class EditorPage : BasePage() {
         htmlEditor.check(matches(withText(expected)))
         label("Verified expected HTML editor contents without stripping")
 
+        return this
+    }
+
+    fun hasChanges(shouldHaveChanges : Boolean): EditorPage {
+        val hasNoChangesMatcher = object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("Aztec has no changes")
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                if (view is AztecText) {
+                    return view.hasChanges() == shouldHaveChanges
+                }
+
+                return false
+            }
+        }
+
+        editor.check(matches(hasNoChangesMatcher))
         return this
     }
 

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -229,4 +229,40 @@ class MixedTextFormattingTests : BaseTest() {
                 .toggleHtml()
                 .verifyHTML(html)
     }
+
+    /**
+     * Currently, this html <b>bold <i>italic</i> bold</b> after being parsed to span and back to html will become
+     * <b>bold </b><b><i>italic</i></b><b> bold</b>. This is not a bug, this is how Google originally implemented the parsing inside Html.java.
+     * https://github.com/wordpress-mobile/AztecEditor-Android/issues/136
+     *
+     * In this test we check the new `hasChanges` method to check if the post content has been edited by the user
+     */
+    @Test
+    fun testHasNoChangesWithMixedBoldAndItalicFormatting() {
+        val input = "<b>bold <i>italic</i> bold</b>"
+        val inputAfterParser = "<b>bold </b><b><i>italic</i></b><b> bold</b>"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(input)
+                .toggleHtml()
+                .toggleHtml()
+                .verifyHTML(inputAfterParser) // Verify that the input has changed by the HTML parser
+                .hasChanges(false) // Verify that the user had not changed the input
+    }
+
+    @Test
+    fun testHasChangesWithMixedBoldAndItalicFormatting() {
+        val input = "<b>bold <i>italic</i> bold</b>"
+        val insertedText = "text added"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(input)
+                .toggleHtml()
+                .setCursorPositionAtEnd()
+                .insertText(insertedText)
+                .toggleHtml()
+                .hasChanges(true)
+    }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -1201,4 +1201,14 @@ class AztecParserTest : AndroidTestCase() {
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlMixedBolndAndItalic_isNotEqual() {
+        val input = "<b>bold <i>italic</i> bold</b>"
+        val inputAfterParser = "<b>bold </b><b><i>italic</i></b><b> bold</b>"
+        val span = SpannableString(mParser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(output, inputAfterParser)
+    }
 }


### PR DESCRIPTION
This PR adds a utility method to `AztecText` that should be used to check wether the users have made changes to the content of the posts.

For example this html `<b>bold <i>italic</i> bold</b>` after being parsed to span and back to html will become `<b>bold </b><b><i>italic</i></b><b> bold</b>`. Reported in #136 - this is how Google originally implemented the parsing inside Html.java.
We've also seen similar problem with `img` tags.

This PR keeps a copy of the initial content set to the editor and use it later to check if changes have been made to the post content.
Tests are also available.

[wp-android details]
This PR tries to fix a bad UX where the post is uploaded to the server even if the user has not made any changes to it.


Not sure if I missed something, so better to check with @0nko 


