### PR TITLE
Fix tests and improve CSS styles merger

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -52,7 +52,7 @@ class GutenbergCompatTests : BaseTest() {
 
     @Test
     fun testRetainGutenbergPostContentAndInlineGutenbergComment() {
-        val html =  "<!-- wp:latest-posts {\"postsToShow\":4,\"displayPostDate\":true} /-->" +
+        val html = "<!-- wp:latest-posts {\"postsToShow\":4,\"displayPostDate\":true} /-->" +
                 "<!-- wp:paragraph --><p>Blue is not a color</p><!-- /wp:paragraph -->" +
                 "<!-- wp:list --><ul><li>item 1</li><li>item2</li></ul><!-- /wp:list -->" +
                 "<!-- wp:heading --><h2>H2</h2><!-- /wp:heading -->" +

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -124,10 +124,10 @@ class CssStyleFormatter {
         }
 
         fun mergeStyleAttributes(firstStyle: String, secondStyle: String): String {
-            val firstStyles = firstStyle.trim().split(";").map { it.trim().replace(" ","") }
-            var secondStyles = secondStyle.trim().split(";").map { it.trim().replace(" ","") }
+            val firstStyles = firstStyle.trim().split(";").map { it.trim().replace(" ", "") }
+            var secondStyles = secondStyle.trim().split(";").map { it.trim().replace(" ", "") }
 
-            val mergedArray = firstStyles.union(secondStyles).filterNot {it.trim().isEmpty()}
+            val mergedArray = firstStyles.union(secondStyles).filterNot { it.trim().isEmpty() }
 
             var style = ""
             mergedArray.forEach({

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -124,13 +124,16 @@ class CssStyleFormatter {
         }
 
         fun mergeStyleAttributes(firstStyle: String, secondStyle: String): String {
-            var style = firstStyle.trim()
+            val firstStyles = firstStyle.trim().split(";").map { it.trim().replace(" ","") }
+            var secondStyles = secondStyle.trim().split(";").map { it.trim().replace(" ","") }
 
-            if (!style.isEmpty() && !style.endsWith(";")) {
-                style += "; "
-            }
+            val mergedArray = firstStyles.union(secondStyles).filterNot {it.trim().isEmpty()}
 
-            return style + secondStyle
+            var style = ""
+            mergedArray.forEach({
+                style = style + it.replace(":", ": ") + "; "
+            })
+            return style.trimEnd()
         }
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
@@ -26,7 +26,7 @@ class CssUnderlinePluginTest {
     private val COMPLEX_HTML = "<span style=\"test: value\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</span>"
     private val COMPLEX_REGULAR_DIV_HTML = "<div style=\"test: value;\">$REGULAR_UNDERLINE_WITH_STYLES_HTML</div>"
     private val COMPLEX_CSS_DIV_HTML = "<div style=\"test: value;\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</div>"
-    private val CSS_STYLE_UNDERLINE_WITH_EVEN_MORE_STYLES_REORDERED_HTML = "<span style=\"color: green; test: value; text-decoration: underline;\">Underline</span>"
+    private val CSS_STYLE_UNDERLINE_WITH_EVEN_MORE_STYLES_REORDERED_HTML = "<span style=\"color: green; text-decoration: underline; test: value;\">Underline</span>"
     private val CSS_UNDERLINE_INSIDE_BOLD = "<b><span style=\"color: lime; text-decoration: underline;\">Underline</span></b>"
     private val CSS_UNDERLINE_OUTSIDE_BOLD = "<span style=\"color: lime; text-decoration: underline;\"><b>Underline</b></span>"
 


### PR DESCRIPTION
Some *CSS* related tests are failing in `develop` due to a problem with the CSS styles merger that does not take in consideration duplicates. 

The problems with tests were introduced in #674, where at the beginning of the initialization process we call `calculateInitialHTMLSHA` to keep an hash of the initial content of the editor.
The routine `calculateInitialHTMLSHA` internally calls `toPlainHtml` , and it seems that 2 consecutive calls to `toPlainHtml` does make the CSS merger in trouble since it doesn't not take in consideration duplicates. I think there is an underlying problem in the CSS plugin, but for now I fixed it by improving the CSS merger class making sure to address duplicate styles on merging.