### PR TITLE
Sync the editors on switch if change zeros out original change

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/BasicTextEditingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/BasicTextEditingTests.kt
@@ -1,0 +1,28 @@
+package org.wordpress.aztec.demo.tests
+
+import android.support.test.rule.ActivityTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.wordpress.aztec.demo.BaseTest
+import org.wordpress.aztec.demo.MainActivity
+import org.wordpress.aztec.demo.pages.EditorPage
+
+class BasicTextEditingTests : BaseTest() {
+
+    @Rule
+    @JvmField
+    var mActivityTestRule = ActivityTestRule(MainActivity::class.java)
+
+    // Test reproducing the issue described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/711
+    @Test
+    fun testEditOutChangesSwitch() {
+        EditorPage()
+                .insertText("text")
+                .toggleHtml()
+                .toggleHtml()
+                .clearText()
+                .toggleHtml()
+                .verifyHTML("")
+    }
+
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -163,7 +163,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         @Throws(NoSuchAlgorithmException::class)
-        private fun calculateSHA256(s: String): ByteArray {
+        fun calculateSHA256(s: String): ByteArray {
             val digest = MessageDigest.getInstance("SHA-256")
             digest.update(s.toByteArray())
             return digest.digest()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -32,6 +32,7 @@ import org.wordpress.aztec.R
 import org.wordpress.aztec.plugins.IMediaToolbarButton
 import org.wordpress.aztec.plugins.IToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
+import java.util.Arrays
 import java.util.ArrayList
 import java.util.Locale
 
@@ -41,6 +42,9 @@ import java.util.Locale
  * Supports RTL layout direction on API 19+
  */
 class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
+    val RETAINED_EDITOR_HTML_PARSED_SHA256_KEY = "RETAINED_EDITOR_HTML_PARSED_SHA256_KEY"
+    val RETAINED_SOURCE_HTML_PARSED_SHA256_KEY = "RETAINED_SOURCE_HTML_PARSED_SHA256_KEY"
+
     private var aztecToolbarListener: IAztecToolbarClickListener? = null
     private var editor: AztecText? = null
     private var headingMenu: PopupMenu? = null
@@ -52,6 +56,9 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private var isExpanded: Boolean = false
     private var isMediaToolbarVisible: Boolean = false
     private var isMediaModeEnabled: Boolean = false
+
+    var editorContentParsedSHA256LastSwitch: ByteArray = ByteArray(0)
+    var sourceContentParsedSHA256LastSwitch: ByteArray = ByteArray(0)
 
     private lateinit var toolbarScrolView: HorizontalScrollView
     private lateinit var buttonEllipsisCollapsed: RippleToggleButton
@@ -346,6 +353,8 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         isMediaToolbarVisible = restoredState.getBoolean("isMediaToolbarVisible")
         setAdvancedState()
         setupMediaToolbar()
+        editorContentParsedSHA256LastSwitch = restoredState.getByteArray(RETAINED_EDITOR_HTML_PARSED_SHA256_KEY)
+        sourceContentParsedSHA256LastSwitch = restoredState.getByteArray(RETAINED_SOURCE_HTML_PARSED_SHA256_KEY)
     }
 
     override fun onSaveInstanceState(): Parcelable {
@@ -356,6 +365,8 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         bundle.putBoolean("isMediaMode", isMediaModeEnabled)
         bundle.putBoolean("isExpanded", isExpanded)
         bundle.putBoolean("isMediaToolbarVisible", isMediaToolbarVisible)
+        bundle.putByteArray(RETAINED_EDITOR_HTML_PARSED_SHA256_KEY, editorContentParsedSHA256LastSwitch)
+        bundle.putByteArray(RETAINED_SOURCE_HTML_PARSED_SHA256_KEY, sourceContentParsedSHA256LastSwitch)
         savedState.state = bundle
         return savedState
     }
@@ -561,22 +572,37 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         }
     }
 
+    private fun syncEditorFromSource() {
+        val editorHtml = editor!!.toPlainHtml(true)
+        val sha256 = AztecText.calculateSHA256(editorHtml)
+        if (editor!!.hasChanges() != NO_CHANGES || !Arrays.equals(editorContentParsedSHA256LastSwitch, sha256)) {
+            sourceEditor!!.displayStyledAndFormattedHtml(editorHtml)
+        }
+        editorContentParsedSHA256LastSwitch = sha256
+    }
+
+    private fun syncSourceFromEditor() {
+        // temp var of the source html to load it to the editor if needed
+        val sourceHtml = sourceEditor!!.getPureHtml(true)
+        val sha256 = AztecText.calculateSHA256(sourceHtml)
+        if (sourceEditor!!.hasChanges() != NO_CHANGES || !Arrays.equals(sourceContentParsedSHA256LastSwitch, sha256)) {
+            editor!!.fromHtml(sourceHtml)
+        }
+        sourceContentParsedSHA256LastSwitch = sha256
+    }
+
     override fun toggleEditorMode() {
         // only allow toggling if sourceEditor is present
         if (sourceEditor == null) return
 
         if (editor!!.visibility == View.VISIBLE) {
-            if (editor!!.hasChanges() != NO_CHANGES) {
-                sourceEditor!!.displayStyledAndFormattedHtml(editor!!.toPlainHtml(true))
-            }
+            syncEditorFromSource()
             editor!!.visibility = View.GONE
             sourceEditor!!.visibility = View.VISIBLE
 
             toggleHtmlMode(true)
         } else {
-            if (sourceEditor!!.hasChanges() != NO_CHANGES) {
-                editor!!.fromHtml(sourceEditor!!.getPureHtml(true))
-            }
+            syncSourceFromEditor()
             editor!!.visibility = View.VISIBLE
             sourceEditor!!.visibility = View.GONE
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -572,7 +572,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         }
     }
 
-    private fun syncEditorFromSource() {
+    private fun syncSourceFromEditor() {
         val editorHtml = editor!!.toPlainHtml(true)
         val sha256 = AztecText.calculateSHA256(editorHtml)
         if (editor!!.hasChanges() != NO_CHANGES || !Arrays.equals(editorContentParsedSHA256LastSwitch, sha256)) {
@@ -581,7 +581,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         editorContentParsedSHA256LastSwitch = sha256
     }
 
-    private fun syncSourceFromEditor() {
+    private fun syncEditorFromSource() {
         // temp var of the source html to load it to the editor if needed
         val sourceHtml = sourceEditor!!.getPureHtml(true)
         val sha256 = AztecText.calculateSHA256(sourceHtml)
@@ -596,13 +596,13 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         if (sourceEditor == null) return
 
         if (editor!!.visibility == View.VISIBLE) {
-            syncEditorFromSource()
+            syncSourceFromEditor()
             editor!!.visibility = View.GONE
             sourceEditor!!.visibility = View.VISIBLE
 
             toggleHtmlMode(true)
         } else {
-            syncSourceFromEditor()
+            syncEditorFromSource()
             editor!!.visibility = View.VISIBLE
             sourceEditor!!.visibility = View.GONE
 


### PR DESCRIPTION
### Fix #711 

This PR add another check for when switching between visual and html mode to have the editors sync their content between them if an editor has been modified since the last time a switch happened. That way, a change that effectively cancels out any change compared to the originally loaded content will be mirrored to the other editor as well.


### Test
1. Run the demo app and add some characters at the beginning of text
2. Switch to html mode
3. Switch back to visual
4. Remove/delete the characters added in step 1
5. Switch to html mode and observe the chars from Step 1 having been removed from the html mode too