### PR TITLE
adds a Regex to make sure audio tag gets both start and end tags

### DIFF
--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodePlugin.kt
@@ -14,7 +14,13 @@ class AudioShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
     }
 
     override fun onHtmlProcessed(source: String): String {
-        if (GutenbergUtils.contentContainsGutenbergBlocks(source)) return source
+        if (GutenbergUtils.contentContainsGutenbergBlocks(source)) {
+            // From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
+            // > Tag omission	None, both the starting and ending tag are mandatory.
+            return StringBuilder(source)
+                    .replace(Regex("(<$TAG[^>]*?)(\\s*/>)"), "\$1></$TAG>")
+        }
+
         return StringBuilder(source)
                 .replace(Regex("<$TAG([^>]*(?<! )) */>"), "[$TAG$1]")
                 .replace(Regex("<$TAG([^>]*(?<! )) *></$TAG>"), "[$TAG$1]")

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
@@ -51,7 +51,7 @@ class AudioShortcodeTest {
 
         // expected result: the <audio> tag does not get converted to shortcode when it's found within a Gutenberg block
         // Note: the slight difference of <audio controls> being converted to <audio controls="controls"> should be equivalent
-        val htmlWithoutShortcode = "<!-- wp:audio {\"id\":435} --><figure class=\"wp-block-audio\"><audio controls=\"controls\" src=\"https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2018/05/ArgentinaAnthem.mp3\" /><figcaption>a caption</figcaption></figure><!-- /wp:audio -->"
+        val htmlWithoutShortcode = "<!-- wp:audio {\"id\":435} --><figure class=\"wp-block-audio\"><audio controls=\"controls\" src=\"https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2018/05/ArgentinaAnthem.mp3\"></audio><figcaption>a caption</figcaption></figure><!-- /wp:audio -->"
 
         Assert.assertEquals(htmlWithoutShortcode, editText.toPlainHtml())
     }


### PR DESCRIPTION
### Fix
Fixes #694  by introducing a regex in the `onHtmlProcessed` method of `AudioShortcodePlugin` to make sure we have a start and ending tags for `audio`.

As per discussed eslewhere, this should be the less disruptive change, and that's why I decided to encapsulate it in the plugin _and_ only for Gutenberg blocks handling, even when the problem is a broader HTML validation thing.

### Test
Test case has been provided in  https://github.com/wordpress-mobile/AztecEditor-Android/compare/issue/691-fix-audio-tag-through-plugin?expand=1#diff-36410cec871dab8b74e812d4f1efbbee 
You can also manually test by doing this:
1. Feed the demo app with
```
<!-- wp:audio {\"id\":435} --><figure class=\"wp-block-audio\"><audio controls=\"controls\" src=\"https://domain.com/content.mp3\"></audio><figcaption>a caption</figcaption></figure><!-- /wp:audio -->
```
2. switch to Visual
3. witch back to HTML mode, you should see the `</audio>` ending tag is still there.

