### PR TITLE
Fix audio tag handling for Gutenberg audio blocks

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -1,5 +1,7 @@
 package org.wordpress.aztec.demo.pages
 
+import android.app.Activity
+import android.support.test.InstrumentationRegistry.getInstrumentation
 import android.support.test.espresso.DataInteraction
 import android.support.test.espresso.Espresso.onData
 import android.support.test.espresso.Espresso.onView
@@ -12,6 +14,8 @@ import android.support.test.espresso.action.ViewActions.typeTextIntoFocusedView
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import android.support.test.runner.lifecycle.Stage
 import android.view.KeyEvent
 import android.view.View
 import org.hamcrest.Description
@@ -24,6 +28,7 @@ import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage
 import org.wordpress.aztec.demo.Matchers
 import org.wordpress.aztec.demo.R
+import org.wordpress.aztec.source.SourceViewEditText
 
 class EditorPage : BasePage() {
     private var editor: ViewInteraction
@@ -49,6 +54,8 @@ class EditorPage : BasePage() {
 
     private var photoButton: ViewInteraction
     private var galleryButton: ViewInteraction
+
+    private var currentActivity: Activity?
 
     override val trait: ViewInteraction
         get() = onView(withId(R.id.aztec))
@@ -77,6 +84,27 @@ class EditorPage : BasePage() {
 
         photoButton = onView(allOf(withId(android.R.id.title), withText("Photo from device")))
         galleryButton = onView(withId(R.id.media_bar_button_gallery))
+
+        currentActivity = null
+    }
+
+    private fun getActivityInstance(): Activity? {
+        getInstrumentation().runOnMainSync {
+            val resumedActivities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED)
+            if (resumedActivities.iterator().hasNext()) {
+                currentActivity = resumedActivities.iterator().next() as Activity
+            }
+        }
+
+        return currentActivity
+    }
+
+    fun getAztecText(): AztecText? {
+        return getActivityInstance()?.findViewById(R.id.aztec)
+    }
+
+    fun getAztecSourceEditor(): SourceViewEditText? {
+        return getActivityInstance()?.findViewById(R.id.source)
     }
 
     fun tapTop(): EditorPage {

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -55,8 +55,6 @@ class EditorPage : BasePage() {
     private var photoButton: ViewInteraction
     private var galleryButton: ViewInteraction
 
-    private var currentActivity: Activity?
-
     override val trait: ViewInteraction
         get() = onView(withId(R.id.aztec))
 
@@ -84,27 +82,6 @@ class EditorPage : BasePage() {
 
         photoButton = onView(allOf(withId(android.R.id.title), withText("Photo from device")))
         galleryButton = onView(withId(R.id.media_bar_button_gallery))
-
-        currentActivity = null
-    }
-
-    private fun getActivityInstance(): Activity? {
-        getInstrumentation().runOnMainSync {
-            val resumedActivities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED)
-            if (resumedActivities.iterator().hasNext()) {
-                currentActivity = resumedActivities.iterator().next() as Activity
-            }
-        }
-
-        return currentActivity
-    }
-
-    fun getAztecText(): AztecText? {
-        return getActivityInstance()?.findViewById(R.id.aztec)
-    }
-
-    fun getAztecSourceEditor(): SourceViewEditText? {
-        return getActivityInstance()?.findViewById(R.id.source)
     }
 
     fun tapTop(): EditorPage {

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -1,7 +1,5 @@
 package org.wordpress.aztec.demo.pages
 
-import android.app.Activity
-import android.support.test.InstrumentationRegistry.getInstrumentation
 import android.support.test.espresso.DataInteraction
 import android.support.test.espresso.Espresso.onData
 import android.support.test.espresso.Espresso.onView
@@ -14,8 +12,6 @@ import android.support.test.espresso.action.ViewActions.typeTextIntoFocusedView
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
-import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
-import android.support.test.runner.lifecycle.Stage
 import android.view.KeyEvent
 import android.view.View
 import org.hamcrest.Description
@@ -28,7 +24,6 @@ import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage
 import org.wordpress.aztec.demo.Matchers
 import org.wordpress.aztec.demo.R
-import org.wordpress.aztec.source.SourceViewEditText
 
 class EditorPage : BasePage() {
     private var editor: ViewInteraction

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -321,7 +321,6 @@ class GutenbergCompatTests : BaseTest() {
                 .toggleHtml()
                 .verifyHTML(htmlWithoutShortcode)
 
-
         // now test a non-Gutenberg piece and make sure the <audio> tag has been replaced by the [audio] shortcode
         editorPage
                 .toggleHtml()

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -312,7 +312,9 @@ class GutenbergCompatTests : BaseTest() {
 
         val editorPage = EditorPage()
         val audioShortcodePlugin = AudioShortcodePlugin()
-        editorPage.getAztecText()?.plugins?.add(audioShortcodePlugin)
+        val aztecText = mActivityIntentsTestRule.activity.findViewById<AztecText>(R.id.aztec)
+        aztecText.plugins?.add(audioShortcodePlugin)
+
         // let's test the plugin works as expected, i.e. it preserves the Gutenberg block structure
         editorPage
                 .toggleHtml()

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodePlugin.kt
@@ -1,6 +1,7 @@
 package org.wordpress.aztec.plugins.shortcodes
 
 import org.wordpress.aztec.plugins.html2visual.IHtmlPreprocessor
+import org.wordpress.aztec.plugins.shortcodes.utils.GutenbergUtils
 import org.wordpress.aztec.plugins.visual2html.IHtmlPostprocessor
 
 class AudioShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
@@ -8,10 +9,12 @@ class AudioShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
     private val TAG = "audio"
 
     override fun beforeHtmlProcessed(source: String): String {
+        if (GutenbergUtils.contentContainsGutenbergBlocks(source)) return source
         return source.replace(Regex("(?<!\\[)\\[$TAG([^\\]]*)\\](?!\\])"), "<$TAG$1 />")
     }
 
     override fun onHtmlProcessed(source: String): String {
+        if (GutenbergUtils.contentContainsGutenbergBlocks(source)) return source
         return StringBuilder(source)
                 .replace(Regex("<$TAG([^>]*(?<! )) */>"), "[$TAG$1]")
                 .replace(Regex("<$TAG([^>]*(?<! )) *></$TAG>"), "[$TAG$1]")

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/utils/GutenbergUtils.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/utils/GutenbergUtils.kt
@@ -1,0 +1,29 @@
+package org.wordpress.aztec.plugins.shortcodes.utils
+
+class GutenbergUtils {
+    companion object {
+        val GUTENBERG_BLOCK_START = "<!-- wp:"
+        /*
+            Note the way we detect we're in presence of Gutenberg blocks logic is taken from
+            https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L331-L345
+
+            * Determine whether a content string contains blocks. This test optimizes for
+            * performance rather than strict accuracy, detecting the pattern of a block
+            * but not validating its structure. For strict accuracy, you should use the
+            * block parser on post content.
+            *
+            * @since 1.6.0
+            * @see gutenberg_parse_blocks()
+            *
+            * @param string $content Content to test.
+            * @return bool Whether the content contains blocks.
+
+            function gutenberg_content_has_blocks( $content ) {
+                return false !== strpos( $content, '<!-- wp:' );
+            }
+         */
+        fun contentContainsGutenbergBlocks(content: String?): Boolean {
+            return content != null && content.contains(GUTENBERG_BLOCK_START)
+        }
+    }
+}

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
@@ -1,0 +1,71 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.aztec.plugins.shortcodes
+
+import android.app.Activity
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.plugins.shortcodes.TestUtils.safeEmpty
+
+/**
+ * Tests for the caption shortcode plugin
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(25))
+class AudioShortcodeTest {
+    lateinit var editText: AztecText
+
+    private val htmlGutenbergAudioBlock =
+            "<!-- wp:audio {\"id\":435} --><figure class=\"wp-block-audio\"><audio controls src=\"https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2018/05/ArgentinaAnthem.mp3\"></audio><figcaption>a caption</figcaption></figure><!-- /wp:audio -->"
+
+    private val htmlNormalAudioTag =
+            "<figure class=\"wp-block-audio\"><audio controls src=\"https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2018/05/ArgentinaAnthem.mp3\"></audio><figcaption>a caption</figcaption></figure>"
+
+    /**
+     * Initialize variables.
+     */
+    @Before
+    fun init() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+
+        editText = AztecText(activity)
+        editText.setCalypsoMode(false)
+
+        activity.setContentView(editText)
+
+        editText.plugins.add(AudioShortcodePlugin())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testGutenbergAudioBlockDoesntConvertToShortcode() {
+        Assert.assertTrue(safeEmpty(editText))
+
+        editText.fromHtml(htmlGutenbergAudioBlock)
+
+        // expected result: the <audio> tag does not get converted to shortcode when it's found within a Gutenberg block
+        // Note: the slight difference of <audio controls> being converted to <audio controls="controls"> should be equivalent
+        val htmlWithoutShortcode = "<!-- wp:audio {\"id\":435} --><figure class=\"wp-block-audio\"><audio controls=\"controls\" src=\"https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2018/05/ArgentinaAnthem.mp3\" /><figcaption>a caption</figcaption></figure><!-- /wp:audio -->"
+
+        Assert.assertEquals(htmlWithoutShortcode, editText.toPlainHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testAudioTagConvertsToShortcode() {
+        Assert.assertTrue(safeEmpty(editText))
+
+        editText.fromHtml(htmlNormalAudioTag)
+
+        // expected result: the <audio> tag gets converted to shortcode when it's found in free HTML
+        val htmlWithShortcode = "<figure class=\"wp-block-audio\">[audio controls=\"controls\" src=\"https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2018/05/ArgentinaAnthem.mp3\"]<figcaption>a caption</figcaption></figure>"
+
+        Assert.assertEquals(htmlWithShortcode, editText.toPlainHtml())
+    }
+}


### PR DESCRIPTION
### Fix 
Fixes #685 as per the discussion in https://github.com/wordpress-mobile/WordPress-Android/pull/7826#issuecomment-393172951

The idea is that the plugin itself should be aware of Gutenberg blocks, and be able to differentiate and only apply itself to `<audio>` tags that are not within a Gutenberg block.

### Test
1. Feed Aztec with this HTML code, which is the Gutenberg code for an audio block:

```
<!-- wp:audio {"id":435} -->
<figure class="wp-block-audio"><audio controls src="http://www.noiseaddicts.com/samples_1w72b820/4159.mp3"></audio> <figcaption>
  a caption
 </figcaption></figure>
<!-- /wp:audio -->
```
or, create your own on Gutenberg.

2. Switch to visual mode
3. Now switch to HTML-mode
4. Observe the structure for the <audio> tag is preserved as <audio> (note the `controls="controls"` is expected and not harmful):
```
<!-- wp:audio {"id":435} --><figure class="wp-block-audio">
 <audio controls="controls" src="http://www.noiseaddicts.com/samples_1w72b820/4159.mp3"></audio>
 <figcaption>
  a caption
 </figcaption></figure><!-- /wp:audio -->
```

Also, test the same without the enclosing Gutenberg end/start tags:
```<figure class="wp-block-audio"><audio controls src="https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2018/05/ArgentinaAnthem.mp3"></audio><figcaption>a caption</figcaption></figure>```
In this case, the plugin should rightfully change the `<audio>` tags for `[audio]` shortcode, as expected.

**Note**: For easier review, please note the actual code change is in cfc512f, and tests have been added in  7178316, while instrumented tests have been added on 99d3efc.

