### PR TITLE
Do not crash if Attributes->`setValue` and `removeAttribute` fail

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
@@ -23,13 +23,13 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
     }
 
     private fun logInternalState() {
-        AppLog.e(AppLog.T.EDITOR, "AttributesImpl has an internal length of $length")
-        // Since we're not sure the internal state of the Obj is correct we're wrapping toString in a try/catch
+        AppLog.e(AppLog.T.EDITOR, "Dumping internal state:")
+        AppLog.e(AppLog.T.EDITOR, "length = $length")
+        // Since the toString can throw OOB error we need to wrap it in a try/catch
         try {
-            AppLog.e(AppLog.T.EDITOR, "Dumping internal state:")
             AppLog.e(AppLog.T.EDITOR, toString())
-        } catch (t: Throwable) {
-            AppLog.e(AppLog.T.EDITOR, "Error dumping internal state!")
+        } catch (e: ArrayIndexOutOfBoundsException) {
+            AppLog.e(AppLog.T.EDITOR, "Error dumping internal state!", e)
         }
     }
 
@@ -58,12 +58,20 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
 
     override fun toString(): String {
         val sb = StringBuilder()
-        for (i in 0..this.length - 1) {
-            sb.append(this.getLocalName(i))
-            sb.append("=\"")
-            sb.append(this.getValue(i))
-            sb.append("\" ")
+        try {
+            for (i in 0..this.length - 1) {
+                sb.append(this.getLocalName(i))
+                sb.append("=\"")
+                sb.append(this.getValue(i))
+                sb.append("\" ")
+            }
+        } catch (e: ArrayIndexOutOfBoundsException) {
+            // https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
+            AppLog.e(AppLog.T.EDITOR, "IOOB occurred in toString. Dumping partial state:")
+            AppLog.e(AppLog.T.EDITOR, sb.trimEnd().toString())
+            throw e
         }
+
         return sb.trimEnd().toString()
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
@@ -7,16 +7,29 @@ import org.xml.sax.helpers.AttributesImpl
 class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImpl(attributes) {
     fun setValue(key: String, value: String) {
         val index = getIndex(key)
+
         if (index == -1) {
-            addAttribute("", key, key, "string", value)
-        } else {
             try {
-                setValue(index, value)
+                addAttribute("", key, key, "string", value)
             } catch (e: ArrayIndexOutOfBoundsException) {
-                // we should not be here since `getIndex(key)` checks if the attribute is already available or not,
-                // but apparently...https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
-                AppLog.e(AppLog.T.EDITOR, "Tried to set attribute: $key at index: $index")
+                // https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
+                AppLog.e(AppLog.T.EDITOR, "Error adding attribute with name: $key and value: $value")
+                logInternalState()
+                throw e
             }
+        } else {
+            setValue(index, value)
+        }
+    }
+
+    private fun logInternalState() {
+        AppLog.e(AppLog.T.EDITOR, "AttributesImpl has an internal length of $length")
+        // Since we're not sure the internal state of the Obj is correct we're wrapping toString in a try/catch
+        try {
+            AppLog.e(AppLog.T.EDITOR, "Dumping internal state:")
+            AppLog.e(AppLog.T.EDITOR, toString())
+        } catch (t: Throwable) {
+            AppLog.e(AppLog.T.EDITOR, "Error dumping internal state!")
         }
     }
 
@@ -30,10 +43,11 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
             try {
                 removeAttribute(index)
             } catch (e: ArrayIndexOutOfBoundsException) {
-                // we should not be here since hasAttribute checked if the attribute is available or not,
-                // but apparently...https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
-                AppLog.e(AppLog.T.EDITOR, "Tried to remove attribute: $key that is not in the list.")
+                // https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
+                AppLog.e(AppLog.T.EDITOR, "Tried to remove attribute: $key that is not in the list")
                 AppLog.e(AppLog.T.EDITOR, "Reported to be at index: $index")
+                logInternalState()
+                throw e
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
@@ -1,5 +1,6 @@
 package org.wordpress.aztec
 
+import org.wordpress.android.util.AppLog
 import org.xml.sax.Attributes
 import org.xml.sax.helpers.AttributesImpl
 
@@ -9,7 +10,13 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         if (index == -1) {
             addAttribute("", key, key, "string", value)
         } else {
-            setValue(index, value)
+            try {
+                setValue(index, value)
+            } catch (e: ArrayIndexOutOfBoundsException) {
+                // we should not be here since `getIndex(key)` checks if the attribute is already available or not,
+                // but apparently...https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
+                AppLog.e(AppLog.T.EDITOR, "Tried to set attribute: $key at index: $index")
+            }
         }
     }
 
@@ -20,7 +27,14 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
     fun removeAttribute(key: String) {
         if (hasAttribute(key)) {
             val index = getIndex(key)
-            removeAttribute(index)
+            try {
+                removeAttribute(index)
+            } catch (e: ArrayIndexOutOfBoundsException) {
+                // we should not be here since hasAttribute checked if the attribute is available or not,
+                // but apparently...https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
+                AppLog.e(AppLog.T.EDITOR, "Tried to remove attribute: $key that is not in the list.")
+                AppLog.e(AppLog.T.EDITOR, "Reported to be at index: $index")
+            }
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
@@ -29,7 +29,8 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         try {
             AppLog.e(AppLog.T.EDITOR, toString())
         } catch (e: ArrayIndexOutOfBoundsException) {
-            AppLog.e(AppLog.T.EDITOR, "Error dumping internal state!", e)
+            // No need to log anything here. `toString` already writes to log details, but we need to shallow the exception
+            // we don't want to crash logging state of the app
         }
     }
 


### PR DESCRIPTION
Fix #705 by making sure the app doesn't crash on removing or set a value for un unexpected attribute.

Wasn't able to reproduce the issue, but it's pretty high on the list of crashes, so I just wrapped it with a try/catch block and log the problem.