### PR TITLE
Detect change in html editor

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/Matchers.kt
@@ -5,7 +5,9 @@ import android.widget.EditText
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
+import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.source.Format
+import org.wordpress.aztec.source.SourceViewEditText
 
 object Matchers {
     fun withRegex(expected: Regex): Matcher<View> {
@@ -41,6 +43,25 @@ object Matchers {
                     return actualHtml == expectedHtml
                 }
 
+                return false
+            }
+        }
+    }
+
+    fun hasContentChanges(shouldHaveChanges: AztecText.EditorHasChanges): TypeSafeMatcher<View> {
+
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("User has made changes to the post: $shouldHaveChanges")
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                if (view is SourceViewEditText) {
+                    return view.hasChanges() == shouldHaveChanges
+                }
+                if (view is AztecText) {
+                    return view.hasChanges() == shouldHaveChanges
+                }
                 return false
             }
         }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -371,21 +371,12 @@ class EditorPage : BasePage() {
     }
 
     fun hasChanges(shouldHaveChanges : AztecText.EditorHasChanges): EditorPage {
-        val hasNoChangesMatcher = object : TypeSafeMatcher<View>() {
-            override fun describeTo(description: Description) {
-                description.appendText("User has made changes to the post: $shouldHaveChanges")
-            }
+        editor.check(matches(Matchers.hasContentChanges(shouldHaveChanges)))
+        return this
+    }
 
-            public override fun matchesSafely(view: View): Boolean {
-                if (view is AztecText) {
-                    return view.hasChanges() == shouldHaveChanges
-                }
-
-                return false
-            }
-        }
-
-        editor.check(matches(hasNoChangesMatcher))
+    fun hasChangesHTML(shouldHaveChanges : AztecText.EditorHasChanges): EditorPage {
+        htmlEditor.check(matches(Matchers.hasContentChanges(shouldHaveChanges)))
         return this
     }
 

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditorPage.kt
@@ -14,11 +14,9 @@ import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.KeyEvent
 import android.view.View
-import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.hasToString
-import org.hamcrest.TypeSafeMatcher
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.demo.Actions
 import org.wordpress.aztec.demo.BasePage

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/MixedTextFormattingTests.kt
@@ -254,7 +254,6 @@ class MixedTextFormattingTests : BaseTest() {
                 .hasChanges(AztecText.EditorHasChanges.NO_CHANGES) // Verify that the user had not changed the input
     }
 
-    @Ignore("Until this issue is fixed: https://github.com/wordpress-mobile/AztecEditor-Android/issues/698")
     @Test
     fun testHasChangesWithMixedBoldAndItalicFormatting() {
         val input = "<b>bold <i>italic</i> bold</b>"
@@ -270,5 +269,36 @@ class MixedTextFormattingTests : BaseTest() {
                 .toggleHtml()
                 .hasChanges(AztecText.EditorHasChanges.CHANGES)
                 .verifyHTML(afterParser)
+    }
+
+    @Test
+    fun testHasChangesOnHTMLEditor() {
+        val input = "<b>Test</b>"
+        val insertedText = " text added"
+        val afterParser = "<b>Test</b>$insertedText"
+
+        EditorPage().toggleHtml()
+                .insertHTML(input)
+                .toggleHtml()
+                .toggleHtml() // switch back to HTML editor
+                .insertHTML(insertedText)
+                .hasChangesHTML(AztecText.EditorHasChanges.CHANGES)
+                .verifyHTML(afterParser)
+    }
+
+    @Test
+    fun testHasChangesOnHTMLEditorTestedFromVisualEditor() {
+        val input = "<b>Test</b>"
+        val insertedText = " text added"
+        val afterParser = "Test$insertedText"
+
+        EditorPage().toggleHtml()
+                .insertHTML(input)
+                .toggleHtml()
+                .toggleHtml() // switch back to HTML editor
+                .insertHTML(insertedText)
+                .hasChangesHTML(AztecText.EditorHasChanges.CHANGES)
+                .toggleHtml() // switch back to Visual editor
+                .verify(afterParser)
     }
 }

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -412,7 +412,7 @@ open class MainActivity : AppCompatActivity(),
             aztec.visualEditor.setCalypsoMode(false)
             aztec.sourceEditor?.setCalypsoMode(false)
 
-            aztec.sourceEditor?.displayStyledAndFormattedHtml(EXAMPLE)
+            aztec.sourceEditor?.displayStyledAndFormattedHtml(EXAMPLE, false)
 
             aztec.addPlugin(CssUnderlinePlugin())
         }

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -412,7 +412,7 @@ open class MainActivity : AppCompatActivity(),
             aztec.visualEditor.setCalypsoMode(false)
             aztec.sourceEditor?.setCalypsoMode(false)
 
-            aztec.sourceEditor?.displayStyledAndFormattedHtml(EXAMPLE, false)
+            aztec.sourceEditor?.displayStyledAndFormattedHtml(EXAMPLE)
 
             aztec.addPlugin(CssUnderlinePlugin())
         }

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -412,14 +412,17 @@ open class MainActivity : AppCompatActivity(),
             aztec.visualEditor.setCalypsoMode(false)
             aztec.sourceEditor?.setCalypsoMode(false)
 
-            aztec.sourceEditor?.displayStyledAndFormattedHtml(EXAMPLE, false)
-
             aztec.addPlugin(CssUnderlinePlugin())
         }
 
         if (savedInstanceState == null) {
-            aztec.visualEditor.fromHtml(aztec.sourceEditor?.getPureHtml()!!)
+            aztec.visualEditor.fromHtml(EXAMPLE)
             aztec.initSourceEditorHistory()
+        }
+
+        if (!isRunningTest) {
+            aztec.sourceEditor?.displayStyledAndFormattedHtml(aztec.visualEditor.toPlainHtml(true),
+                    aztec.visualEditor.hasChanges() != AztecText.EditorHasChanges.NO_CHANGES)
         }
 
         invalidateOptionsHandler = Handler()

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -412,17 +412,14 @@ open class MainActivity : AppCompatActivity(),
             aztec.visualEditor.setCalypsoMode(false)
             aztec.sourceEditor?.setCalypsoMode(false)
 
+            aztec.sourceEditor?.displayStyledAndFormattedHtml(EXAMPLE, false)
+
             aztec.addPlugin(CssUnderlinePlugin())
         }
 
         if (savedInstanceState == null) {
-            aztec.visualEditor.fromHtml(EXAMPLE)
+            aztec.visualEditor.fromHtml(aztec.sourceEditor?.getPureHtml()!!)
             aztec.initSourceEditorHistory()
-        }
-
-        if (!isRunningTest) {
-            aztec.sourceEditor?.displayStyledAndFormattedHtml(aztec.visualEditor.toPlainHtml(true),
-                    aztec.visualEditor.hasChanges() != AztecText.EditorHasChanges.NO_CHANGES)
         }
 
         invalidateOptionsHandler = Handler()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -174,7 +174,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 if (initialEditorContentParsedSHA256.isEmpty() || Arrays.equals(initialEditorContentParsedSHA256, calculateSHA256(""))) {
                     return calculateSHA256(initialHTMLParsed)
                 } else {
-                    return initialEditorContentParsedSHA256;
+                    return initialEditorContentParsedSHA256
                 }
             } catch (e: Throwable) {
                 // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -173,6 +173,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 // Do not recalculate the hash if it's not the first call to `fromHTML`.
                 if (initialEditorContentParsedSHA256.isEmpty() || Arrays.equals(initialEditorContentParsedSHA256, calculateSHA256(""))) {
                     return calculateSHA256(initialHTMLParsed)
+                } else {
+                    return initialEditorContentParsedSHA256;
                 }
             } catch (e: Throwable) {
                 // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -184,17 +184,15 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         fun hasChanges(initialEditorContentParsedSHA256: ByteArray, newContent: String): EditorHasChanges {
-            if (!initialEditorContentParsedSHA256.isEmpty()) {
-                try {
-                    if (Arrays.equals(initialEditorContentParsedSHA256, calculateSHA256(newContent))) {
-                        return EditorHasChanges.NO_CHANGES
-                    }
-                    return EditorHasChanges.CHANGES
-                } catch (e: Throwable) {
-                    // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException
+            try {
+                if (Arrays.equals(initialEditorContentParsedSHA256, calculateSHA256(newContent))) {
+                    return EditorHasChanges.NO_CHANGES
                 }
+                return EditorHasChanges.CHANGES
+            } catch (e: Throwable) {
+                // Do nothing here. `toPlainHtml` can throw exceptions, also calculateSHA256 -> NoSuchAlgorithmException
+                return EditorHasChanges.UNKNOWN
             }
-            return EditorHasChanges.UNKNOWN
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1481,7 +1481,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             editHtml = unknownHtmlSpan.rawHtml.toString()
         }
 
-        source.displayStyledAndFormattedHtml(editHtml, hasChanges() != EditorHasChanges.NO_CHANGES)
+        source.displayStyledAndFormattedHtml(editHtml)
         builder.setView(dialogView)
 
         builder.setPositiveButton(R.string.block_editor_dialog_button_save, { _, _ ->

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -189,16 +189,14 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
         }
     }
 
-    fun displayStyledAndFormattedHtml(source: String, hasChangesAlready: Boolean) {
+    fun displayStyledAndFormattedHtml(source: String) {
         val styledHtml = styleHtml(Format.addSourceEditorFormatting(source, isInCalypsoMode))
 
         disableTextChangedListener()
         val cursorPosition = consumeCursorTag(styledHtml)
         text = styledHtml
-        if (!hasChangesAlready) {
-            initialEditorContentParsedSHA256 = AztecText.calculateInitialHTMLSHA(getPureHtml(false),
-                    initialEditorContentParsedSHA256)
-        }
+        initialEditorContentParsedSHA256 = AztecText.calculateInitialHTMLSHA(getPureHtml(false),
+                initialEditorContentParsedSHA256)
         enableTextChangedListener()
 
         if (cursorPosition > 0)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -263,17 +263,22 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
     }
 
     fun getPureHtml(withCursorTag: Boolean = false): String {
+        val str: String
+
         if (withCursorTag) {
-            disableTextChangedListener()
+            val withCursor = StringBuffer(text)
             if (!isCursorInsideTag()) {
-                text.insert(selectionEnd, "<aztec_cursor></aztec_cursor>")
+                withCursor.insert(selectionEnd, "<aztec_cursor></aztec_cursor>")
             } else {
-                text.insert(text.lastIndexOf("<", selectionEnd), "<aztec_cursor></aztec_cursor>")
+                withCursor.insert(withCursor.lastIndexOf("<", selectionEnd), "<aztec_cursor></aztec_cursor>")
             }
-            enableTextChangedListener()
+
+            str = withCursor.toString()
+        } else {
+            str = text.toString()
         }
 
-        return Format.removeSourceEditorFormatting(text.toString(), isInCalypsoMode)
+        return Format.removeSourceEditorFormatting(str, isInCalypsoMode)
     }
 
     fun disableTextChangedListener() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -15,6 +15,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.AztecText.EditorHasChanges
 import org.wordpress.aztec.AztecTextAccessibilityDelegate
 import org.wordpress.aztec.History
 import org.wordpress.aztec.R
@@ -43,6 +44,8 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
     private var consumeEditEvent: Boolean = true
 
     private var accessibilityDelegate = AztecTextAccessibilityDelegate(this)
+
+    private var initialEditorContentParsedSHA256: ByteArray = ByteArray(0)
 
     constructor(context: Context) : super(context) {
         init(null)
@@ -94,6 +97,7 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
         visibility = customState.getInt("visibility")
         val retainedContent = InstanceStateUtils.readAndPurgeTempInstance<String>(RETAINED_CONTENT_KEY, "", savedState.state)
         setText(retainedContent)
+        initialEditorContentParsedSHA256 = customState.getByteArray(AztecText.RETAINED_INITIAL_HTML_PARSED_SHA256_KEY)
     }
 
     // Do not include the content of the editor when saving state to bundle.
@@ -106,6 +110,8 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
 
     override fun onSaveInstanceState(): Parcelable {
         val bundle = Bundle()
+        bundle.putByteArray(org.wordpress.aztec.AztecText.RETAINED_INITIAL_HTML_PARSED_SHA256_KEY,
+                initialEditorContentParsedSHA256)
         InstanceStateUtils.writeTempInstance(context, null, RETAINED_CONTENT_KEY, text.toString(), bundle)
         val superState = super.onSaveInstanceState()
         val savedState = SavedState(superState)
@@ -183,12 +189,16 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
         }
     }
 
-    fun displayStyledAndFormattedHtml(source: String) {
+    fun displayStyledAndFormattedHtml(source: String, hasChangesAlready: Boolean) {
         val styledHtml = styleHtml(Format.addSourceEditorFormatting(source, isInCalypsoMode))
 
         disableTextChangedListener()
         val cursorPosition = consumeCursorTag(styledHtml)
         text = styledHtml
+        if (!hasChangesAlready) {
+            initialEditorContentParsedSHA256 = AztecText.calculateInitialHTMLSHA(getPureHtml(false),
+                    initialEditorContentParsedSHA256)
+        }
         enableTextChangedListener()
 
         if (cursorPosition > 0)
@@ -246,6 +256,10 @@ open class SourceViewEditText : android.support.v7.widget.AppCompatEditText, Tex
                 ((indexOfFirstOpeningBracketOnTheLeft > indexOfFirstClosingBracketOnTheLeft) || indexOfFirstClosingBracketOnTheLeft == -1)
 
         return isThereClosingBracketBeforeOpeningBracket && isThereOpeningBracketBeforeClosingBracket
+    }
+
+    fun hasChanges(): EditorHasChanges {
+        return AztecText.hasChanges(initialEditorContentParsedSHA256, getPureHtml(false))
     }
 
     fun getPureHtml(withCursorTag: Boolean = false): String {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -566,14 +566,17 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         if (sourceEditor == null) return
 
         if (editor!!.visibility == View.VISIBLE) {
-            sourceEditor!!.displayStyledAndFormattedHtml(editor!!.toPlainHtml(true),
-                    editor!!.hasChanges() != NO_CHANGES)
+            if (editor!!.hasChanges() != NO_CHANGES) {
+                sourceEditor!!.displayStyledAndFormattedHtml(editor!!.toPlainHtml(true))
+            }
             editor!!.visibility = View.GONE
             sourceEditor!!.visibility = View.VISIBLE
 
             toggleHtmlMode(true)
         } else {
-            editor!!.fromHtml(sourceEditor!!.getPureHtml(true))
+            if (sourceEditor!!.hasChanges() != NO_CHANGES) {
+                editor!!.fromHtml(sourceEditor!!.getPureHtml(true))
+            }
             editor!!.visibility = View.VISIBLE
             sourceEditor!!.visibility = View.GONE
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -25,6 +25,7 @@ import android.widget.Toast
 import android.widget.ToggleButton
 import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.AztecText.EditorHasChanges.NO_CHANGES
 import org.wordpress.aztec.AztecTextFormat
 import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.R
@@ -565,7 +566,8 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         if (sourceEditor == null) return
 
         if (editor!!.visibility == View.VISIBLE) {
-            sourceEditor!!.displayStyledAndFormattedHtml(editor!!.toPlainHtml(true))
+            sourceEditor!!.displayStyledAndFormattedHtml(editor!!.toPlainHtml(true),
+                    editor!!.hasChanges() != NO_CHANGES)
             editor!!.visibility = View.GONE
             sourceEditor!!.visibility = View.VISIBLE
 


### PR DESCRIPTION
### Fix #703

This is a follow up PR to https://github.com/wordpress-mobile/AztecEditor-Android/pull/674, extending the idea of using a hash-based mechanism to detect when the html (source) editor has user-initiated changes in comparison to the original content.

This functionality is needed by wpandroid to properly update a post remotely when the editor is in html mode.

A key detail in this implementation is that now, the source editor's `displayStyledAndFormattedHtml()` method requires a boolean flag to be passed, effectively adopting the "content dirty" flag from the visual editor.

### Test
No test steps available.