### PR TITLE
Add the ability to log Spans details in case of crashes

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -24,16 +24,20 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, priv
         try {
             shouldLog = logHelper?.shouldLog(ex) ?: true
         } catch (e: Throwable) {
-            AppLog.w(AppLog.T.EDITOR, "There was an exception in the Logger Helper. Set the logging to true" )
+            AppLog.w(AppLog.T.EDITOR, "There was an exception in the Logger Helper. Set the logging to true")
         }
 
         if (shouldLog) {
-            // Try to report the HTML code of the content, but do not report exceptions that can occur logging the content
+            // Try to report the HTML code of the content, the spans details, but do not report exceptions that can occur logging the content
             try {
                 AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash " + visualEditor.toPlainHtml(false))
             } catch (e: Throwable) {
-                AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash is unavailable, log the details instead")
+                // nope
+            }
+            try {
                 AztecLog.logContentDetails(visualEditor)
+            } catch (e: Throwable) {
+                // nope
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -30,14 +30,15 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, priv
         if (shouldLog) {
             // Try to report the HTML code of the content, the spans details, but do not report exceptions that can occur logging the content
             try {
-                AppLog.e(AppLog.T.EDITOR, "HTML Content of Aztec Editor before the crash " + visualEditor.toPlainHtml(false))
+                AppLog.e(AppLog.T.EDITOR, "HTML content of Aztec Editor before the crash:")
+                AppLog.e(AppLog.T.EDITOR, visualEditor.toPlainHtml(false))
             } catch (e: Throwable) {
-                // nope
+                AppLog.e(AppLog.T.EDITOR, "Oops! There was an error logging the HTML code.")
             }
             try {
                 AztecLog.logContentDetails(visualEditor)
             } catch (e: Throwable) {
-                // nope
+                // nop
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1124,11 +1124,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         } catch (e: Exception) {
             // FIXME: Remove this log once we've data to replicate the issue, and fix it in some way.
             AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 and #582 for details.")
-            when (e) {
-                is java.lang.ArrayIndexOutOfBoundsException, is java.lang.RuntimeException -> {
-                    AztecLog.logContentDetails(this)
-                }
-            }
+            // No need to log details here. The default AztecExceptionHandler does this for us.
             throw e
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1121,10 +1121,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val output: SpannableStringBuilder
         try {
             output = SpannableStringBuilder(text)
-        } catch (e: java.lang.ArrayIndexOutOfBoundsException) {
+        } catch (e: Exception) {
             // FIXME: Remove this log once we've data to replicate the issue, and fix it in some way.
-            AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 for details.")
-            // No need to log the exception here. The ExceptionHandler does this for us.
+            AppLog.e(AppLog.T.EDITOR, "There was an error creating SpannableStringBuilder. See #452 and #582 for details.")
+            when (e) {
+                is java.lang.ArrayIndexOutOfBoundsException, is java.lang.RuntimeException -> {
+                    AztecLog.logContentDetails(this)
+                }
+            }
             throw e
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/Azteclog.kt
@@ -1,11 +1,11 @@
 package org.wordpress.aztec.util
 
-import android.text.Spannable
-import org.json.JSONArray
-import org.json.JSONException
-import org.json.JSONObject
+import android.text.Spanned
+import android.text.TextUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.AztecText
+import java.util.Arrays
+import java.util.Collections
 
 class AztecLog {
     interface ExternalLogger {
@@ -15,32 +15,106 @@ class AztecLog {
     }
 
     companion object {
+        private const val MARK = 1
+        private const val POINT = 2
+        private const val PARAGRAPH = 3
+
         fun logContentDetails(aztecText: AztecText) {
             AppLog.d(AppLog.T.EDITOR, "Below are the details of the content in the editor:")
             logContentDetails(aztecText.text)
         }
 
-        fun logContentDetails(text: Spannable) {
+        fun logContentDetails(text: Spanned) {
             try {
-                val logContentJSON = JSONObject()
-                logContentJSON.put("content", text.toString())
-                logContentJSON.put("length", text.length)
-                val spansJSON = JSONArray()
-                val spans = text.getSpans(0, text.length, Any::class.java)
-                spans.forEach {
-                    val currenSpanJSON = JSONObject()
-                    currenSpanJSON.put("clazz", it.javaClass.name)
-                    currenSpanJSON.put("start", text.getSpanStart(it))
-                    currenSpanJSON.put("end", text.getSpanEnd(it))
-                    currenSpanJSON.put("flags", text.getSpanFlags(it))
-                    spansJSON.put(currenSpanJSON)
-                }
-                logContentJSON.put("spans", spansJSON)
-                AppLog.d(AppLog.T.EDITOR, logContentJSON.toString())
-            } catch (e: JSONException) {
-                AppLog.e(AppLog.T.EDITOR, "Uhh ohh! There was an error logging the content of the Editor. This should" +
+                AppLog.d(AppLog.T.EDITOR, logSpansDetails(text))
+            } catch (e: Exception) {
+                AppLog.e(AppLog.T.EDITOR, "Uhh ohh! There was an error logging the spans details of the Editor. This should" +
                         "never happen.", e)
             }
+        }
+
+        private fun logSpansDetails(text: Spanned): String {
+            val spans = text.getSpans(0, text.length, Any::class.java)
+            val spansList = Arrays.asList<Any>(*spans)
+
+            val sb = StringBuilder()
+            sb.append('\n').append(text.toString().replace('\n', '¶').replace('\u200B', '¬')) // ␤↵↭
+            sb.append("  length = " + text.length)
+
+            for (span in spansList) {
+                val start = text.getSpanStart(span)
+                val end = text.getSpanEnd(span)
+
+                var gap = text.length + 5
+
+                sb.append('\n')
+
+                if (start > 0) {
+                    sb.append(spaces(start))
+                    gap -= start
+                }
+
+                val spanMode = text.getSpanFlags(span) and Spanned.SPAN_POINT_MARK_MASK
+                val leftMode = (spanMode and 0x30) ushr 4
+                val rightMode = spanMode and 0x03
+
+                if (end - start > 0) {
+                    when (leftMode) {
+                        MARK -> sb.append('>')
+                        POINT -> sb.append('<')
+                        PARAGRAPH -> sb.append(if (start == 0) '<' else '>')
+                    }
+
+                    gap--
+                } else {
+                    if (spanMode == Spanned.SPAN_INCLUSIVE_INCLUSIVE) {
+                        sb.append('x')
+                    } else if (spanMode == Spanned.SPAN_INCLUSIVE_EXCLUSIVE) {
+                        sb.append('>')
+                    } else if (spanMode == Spanned.SPAN_EXCLUSIVE_INCLUSIVE) {
+                        sb.append('<')
+                    } else if (spanMode == Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) {
+                        sb.append('!')
+                    } else if (spanMode == Spanned.SPAN_PARAGRAPH) {
+                        if (start == 0) {
+                            sb.append('!')
+                        } else if (start == text.length) {
+                            sb.append('<')
+                        } else {
+                            sb.append('>')
+                        }
+                    }
+                }
+
+                if (end - start - 1 > 0) {
+                    sb.append(spaces(end - start - 1, "-"))
+                    gap -= end - start - 1
+                }
+
+                if (end - start > 0) {
+                    when (rightMode) {
+                        MARK -> sb.append('>')
+                        POINT -> sb.append('<')
+                        PARAGRAPH -> sb.append(if (end == text.length) '<' else '>')
+                    }
+                    gap--
+                }
+
+                sb.append(spaces(gap))
+
+                sb.append("   ")
+                        .append(String.format("%03d", start))
+                        .append(" -> ")
+                        .append(String.format("%03d", end))
+                        .append(" : ")
+                        .append(span.javaClass.simpleName)
+            }
+
+            return sb.toString()
+        }
+
+        private fun spaces(count: Int, char: String = " "): String {
+            return TextUtils.join("", Collections.nCopies(count, char))
         }
     }
 }


### PR DESCRIPTION
This PR improves and adds details to the logging output produced in case of crashes. 

In details:
- Adds detailed log of spans available in the editor in case of crashes. Previously there was only tracked the HTML code
- Adds a better routine to log spans

This PR doesn't fix anything, it just adds those details needed to fix #452 and #582. Note that details are only logged when the AztecExceptionHandler has a proper logger in place. This is true, in some cases, in `wp-android`.