### PR TITLE
Issue/688 nested paragraphs

### DIFF
--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -1219,4 +1219,13 @@ class AztecParserTest : AndroidTestCase() {
         val output = mParser.toHtml(span)
         Assert.assertEquals(output, inputAfterParser)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlParagraphInsideHiddenSpan_isEqual() {
+        val input = "<p>a</p><div><p>b</p></div><p>c</p>"
+        val span = SpannableString(mParser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
 }


### PR DESCRIPTION
Fixes #688.

**Steps to verify**
1. Start the demo app with the following content:
```
<div>
 <p>first paragraph</p>
</div>
<p>second par</p>
```
2. Then switch the demo app to HTML mode.
3. The output is the same as input