### PR TITLE
Fix for inline GB comments

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -51,6 +51,21 @@ class GutenbergCompatTests : BaseTest() {
     }
 
     @Test
+    fun testRetainGutenbergPostContentAndInlineGutenbergComment() {
+        val html =  "<!-- wp:latest-posts {\"postsToShow\":4,\"displayPostDate\":true} /-->" +
+                "<!-- wp:paragraph --><p>Blue is not a color</p><!-- /wp:paragraph -->" +
+                "<!-- wp:list --><ul><li>item 1</li><li>item2</li></ul><!-- /wp:list -->" +
+                "<!-- wp:heading --><h2>H2</h2><!-- /wp:heading -->" +
+                "<!-- wp:latest-posts {\"postsToShow\":10,\"displayPostDate\":false} /-->"
+
+        EditorPage().toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
     fun testRetainGutenbergCommentsOnAddingText() {
         val htmlStart = "<!-- wp:paragraph --><p>Blue is not</p><!-- /wp:paragraph -->"
         val appendText = " a beautiful color"

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
@@ -1,19 +1,24 @@
 package org.wordpress.aztec.plugins.wpcomments
 
+import android.support.v4.content.ContextCompat
 import android.text.Editable
 import android.text.Spannable
+import android.text.style.CharacterStyle
 import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.Constants
 import org.wordpress.aztec.plugins.IAztecPlugin
 import org.wordpress.aztec.plugins.html2visual.IHtmlCommentHandler
 import org.wordpress.aztec.plugins.visual2html.IBlockSpanHandler
+import org.wordpress.aztec.plugins.visual2html.IInlineSpanHandler
 import org.wordpress.aztec.plugins.wpcomments.handlers.GutenbergCommentHandler
 import org.wordpress.aztec.plugins.wpcomments.spans.GutenbergCommentSpan
+import org.wordpress.aztec.plugins.wpcomments.spans.GutenbergInlineCommentSpan
 import org.wordpress.aztec.spans.IAztecParagraphStyle
 import org.wordpress.aztec.util.getLast
 import org.wordpress.aztec.watchers.BlockElementWatcher
 
 class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: AztecText? = null) :
-        IAztecPlugin, IHtmlCommentHandler, IBlockSpanHandler {
+        IAztecPlugin, IHtmlCommentHandler, IBlockSpanHandler, IInlineSpanHandler {
 
     init {
         aztecText?.let {
@@ -24,7 +29,8 @@ class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: Azt
     }
 
     override fun handleComment(text: String, output: Editable, nestingLevel: Int, updateNesting: (Int) -> Unit): Boolean {
-        if (text.trimStart().startsWith("wp:", true)) {
+        // Here we handle GB block comments
+        if (text.trimStart().startsWith("wp:", true) && !text.trimEnd().endsWith("/")) {
             val spanStart = output.length
             output.setSpan(
                     GutenbergCommentSpan(text, nestingLevel + 1),
@@ -47,9 +53,28 @@ class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: Azt
             return true
         }
 
+        // Here we handle GB inline comments
+        if (aztecText != null && text.trimStart().startsWith("wp:", true)
+                && text.trimEnd().endsWith("/")) {
+            val spanStart = output.length
+            output.append(Constants.MAGIC_CHAR)
+            output.setSpan(
+                    GutenbergInlineCommentSpan(
+                            text,
+                            aztecText.context,
+                            ContextCompat.getDrawable(aztecText.context, android.R.drawable.ic_menu_help)!!,
+                            nestingLevel
+                    ),
+                    spanStart,
+                    output.length,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            return true
+        }
         return false
     }
 
+    /* GB block comments handling below */
     override fun canHandleSpan(span: IAztecParagraphStyle): Boolean {
         return span is GutenbergCommentSpan
     }
@@ -60,5 +85,18 @@ class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: Azt
 
     override fun handleSpanEnd(html: StringBuilder, span: IAztecParagraphStyle) {
         html.append("<!--${span.endTag}-->")
+    }
+
+    /* GB inline comments handling below */
+    override fun canHandleSpan(span: CharacterStyle): Boolean {
+        return span is GutenbergInlineCommentSpan
+    }
+
+    override fun handleSpanStart(html: StringBuilder, span: CharacterStyle) {
+        html.append("<!--")
+        html.append((span as GutenbergInlineCommentSpan).commentText)
+    }
+    override fun handleSpanEnd(html: StringBuilder, span: CharacterStyle) {
+        html.append("-->")
     }
 }

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergInlineCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergInlineCommentSpan.kt
@@ -1,0 +1,15 @@
+package org.wordpress.aztec.plugins.wpcomments.spans
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.spans.AztecDynamicImageSpan
+import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
+
+class GutenbergInlineCommentSpan @JvmOverloads constructor(val commentText: String, context: Context, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
+        AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan {
+
+    init {
+        textView = editor
+    }
+}


### PR DESCRIPTION
This PR fixes #675 by making sure inline Gutenberg comments are not eat by the GB block handler, and shows a `?` placeholder on Visual Editor.

We can ask designer to prepare a new drawable with some text in it, like `GB block`, and show it instead. (See how More and Page WordPress comments are handled visually in Aztec).

