### PR TITLE
Instruct Aztec to produce valid HTML output

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -53,6 +53,7 @@ import android.view.View
 import android.view.WindowManager
 import android.view.inputmethod.BaseInputConnection
 import android.widget.EditText
+import org.jsoup.Jsoup
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.aztec.formatting.BlockFormatter
@@ -1111,7 +1112,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             // paragraphs and line breaks are added on server, from newline characters
             return Format.addSourceEditorFormatting(html, true)
         } else {
-            return html
+            val doc = Jsoup.parseBodyFragment(html).outputSettings(Format.getJsoupSettings(isInCalypsoMode))
+            return doc.body().html().trim()
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -24,7 +24,10 @@ object Format {
         var html = replaceAll(content, "iframe", iframePlaceholder)
         html = html.replace("<aztec_cursor>", "")
 
-        val doc = Jsoup.parseBodyFragment(html).outputSettings(Document.OutputSettings().prettyPrint(!isCalypsoFormat))
+        val outputSetting = Document.OutputSettings()
+        outputSetting.prettyPrint(!isCalypsoFormat)
+        outputSetting.syntax(Document.OutputSettings.Syntax.html)
+        val doc = Jsoup.parseBodyFragment(html).outputSettings(outputSetting)
         if (isCalypsoFormat) {
             // remove empty span tags
             doc.select("*")
@@ -51,7 +54,11 @@ object Format {
     fun removeSourceEditorFormatting(html: String, isCalypsoFormat: Boolean = false): String {
         if (isCalypsoFormat) {
             val htmlWithoutSourceFormatting = toCalypsoHtml(html)
-            val doc = Jsoup.parseBodyFragment(htmlWithoutSourceFormatting.replace("\n", "")).outputSettings(Document.OutputSettings().prettyPrint(false))
+            val outputSetting = Document.OutputSettings()
+            outputSetting.prettyPrint(false)
+            outputSetting.syntax(Document.OutputSettings.Syntax.html)
+
+            val doc = Jsoup.parseBodyFragment(htmlWithoutSourceFormatting.replace("\n", "")).outputSettings(outputSetting)
             return doc.body().html()
         } else {
             return replaceAll(html, "\\s*<(/?($block)(.*?))>\\s*", "<$1>")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -20,14 +20,19 @@ object Format {
     private val iframePlaceholder = "iframe-replacement-0x0"
 
     @JvmStatic
+    fun getJsoupSettings(isCalypsoFormat: Boolean): Document.OutputSettings {
+        val outputSetting = Document.OutputSettings()
+        outputSetting.prettyPrint(!isCalypsoFormat)
+        outputSetting.syntax(Document.OutputSettings.Syntax.html)
+        return outputSetting
+    }
+
+    @JvmStatic
     fun addSourceEditorFormatting(content: String, isCalypsoFormat: Boolean = false): String {
         var html = replaceAll(content, "iframe", iframePlaceholder)
         html = html.replace("<aztec_cursor>", "")
 
-        val outputSetting = Document.OutputSettings()
-        outputSetting.prettyPrint(!isCalypsoFormat)
-        outputSetting.syntax(Document.OutputSettings.Syntax.html)
-        val doc = Jsoup.parseBodyFragment(html).outputSettings(outputSetting)
+        val doc = Jsoup.parseBodyFragment(html).outputSettings(getJsoupSettings(isCalypsoFormat))
         if (isCalypsoFormat) {
             // remove empty span tags
             doc.select("*")
@@ -54,11 +59,8 @@ object Format {
     fun removeSourceEditorFormatting(html: String, isCalypsoFormat: Boolean = false): String {
         if (isCalypsoFormat) {
             val htmlWithoutSourceFormatting = toCalypsoHtml(html)
-            val outputSetting = Document.OutputSettings()
-            outputSetting.prettyPrint(false)
-            outputSetting.syntax(Document.OutputSettings.Syntax.html)
-
-            val doc = Jsoup.parseBodyFragment(htmlWithoutSourceFormatting.replace("\n", "")).outputSettings(outputSetting)
+            val doc = Jsoup.parseBodyFragment(htmlWithoutSourceFormatting.replace("\n", ""))
+                    .outputSettings(getJsoupSettings(isCalypsoFormat))
             return doc.body().html()
         } else {
             return replaceAll(html, "\\s*<(/?($block)(.*?))>\\s*", "<$1>")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -14,6 +14,7 @@ import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
+import org.jsoup.Jsoup
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.AztecTextAccessibilityDelegate
 import org.wordpress.aztec.History
@@ -259,7 +260,9 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
             enableTextChangedListener()
         }
 
-        return Format.removeSourceEditorFormatting(text.toString(), isInCalypsoMode)
+        val html = Format.removeSourceEditorFormatting(text.toString(), isInCalypsoMode)
+        val doc = Jsoup.parseBodyFragment(html).outputSettings(Format.getJsoupSettings(isInCalypsoMode))
+        return doc.body().html().trim()
     }
 
     fun disableTextChangedListener() {


### PR DESCRIPTION
As per chat convo we've noticed that Aztec was producing in output valid XML document rather than valid HTML document.
As an example of the problem try the following valid HTML in the demo app
```
<!-- wp:audio {"id":40} -->
<figure class="wp-block-audio"><audio controls src="your-content.mp3"></audio></figure>
<!-- /wp:audio -->
```
Then swittch to HTML and you will see:

```
<!-- wp:audio {"id":40} -->
<figure class="wp-block-audio"><audio controls src="your-content.mp3" /></figure>
<!-- /wp:audio -->
```

The `Formatter` produces a slightly different version of the input document, where the `audio` tag is replaced by a self-closing audio tag. That's outside the HTML specs. 
(If you need the HTML ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)


- In this PR we've set Jsoup to produce HTML when formatting HTML for the HTML Editor.
- We're also passing the output HTML to Jsoup to make sure the HTML produced by the editor is valid


**Note:** GB Tests need to be updated after these changes. 