### PR TITLE
Fix video tag shortcode & start/end tags through plugin

### DIFF
--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodePlugin.kt
@@ -28,7 +28,7 @@ class VideoShortcodePlugin : IHtmlPreprocessor, IHtmlPostprocessor {
 
         return StringBuilder(source)
                 .replace(Regex("<$TAG([^>]*(?<! )) */>"), { it -> fromHTMLToShortcode(it) })
-                .replace(Regex("<$TAG([^>]*(?<! )) */>"), { it -> fromHTMLToShortcode(it) })
+                .replace(Regex("<$TAG([^>]*(?<! )) *></$TAG>"), { it -> fromHTMLToShortcode(it) })
     }
 
     /**

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
@@ -14,7 +14,7 @@ import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.plugins.shortcodes.TestUtils.safeEmpty
 
 /**
- * Tests for the caption shortcode plugin
+ * Tests for the audio shortcode plugin
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(constants = BuildConfig::class, sdk = intArrayOf(25))

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
@@ -1,0 +1,71 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.aztec.plugins.shortcodes
+
+import android.app.Activity
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.plugins.shortcodes.TestUtils.safeEmpty
+
+/**
+ * Tests for the video shortcode plugin
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(25))
+class VideoShortcodeTest {
+    lateinit var editText: AztecText
+
+    private val htmlGutenbergVideoBlock =
+            "<!-- wp:video {\"id\":25} --><figure class=\"wp-block-video\"><video controls src=\"https://somedomain.com/wp-content/uploads/2017/05/VID-20170508-WA0011-1.mp4\"></video></figure><!-- /wp:video -->"
+
+    private val htmlNormalVideoTag =
+            "<figure class=\"wp-block-video\"><video controls src=\"https://somedomain.com/wp-content/uploads/2017/05/VID-20170508-WA0011-1.mp4\"></video></figure>"
+
+    /**
+     * Initialize variables.
+     */
+    @Before
+    fun init() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+
+        editText = AztecText(activity)
+        editText.setCalypsoMode(false)
+
+        activity.setContentView(editText)
+
+        editText.plugins.add(VideoShortcodePlugin())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testGutenbergVideoBlockDoesntConvertToShortcode() {
+        Assert.assertTrue(safeEmpty(editText))
+
+        editText.fromHtml(htmlGutenbergVideoBlock)
+
+        // expected result: the <video> tag does not get converted to shortcode when it's found within a Gutenberg block
+        // Note: the slight difference of <video controls> being converted to <video controls="controls"> should be equivalent
+        val htmlWithoutShortcode = "<!-- wp:video {\"id\":25} --><figure class=\"wp-block-video\"><video controls=\"controls\" src=\"https://somedomain.com/wp-content/uploads/2017/05/VID-20170508-WA0011-1.mp4\"></video></figure><!-- /wp:video -->"
+
+        Assert.assertEquals(htmlWithoutShortcode, editText.toPlainHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testAudioTagConvertsToShortcode() {
+        Assert.assertTrue(safeEmpty(editText))
+
+        editText.fromHtml(htmlNormalVideoTag)
+
+        // expected result: the <video> tag gets converted to shortcode when it's found in free HTML
+        val htmlWithShortcode = "<figure class=\"wp-block-video\">[video controls=\"controls\" src=\"https://somedomain.com/wp-content/uploads/2017/05/VID-20170508-WA0011-1.mp4\"]</figure>"
+
+        Assert.assertEquals(htmlWithShortcode, editText.toPlainHtml())
+    }
+}

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
@@ -58,7 +58,7 @@ class VideoShortcodeTest {
 
     @Test
     @Throws(Exception::class)
-    fun testAudioTagConvertsToShortcode() {
+    fun testVideoTagConvertsToShortcode() {
         Assert.assertTrue(safeEmpty(editText))
 
         editText.fromHtml(htmlNormalVideoTag)


### PR DESCRIPTION
### Fix
- Fixes #695 in a similar way to #692  by introducing a regex in the `onHtmlProcessed` method of `VideoShortcodePlugin` to make sure we have a start and ending tags for `video`.

- This PR also treats the `[video]` shortcode only on non-Gutenberg posts, in a similar way as #689 did for `[audio]` shortcode

- Also this PR has a fix in b7c2d7c5 as probably due to a copy/paste error the `VideoShortcodePlugin`  wasn't considering the case for start/end tags  to be replaced by the `[video]` shortcode. (bug [introduced here](https://github.com/wordpress-mobile/AztecEditor-Android/commit/22ba6fa37cb24d08f74ffbd14a32558a95a45630#diff-2e1ffe3f608cb361bfceb254d69e65b3) ).

### Test
Test cases for both shortcode handling and start/end tags preservation are provided in  https://github.com/wordpress-mobile/AztecEditor-Android/compare/issue/695-fix-video-tag-through-plugin?expand=1#diff-93c2d435bf9314a5dd124edac5ea7703
You can also manually test by doing this:
**TEST A**: keep the start/end tags on Gutenberg Video blocks
1. Feed the demo app with
```
<!-- wp:video {"id":25} --><figure class="wp-block-video"><video controls src="https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2017/05/VID-20170508-WA0011-1.mp4"></video></figure><!-- /wp:video -->
```
2. switch to Visual
3. witch back to HTML mode, you should see the `</video>` ending tag is still there.

**TEST B**: convert to shortcode
1. Feed the demo app with
```
<figure class="wp-block-video"><video controls src="https://selfhostedmario.mystagingwebsite.com/wp-content/uploads/2017/05/VID-20170508-WA0011-1.mp4"></video></figure>
```
2. switch to Visual
3. witch back to HTML mode, you should see the `<video>` tag converted to `[video]` shortcode format.



