### PR TITLE
Don't steal focus on initial load of media

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1025,7 +1025,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 private fun replaceImage(drawable: Drawable?) {
                     it.drawable = drawable
                     post {
-                        refreshText()
+                        refreshText(false)
                     }
                 }
             }
@@ -1058,7 +1058,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 private fun replaceImage(drawable: Drawable?) {
                     it.drawable = drawable
                     post {
-                        refreshText()
+                        refreshText(false)
                     }
                 }
             }
@@ -1246,10 +1246,16 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     open fun refreshText() {
+        refreshText(true)
+    }
+
+    open fun refreshText(keepFocus: Boolean) {
         disableTextChangedListener()
         val selStart = selectionStart
         val selEnd = selectionEnd
-        setFocusOnParentView()
+        if (keepFocus) {
+            setFocusOnParentView()
+        }
         text = editableText
         setSelection(selStart, selEnd)
         enableTextChangedListener()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1249,11 +1249,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         refreshText(true)
     }
 
-    open fun refreshText(keepFocus: Boolean) {
+    open fun refreshText(stealEditorFocus: Boolean) {
         disableTextChangedListener()
         val selStart = selectionStart
         val selEnd = selectionEnd
-        if (keepFocus) {
+        if (stealEditorFocus) {
             setFocusOnParentView()
         }
         text = editableText

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/VideoPressExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/VideoPressExtensions.kt
@@ -24,7 +24,7 @@ fun AztecText.updateVideoPressThumb(thumbURL: String, videoURL: String, videoPre
                 }
             }
             post {
-                refreshText()
+                refreshText(false)
             }
         }
 


### PR DESCRIPTION
### Fix #700 

As part of the work in https://github.com/wordpress-mobile/AztecEditor-Android/pull/349, a workaround was implemented to remove the focus from the editor's View. This PR specializes the workaround to exclude the case when initializing the editor, which happens everytime the user switches from html to visual.

### Test
1. Run the demo app
2. Switch to html mode
3. Place the cursor at the end of the `Heading 6` text, right before the `</h6> tag
4. Switch back to visual mode and notice the cursor blinking at the end of the `Heading 6` line