### PR TITLE
Proper handling of email, schemeless URLs

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -162,7 +162,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
-    private val REGEXP_EMAIL = Regex("^[A-Z0-9._%+-]+@[A-Z0-9.-]+.[A-Z]{2,20}$",
+    private val REGEXP_EMAIL = Regex("^[A-Z0-9._%+-]+@[A-Z0-9.-]+.[A-Z]{2,}$",
             setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE))
     private val REGEXP_STANDALONE_URL = Regex("^(?:[a-z]+:|#|\\?|\\.|/)", RegexOption.DOT_MATCHES_ALL)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -162,6 +162,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
+    private val REGEXP_EMAIL = Regex("^[A-Z0-9._%+-]+@[A-Z0-9.-]+.[A-Z]{2,4}$",
+            setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE))
+    private val REGEXP_STANDALONE_URL = Regex("^(?:[a-z]+:|#|\\?|\\.|/)", RegexOption.DOT_MATCHES_ALL)
+
     enum class EditorHasChanges {
         CHANGES, NO_CHANGES, UNKNOWN
     }
@@ -1420,6 +1424,17 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         onSelectionChanged(urlSpanBounds.first, urlSpanBounds.second)
     }
 
+    private fun correctUrl(inputUrl: String): String {
+        val url = inputUrl.trim()
+        if (REGEXP_EMAIL.matches(url)) {
+            return "mailto:$url"
+        }
+        if (!REGEXP_STANDALONE_URL.containsMatchIn(url)) {
+            return "http://$url"
+        }
+        return url
+    }
+
     @SuppressLint("InflateParams")
     fun showLinkDialog(presetUrl: String = "", presetAnchor: String = "") {
         val urlAndAnchor = linkFormatter.getSelectedUrlWithAnchor()
@@ -1441,7 +1456,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         builder.setTitle(R.string.link_dialog_title)
 
         builder.setPositiveButton(R.string.link_dialog_button_ok, { _, _ ->
-            val linkText = urlInput.text.toString().trim { it <= ' ' }
+            val linkText = correctUrl(urlInput.text.toString().trim { it <= ' ' })
             val anchorText = anchorInput.text.toString().trim { it <= ' ' }
 
             link(linkText, anchorText)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1456,7 +1456,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         builder.setTitle(R.string.link_dialog_title)
 
         builder.setPositiveButton(R.string.link_dialog_button_ok, { _, _ ->
-            val linkText = correctUrl(urlInput.text.toString().trim { it <= ' ' })
+            val linkText = TextUtils.htmlEncode(correctUrl(urlInput.text.toString().trim { it <= ' ' }))
             val anchorText = anchorInput.text.toString().trim { it <= ' ' }
 
             link(linkText, anchorText)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -162,7 +162,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
-    private val REGEXP_EMAIL = Regex("^[A-Z0-9._%+-]+@[A-Z0-9.-]+.[A-Z]{2,4}$",
+    private val REGEXP_EMAIL = Regex("^[A-Z0-9._%+-]+@[A-Z0-9.-]+.[A-Z]{2,20}$",
             setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE))
     private val REGEXP_STANDALONE_URL = Regex("^(?:[a-z]+:|#|\\?|\\.|/)", RegexOption.DOT_MATCHES_ALL)
 


### PR DESCRIPTION
### Fix #460

This PR mirrors the [behavior from Calypso](https://github.com/Automattic/wp-calypso/blob/ab1c7779fb25d96220ec03dd9557d6fc89bbfd11/client/post-editor/editor-html-toolbar/add-link-dialog.jsx#L51-L60) to handle email links and links that need the scheme added.

### Test 1
1. Open the demo app and tap on the toolbar to insert a link
2. In the URL field type: `name@company.com`, copy the same to the Link text field and tap OK
3. Switch to html and notice that the `href` points to: `mailto:name@company.com` (prepended with `mailto:`)

### Test 2
1. Open the demo app and tap on the toolbar to insert a link
2. In the URL field type: `#internalanchor`, copy the same to the Link text field and tap OK
3. Switch to html and notice that the `href` points to: `#internalanchor` (no `http://` added)

### Test 3
1. Open the demo app and tap on the toolbar to insert a link
2. In the URL field type: `wordpress.org`, copy the same to the Link text field and tap OK
3. Switch to html and notice that the `href` points to: `http://wordpress.org` (there's an added `http://`)