### PR TITLE
Fix - Add missing hasChanges method to HTML editor

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
@@ -5,7 +5,9 @@ import android.widget.EditText
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
+import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.source.Format
+import org.wordpress.aztec.source.SourceViewEditText
 
 object Matchers {
     fun withRegex(expected: Regex): Matcher<View> {
@@ -41,6 +43,25 @@ object Matchers {
                     return actualHtml == expectedHtml
                 }
 
+                return false
+            }
+        }
+    }
+
+    fun hasContentChanges(shouldHaveChanges: AztecText.EditorHasChanges): TypeSafeMatcher<View> {
+
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("User has made changes to the post: $shouldHaveChanges")
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                if (view is SourceViewEditText) {
+                    return view.hasChanges() == shouldHaveChanges
+                }
+                if (view is AztecText) {
+                    return view.hasChanges() == shouldHaveChanges
+                }
                 return false
             }
         }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
@@ -5,6 +5,7 @@ import android.widget.EditText
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
+import org.wordpress.aztec.AztecInitialContentHolder
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.source.Format
 import org.wordpress.aztec.source.SourceViewEditText
@@ -48,7 +49,7 @@ object Matchers {
         }
     }
 
-    fun hasContentChanges(shouldHaveChanges: AztecText.EditorHasChanges): TypeSafeMatcher<View> {
+    fun hasContentChanges(shouldHaveChanges: AztecInitialContentHolder.EditorHasChanges): TypeSafeMatcher<View> {
 
         return object : TypeSafeMatcher<View>() {
             override fun describeTo(description: Description) {

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -17,7 +17,7 @@ import android.view.View
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.hasToString
-import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.AztecInitialContentHolder
 import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage
 import org.wordpress.aztec.demo.Matchers
@@ -368,12 +368,12 @@ class EditorPage : BasePage() {
         return this
     }
 
-    fun hasChanges(shouldHaveChanges : AztecText.EditorHasChanges): EditorPage {
+    fun hasChanges(shouldHaveChanges : AztecInitialContentHolder.EditorHasChanges): EditorPage {
         editor.check(matches(Matchers.hasContentChanges(shouldHaveChanges)))
         return this
     }
 
-    fun hasChangesHTML(shouldHaveChanges : AztecText.EditorHasChanges): EditorPage {
+    fun hasChangesHTML(shouldHaveChanges : AztecInitialContentHolder.EditorHasChanges): EditorPage {
         htmlEditor.check(matches(Matchers.hasContentChanges(shouldHaveChanges)))
         return this
     }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -14,11 +14,9 @@ import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.KeyEvent
 import android.view.View
-import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.hasToString
-import org.hamcrest.TypeSafeMatcher
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage
@@ -371,21 +369,12 @@ class EditorPage : BasePage() {
     }
 
     fun hasChanges(shouldHaveChanges : AztecText.EditorHasChanges): EditorPage {
-        val hasNoChangesMatcher = object : TypeSafeMatcher<View>() {
-            override fun describeTo(description: Description) {
-                description.appendText("User has made changes to the post: $shouldHaveChanges")
-            }
+        editor.check(matches(Matchers.hasContentChanges(shouldHaveChanges)))
+        return this
+    }
 
-            public override fun matchesSafely(view: View): Boolean {
-                if (view is AztecText) {
-                    return view.hasChanges() == shouldHaveChanges
-                }
-
-                return false
-            }
-        }
-
-        editor.check(matches(hasNoChangesMatcher))
+    fun hasChangesHTML(shouldHaveChanges : AztecText.EditorHasChanges): EditorPage {
+        htmlEditor.check(matches(Matchers.hasContentChanges(shouldHaveChanges)))
         return this
     }
 

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -298,7 +298,7 @@ class MixedTextFormattingTests : BaseTest() {
                 .toggleHtml() // switch back to HTML editor
                 .insertHTML(insertedText)
                 .hasChangesHTML(AztecInitialContentHolder.EditorHasChanges.CHANGES)
-                .toggleHtml() // switch back to HTML editor
+                .toggleHtml() // switch back to Visual editor
                 .verify(afterParser)
     }
 }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -4,7 +4,7 @@ import android.support.test.rule.ActivityTestRule
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.AztecInitialContentHolder
 import org.wordpress.aztec.demo.BaseTest
 import org.wordpress.aztec.demo.MainActivity
 import org.wordpress.aztec.demo.pages.EditorPage
@@ -251,7 +251,7 @@ class MixedTextFormattingTests : BaseTest() {
                 .insertHTML(input)
                 .toggleHtml()
                 .toggleHtml()
-                .hasChanges(AztecText.EditorHasChanges.NO_CHANGES) // Verify that the user had not changed the input
+                .hasChanges(AztecInitialContentHolder.EditorHasChanges.NO_CHANGES) // Verify that the user had not changed the input
     }
 
     @Test
@@ -267,7 +267,7 @@ class MixedTextFormattingTests : BaseTest() {
                 .setCursorPositionAtEnd()
                 .insertText(insertedText)
                 .toggleHtml()
-                .hasChanges(AztecText.EditorHasChanges.CHANGES)
+                .hasChanges(AztecInitialContentHolder.EditorHasChanges.CHANGES)
                 .verifyHTML(afterParser)
     }
 
@@ -282,24 +282,23 @@ class MixedTextFormattingTests : BaseTest() {
                 .toggleHtml()
                 .toggleHtml() // switch back to HTML editor
                 .insertHTML(insertedText)
-                .hasChangesHTML(AztecText.EditorHasChanges.CHANGES)
+                .hasChangesHTML(AztecInitialContentHolder.EditorHasChanges.CHANGES)
                 .verifyHTML(afterParser)
     }
 
     @Test
-    fun testHasNoChangesOnHTMLEditor() {
-        val input = "<b>bold <i>italic</i> bold</b>"
+    fun testHasChangesOnHTMLEditorTestedFromVisualEditor() {
+        val input = "<b>Test</b>"
         val insertedText = " text added"
-        val afterParser = "<b>bold </b><i><b>italic</b></i><b> bold$insertedText</b>"
+        val afterParser = "Test$insertedText"
 
-        EditorPage()
-                .toggleHtml() // switch to HTML editor
+        EditorPage().toggleHtml()
                 .insertHTML(input)
-                .toggleHtml() // switch to Visual editor
-                .setCursorPositionAtEnd()
-                .insertText(insertedText)
-                .toggleHtml() // switch to HTML editor
-                .hasChangesHTML(AztecText.EditorHasChanges.NO_CHANGES)
-                .verifyHTML(afterParser)
+                .toggleHtml()
+                .toggleHtml() // switch back to HTML editor
+                .insertHTML(insertedText)
+                .hasChangesHTML(AztecInitialContentHolder.EditorHasChanges.CHANGES)
+                .toggleHtml() // switch back to HTML editor
+                .verify(afterParser)
     }
 }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -270,4 +270,36 @@ class MixedTextFormattingTests : BaseTest() {
                 .hasChanges(AztecText.EditorHasChanges.CHANGES)
                 .verifyHTML(afterParser)
     }
+
+    @Test
+    fun testHasChangesOnHTMLEditor() {
+        val input = "<b>Test</b>"
+        val insertedText = " text added"
+        val afterParser = "<b>Test</b>$insertedText"
+
+        EditorPage().toggleHtml()
+                .insertHTML(input)
+                .toggleHtml()
+                .toggleHtml() // switch back to HTML editor
+                .insertHTML(insertedText)
+                .hasChangesHTML(AztecText.EditorHasChanges.CHANGES)
+                .verifyHTML(afterParser)
+    }
+
+    @Test
+    fun testHasNoChangesOnHTMLEditor() {
+        val input = "<b>bold <i>italic</i> bold</b>"
+        val insertedText = " text added"
+        val afterParser = "<b>bold </b><i><b>italic</b></i><b> bold$insertedText</b>"
+
+        EditorPage()
+                .toggleHtml() // switch to HTML editor
+                .insertHTML(input)
+                .toggleHtml() // switch to Visual editor
+                .setCursorPositionAtEnd()
+                .insertText(insertedText)
+                .toggleHtml() // switch to HTML editor
+                .hasChangesHTML(AztecText.EditorHasChanges.NO_CHANGES)
+                .verifyHTML(afterParser)
+    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -28,6 +28,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
 
     init {
         initToolbar()
+        initInitialContentHolder()
     }
 
     private constructor(activity: Activity, @IdRes aztecTextId: Int,
@@ -46,10 +47,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
 
         initToolbar()
         initSourceEditorHistory()
-
-        val initialContentHolder = AztecInitialContentHolder()
-        visualEditor.initialContentHolder = initialContentHolder
-        sourceEditor.initialContentHolder = initialContentHolder
+        initInitialContentHolder()
     }
 
     companion object Factory {
@@ -69,6 +67,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
         fun with(visualEditor: AztecText, toolbar: AztecToolbar, toolbarClickListener: IAztecToolbarClickListener): Aztec {
             return Aztec(visualEditor, toolbar, toolbarClickListener)
         }
+    }
+
+    private fun initInitialContentHolder() {
+        val initialContentHolder = AztecInitialContentHolder()
+        visualEditor.initialContentHolder = initialContentHolder
+        sourceEditor?.initialContentHolder = initialContentHolder
     }
 
     fun setImageGetter(imageGetter: Html.ImageGetter): Aztec {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -46,6 +46,10 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
 
         initToolbar()
         initSourceEditorHistory()
+
+        val initialContentHolder = AztecInitialContentHolder()
+        visualEditor.initialContentHolder = initialContentHolder
+        sourceEditor.initialContentHolder = initialContentHolder
     }
 
     companion object Factory {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
@@ -13,10 +13,12 @@ class AztecInitialContentHolder() : Parcelable {
     }
 
     constructor(parcel : Parcel) : this() {
+        initialEditorContentParsedSHA256 = ByteArray(parcel.readInt())
         parcel.readByteArray(initialEditorContentParsedSHA256)
     }
 
     override fun writeToParcel(dest: Parcel?, flags: Int) {
+        dest?.writeInt(initialEditorContentParsedSHA256.size)
         dest?.writeByteArray(initialEditorContentParsedSHA256)
     }
 
@@ -24,14 +26,16 @@ class AztecInitialContentHolder() : Parcelable {
         return 0
     }
 
-    @SuppressWarnings("unused")
-    val CREATOR: Parcelable.Creator<AztecInitialContentHolder> = object : Parcelable.Creator<AztecInitialContentHolder> {
-        override fun createFromParcel(`in`: Parcel): AztecInitialContentHolder {
-            return AztecInitialContentHolder(`in`)
-        }
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<AztecInitialContentHolder> = object : Parcelable.Creator<AztecInitialContentHolder> {
+            override fun createFromParcel(`in`: Parcel): AztecInitialContentHolder {
+                return AztecInitialContentHolder(`in`)
+            }
 
-        override fun newArray(size: Int): Array<AztecInitialContentHolder?> {
-            return arrayOfNulls(size)
+            override fun newArray(size: Int): Array<AztecInitialContentHolder?> {
+                return arrayOfNulls(size)
+            }
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
@@ -12,6 +12,10 @@ class AztecInitialContentHolder() : Parcelable {
         CHANGES, NO_CHANGES, UNKNOWN
     }
 
+    interface EditorHasChangesInterface {
+        fun hasChanges(): AztecInitialContentHolder.EditorHasChanges
+    }
+
     constructor(parcel : Parcel) : this() {
         initialEditorContentParsedSHA256 = ByteArray(parcel.readInt())
         parcel.readByteArray(initialEditorContentParsedSHA256)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
@@ -49,11 +49,10 @@ class AztecInitialContentHolder() : Parcelable {
         try {
             // Do not recalculate the hash if it's not the first call to `fromHTML`.
             if (needToSetInitialValue()) {
-                //   val initialHTMLParsed = toPlainHtml(false)
                 initialEditorContentParsedSHA256 = calculateSHA256(source)
             }
         } catch (e: Throwable) {
-            // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException
+            // Do nothing here. calculateSHA256 -> NoSuchAlgorithmException
         }
     }
 
@@ -72,7 +71,7 @@ class AztecInitialContentHolder() : Parcelable {
                 }
                 return EditorHasChanges.CHANGES
             } catch (e: Throwable) {
-                // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException
+                // Do nothing here. calculateSHA256 -> NoSuchAlgorithmException
             }
         }
         return EditorHasChanges.UNKNOWN

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecInitialContentHolder.kt
@@ -1,0 +1,76 @@
+package org.wordpress.aztec
+
+import android.os.Parcel
+import android.os.Parcelable
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+import java.util.Arrays
+
+class AztecInitialContentHolder() : Parcelable {
+
+    enum class EditorHasChanges {
+        CHANGES, NO_CHANGES, UNKNOWN
+    }
+
+    constructor(parcel : Parcel) : this() {
+        parcel.readByteArray(initialEditorContentParsedSHA256)
+    }
+
+    override fun writeToParcel(dest: Parcel?, flags: Int) {
+        dest?.writeByteArray(initialEditorContentParsedSHA256)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    @SuppressWarnings("unused")
+    val CREATOR: Parcelable.Creator<AztecInitialContentHolder> = object : Parcelable.Creator<AztecInitialContentHolder> {
+        override fun createFromParcel(`in`: Parcel): AztecInitialContentHolder {
+            return AztecInitialContentHolder(`in`)
+        }
+
+        override fun newArray(size: Int): Array<AztecInitialContentHolder?> {
+            return arrayOfNulls(size)
+        }
+    }
+
+    private var initialEditorContentParsedSHA256: ByteArray = ByteArray(0)
+
+    fun needToSetInitialValue(): Boolean {
+        return (initialEditorContentParsedSHA256.isEmpty() || Arrays.equals(initialEditorContentParsedSHA256, calculateSHA256("")))
+    }
+
+    fun setInitialContent(source: String) {
+        try {
+            // Do not recalculate the hash if it's not the first call to `fromHTML`.
+            if (needToSetInitialValue()) {
+                //   val initialHTMLParsed = toPlainHtml(false)
+                initialEditorContentParsedSHA256 = calculateSHA256(source)
+            }
+        } catch (e: Throwable) {
+            // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException
+        }
+    }
+
+    @Throws(NoSuchAlgorithmException::class)
+    private fun calculateSHA256(s: String): ByteArray {
+        val digest = MessageDigest.getInstance("SHA-256")
+        digest.update(s.toByteArray())
+        return digest.digest()
+    }
+
+    fun hasChanges(source: String): EditorHasChanges {
+        if (!initialEditorContentParsedSHA256.isEmpty()) {
+            try {
+                if (Arrays.equals(initialEditorContentParsedSHA256, calculateSHA256(source))) {
+                    return EditorHasChanges.NO_CHANGES
+                }
+                return EditorHasChanges.CHANGES
+            } catch (e: Throwable) {
+                // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException
+            }
+        }
+        return EditorHasChanges.UNKNOWN
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -989,7 +989,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         initialContentHolder?.let {
             if (it.needToSetInitialValue()) {
-                it.setInitialContent(toPlainHtml(false))
+                try {
+                    it.setInitialContent(toPlainHtml(false))
+                } catch (e: Throwable) {
+                    // Do nothing here. `toPlainHtml` can throw exceptions
+                }
             }
         }
 
@@ -999,7 +1003,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     fun hasChanges(): AztecInitialContentHolder.EditorHasChanges {
         initialContentHolder?.let {
-            return it.hasChanges(toPlainHtml(false))
+            try {
+                return it.hasChanges(toPlainHtml(false))
+            } catch (e: Throwable) {
+                // Do nothing here. `toPlainHtml` can throw exceptions
+            }
         }
         return AztecInitialContentHolder.EditorHasChanges.UNKNOWN
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -115,7 +115,8 @@ import java.util.Arrays
 import java.util.LinkedList
 
 @Suppress("UNUSED_PARAMETER")
-open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlTappedListener, IEventInjector {
+open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlTappedListener, IEventInjector,
+        AztecInitialContentHolder.EditorHasChangesInterface {
     companion object {
         val BLOCK_EDITOR_HTML_KEY = "RETAINED_BLOCK_HTML_KEY"
         val BLOCK_EDITOR_START_INDEX_KEY = "BLOCK_EDITOR_START_INDEX_KEY"
@@ -1001,7 +1002,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         loadVideos()
     }
 
-    fun hasChanges(): AztecInitialContentHolder.EditorHasChanges {
+    override fun hasChanges(): AztecInitialContentHolder.EditorHasChanges {
         initialContentHolder?.let {
             try {
                 return it.hasChanges(toPlainHtml(false))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -23,7 +23,8 @@ import org.wordpress.aztec.spans.AztecCursorSpan
 import org.wordpress.aztec.util.InstanceStateUtils
 
 @SuppressLint("SupportAnnotationUsage")
-open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatcher {
+open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, TextWatcher,
+        AztecInitialContentHolder.EditorHasChangesInterface {
     companion object {
         val RETAINED_CONTENT_KEY = "RETAINED_CONTENT_KEY"
         val RETAINED_INITIAL_HTML_PARSED_SHA256_KEY = "RETAINED_INITIAL_HTML_PARSED_SHA256_KEY"
@@ -191,13 +192,13 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
     }
 
     fun displayStyledAndFormattedHtml(source: String) {
+        val formattedSource = Format.addSourceEditorFormatting(source, isInCalypsoMode)
         initialContentHolder?.let {
             if (it.needToSetInitialValue()) {
-                it.setInitialContent(source)
+                it.setInitialContent(formattedSource)
             }
         }
-
-        val styledHtml = styleHtml(Format.addSourceEditorFormatting(source, isInCalypsoMode))
+        val styledHtml = styleHtml(formattedSource)
 
         disableTextChangedListener()
         val cursorPosition = consumeCursorTag(styledHtml)
@@ -208,7 +209,7 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
             setSelection(cursorPosition)
     }
 
-    fun hasChanges(): AztecInitialContentHolder.EditorHasChanges {
+    override fun hasChanges(): AztecInitialContentHolder.EditorHasChanges {
         initialContentHolder?.let {
             return it.hasChanges(getPureHtml(false))
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -192,13 +192,12 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
     }
 
     fun displayStyledAndFormattedHtml(source: String) {
-        val formattedSource = Format.addSourceEditorFormatting(source, isInCalypsoMode)
         initialContentHolder?.let {
             if (it.needToSetInitialValue()) {
-                it.setInitialContent(formattedSource)
+                it.setInitialContent(source)
             }
         }
-        val styledHtml = styleHtml(formattedSource)
+        val styledHtml = styleHtml(Format.addSourceEditorFormatting(source, isInCalypsoMode))
 
         disableTextChangedListener()
         val cursorPosition = consumeCursorTag(styledHtml)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
@@ -26,7 +26,7 @@ class CssUnderlinePluginTest {
     private val COMPLEX_HTML = "<span style=\"test: value\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</span>"
     private val COMPLEX_REGULAR_DIV_HTML = "<div style=\"test: value;\">$REGULAR_UNDERLINE_WITH_STYLES_HTML</div>"
     private val COMPLEX_CSS_DIV_HTML = "<div style=\"test: value;\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</div>"
-    private val CSS_STYLE_UNDERLINE_WITH_EVEN_MORE_STYLES_REORDERED_HTML = "<span style=\"color: green; text-decoration: underline; test: value;\">Underline</span>"
+    private val CSS_STYLE_UNDERLINE_WITH_EVEN_MORE_STYLES_REORDERED_HTML = "<span style=\"color: green; test: value; text-decoration: underline;\">Underline</span>"
     private val CSS_UNDERLINE_INSIDE_BOLD = "<b><span style=\"color: lime; text-decoration: underline;\">Underline</span></b>"
     private val CSS_UNDERLINE_OUTSIDE_BOLD = "<span style=\"color: lime; text-decoration: underline;\"><b>Underline</b></span>"
 


### PR DESCRIPTION
We had add a way to detect if changes were made to the Visual Editor in https://github.com/wordpress-mobile/AztecEditor-Android/pull/674 but forgot to add the same checks to the HTML Editor. Resulting in hosting apps that are unaware if users made changes in the HTML editor or not.

To test this PR, open the demo app, makes some changes to the content in the HTL Editor and verify by calling `hasChanges` on it.
