### PR TITLE
Aztec may break css styles, and GB cover image blocks

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/CssUnderlineFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/CssUnderlineFormattingTests.kt
@@ -27,7 +27,7 @@ class CssUnderlineFormattingTests : BaseTest() {
     fun testSimpleCssUnderlineFormatting() {
         val text1 = "some"
         val text2 = "text"
-        val html = "$text1<span style=\"text-decoration: underline;\">$text2</span>"
+        val html = "$text1<span style=\"text-decoration:underline;\">$text2</span>"
 
         EditorPage()
                 .insertText(text1)
@@ -56,7 +56,7 @@ class CssUnderlineFormattingTests : BaseTest() {
         val text1 = "some"
         val text2 = "text"
         val html = "$text1<u>$text2</u>"
-        val expectedHtml = "$text1<span style=\"text-decoration: underline;\">$text2</span>"
+        val expectedHtml = "$text1<span style=\"text-decoration:underline;\">$text2</span>"
 
         EditorPage()
                 .toggleHtml()
@@ -78,8 +78,8 @@ class CssUnderlineFormattingTests : BaseTest() {
         val text1 = "some"
         val text2 = "text"
         val html = "$text1<u>$text2</u>"
-        val expectedHtml = "$text1<span style=\"text-decoration: underline;\">te</span>\n\n" +
-                "<span style=\"text-decoration: underline;\">xt</span>"
+        val expectedHtml = "$text1<span style=\"text-decoration:underline;\">te</span>\n\n" +
+                "<span style=\"text-decoration:underline;\">xt</span>"
 
         EditorPage()
                 .toggleHtml()

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -52,6 +52,21 @@ class GutenbergCompatTests : BaseTest() {
     }
 
     @Test
+    fun testRetainGutenbergPostContentWithCoverImage() {
+        val html = "<!-- wp:cover-image {\"url\":\"https://cldup.com/Fz-ASbo2s3.jpg\",\"align\":\"wide\"} -->" +
+                "<div class=\"wp-block-cover-image has-background-dim alignwide\" style=\"background-image:url('https://cldup.com/Fz-ASbo2s3.jpg');\">" +
+                "    <p class=\"wp-block-cover-image-text\">Of Mountains &amp; Printing Presses</p>" +
+                "</div>" +
+                "<!-- /wp:cover-image -->"
+
+        EditorPage().toggleHtml()
+                .insertHTML(html)
+                .toggleHtml()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
     fun testRetainGutenbergPostContentAndInlineGutenbergComment() {
         val html = "<!-- wp:latest-posts {\"postsToShow\":4,\"displayPostDate\":true} /-->" +
                 "<!-- wp:paragraph --><p>Blue is not a color</p><!-- /wp:paragraph -->" +

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -118,7 +118,7 @@ class CssStyleFormatter {
                 style += ";"
             }
 
-            style += " $styleAttributeName: $styleAttributeValue;"
+            style += " $styleAttributeName:$styleAttributeValue;"
             attributes.setValue(STYLE_ATTRIBUTE, style.trim())
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -95,7 +95,6 @@ class CssStyleFormatter {
                     attributes.removeAttribute(STYLE_ATTRIBUTE)
                 } else {
                     newStyle = newStyle.replace(";".toRegex(), "; ")
-                    newStyle = newStyle.replace(":".toRegex(), ": ")
                     attributes.setValue(STYLE_ATTRIBUTE, newStyle.trim())
                 }
             }
@@ -131,7 +130,7 @@ class CssStyleFormatter {
 
             var style = ""
             mergedArray.forEach({
-                style = style + it.replace(":", ": ") + "; "
+                style = style + it + ";"
             })
             return style.trimEnd()
         }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -809,18 +809,18 @@ class AztecToolbarTest {
 
         editText.setSelection(3)
         alignRightButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\">Hello, this is some unformatted text.</p>",
+        Assert.assertEquals("<p style=\"text-align:right;\">Hello, this is some unformatted text.</p>",
                 editText.toHtml())
 
         alignRightButton.performClick()
         Assert.assertEquals("<p>Hello, this is some unformatted text.</p>", editText.toHtml())
 
         alignLeftButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: left;\">Hello, this is some unformatted text.</p>",
+        Assert.assertEquals("<p style=\"text-align:left;\">Hello, this is some unformatted text.</p>",
                 editText.toHtml())
 
         alignCenterButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: center;\">Hello, this is some unformatted text.</p>",
+        Assert.assertEquals("<p style=\"text-align:center;\">Hello, this is some unformatted text.</p>",
                 editText.toHtml())
     }
 
@@ -831,14 +831,14 @@ class AztecToolbarTest {
 
         editText.setSelection(3)
         alignRightButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\">Hello, this is some unformatted text.</p>" +
+        Assert.assertEquals("<p style=\"text-align:right;\">Hello, this is some unformatted text.</p>" +
                 "Another line<br>Third line",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("Third"))
         alignCenterButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\">Hello, this is some unformatted text.</p>" +
-                "Another line<p style=\"text-align: center;\">Third line</p>",
+        Assert.assertEquals("<p style=\"text-align:right;\">Hello, this is some unformatted text.</p>" +
+                "Another line<p style=\"text-align:center;\">Third line</p>",
                 editText.toHtml())
     }
 
@@ -849,20 +849,20 @@ class AztecToolbarTest {
 
         editText.setSelection(editText.text.indexOf("bold"))
         alignRightButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\"><b>bold</b></p><i>italic</i><br><u>underline</u>",
+        Assert.assertEquals("<p style=\"text-align:right;\"><b>bold</b></p><i>italic</i><br><u>underline</u>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("italic"))
         alignCenterButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\"><b>bold</b></p>" +
-                "<p style=\"text-align: center;\"><i>italic</i></p><u>underline</u>",
+        Assert.assertEquals("<p style=\"text-align:right;\"><b>bold</b></p>" +
+                "<p style=\"text-align:center;\"><i>italic</i></p><u>underline</u>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("underline"))
         alignLeftButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\"><b>bold</b></p>" +
-                "<p style=\"text-align: center;\"><i>italic</i></p>" +
-                "<p style=\"text-align: left;\"><u>underline</u></p>",
+        Assert.assertEquals("<p style=\"text-align:right;\"><b>bold</b></p>" +
+                "<p style=\"text-align:center;\"><i>italic</i></p>" +
+                "<p style=\"text-align:left;\"><u>underline</u></p>",
                 editText.toHtml())
     }
 
@@ -873,7 +873,7 @@ class AztecToolbarTest {
 
         editText.setSelection(2, editText.length() - 2)
         alignRightButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\"><b>bold</b><br><i>italic</i><br><u>underline</u></p>",
+        Assert.assertEquals("<p style=\"text-align:right;\"><b>bold</b><br><i>italic</i><br><u>underline</u></p>",
                 editText.toHtml())
     }
 
@@ -884,7 +884,7 @@ class AztecToolbarTest {
 
         editText.setSelection(editText.text.indexOf("Heading 2"))
         alignRightButton.performClick()
-        Assert.assertEquals("<h1>Heading 1</h1><h2 style=\"text-align: right;\">Heading 2</h2><h3>Heading 3</h3>",
+        Assert.assertEquals("<h1>Heading 1</h1><h2 style=\"text-align:right;\">Heading 2</h2><h3>Heading 3</h3>",
                 editText.toHtml())
     }
 
@@ -895,7 +895,7 @@ class AztecToolbarTest {
 
         editText.setSelection(editText.text.indexOf("2") + 1)
         alignCenterButton.performClick()
-        Assert.assertEquals("<h1>Heading 1</h1><h2 style=\"text-align: center;\">Heading 2</h2><h3>Heading 3</h3>",
+        Assert.assertEquals("<h1>Heading 1</h1><h2 style=\"text-align:center;\">Heading 2</h2><h3>Heading 3</h3>",
                 editText.toHtml())
     }
 
@@ -906,8 +906,8 @@ class AztecToolbarTest {
 
         editText.setSelection(editText.text.indexOf("2"), editText.text.length)
         alignCenterButton.performClick()
-        Assert.assertEquals("<h1>Heading 1</h1><h2 style=\"text-align: center;\">Heading 2</h2>" +
-                "<h3 style=\"text-align: center;\">Heading 3</h3>",
+        Assert.assertEquals("<h1>Heading 1</h1><h2 style=\"text-align:center;\">Heading 2</h2>" +
+                "<h3 style=\"text-align:center;\">Heading 3</h3>",
                 editText.toHtml())
     }
 
@@ -918,9 +918,9 @@ class AztecToolbarTest {
 
         editText.setSelection(0, editText.length())
         alignLeftButton.performClick()
-        Assert.assertEquals("<ul><li style=\"text-align: left;\">item 1</li>" +
-                "<li style=\"text-align: left;\">item 2</li>" +
-                "<li style=\"text-align: left;\">item 3</li></ul>",
+        Assert.assertEquals("<ul><li style=\"text-align:left;\">item 1</li>" +
+                "<li style=\"text-align:left;\">item 2</li>" +
+                "<li style=\"text-align:left;\">item 3</li></ul>",
                 editText.toHtml())
     }
 
@@ -931,13 +931,13 @@ class AztecToolbarTest {
 
         editText.setSelection(editText.text.indexOf("1"))
         alignLeftButton.performClick()
-        Assert.assertEquals("<ul><li style=\"text-align: left;\">item 1</li>" +
+        Assert.assertEquals("<ul><li style=\"text-align:left;\">item 1</li>" +
                 "<li>item 2</li><li>item 3</li></ul>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("1") + 1)
         alignRightButton.performClick()
-        Assert.assertEquals("<ul><li style=\"text-align: right;\">item 1</li>" +
+        Assert.assertEquals("<ul><li style=\"text-align:right;\">item 1</li>" +
                 "<li>item 2</li><li>item 3</li></ul>",
                 editText.toHtml())
 
@@ -947,25 +947,25 @@ class AztecToolbarTest {
 
         editText.setSelection(editText.text.indexOf("1") + 2)
         alignCenterButton.performClick()
-        Assert.assertEquals("<ul><li>item 1</li><li style=\"text-align: center;\">item 2</li><li>item 3</li></ul>",
+        Assert.assertEquals("<ul><li>item 1</li><li style=\"text-align:center;\">item 2</li><li>item 3</li></ul>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.length)
         alignCenterButton.performClick()
-        Assert.assertEquals("<ul><li>item 1</li><li style=\"text-align: center;\">item 2</li><li style=\"text-align: center;\">item 3</li></ul>",
+        Assert.assertEquals("<ul><li>item 1</li><li style=\"text-align:center;\">item 2</li><li style=\"text-align:center;\">item 3</li></ul>",
                 editText.toHtml())
     }
 
     @Test
     @Throws(Exception::class)
     fun orderedListMultiselectAlignment() {
-        editText.fromHtml("<ol><li>item 1</li><li style=\"text-align: center;\">item 2</li></ol>" +
+        editText.fromHtml("<ol><li>item 1</li><li style=\"text-align:center;\">item 2</li></ol>" +
                 "<hr /><ol><li>item 3</li><li>item 4</li></ol>")
 
         editText.setSelection(editText.text.indexOf("2"), editText.text.indexOf("3"))
         alignRightButton.performClick()
-        Assert.assertEquals("<ol><li>item 1</li><li style=\"text-align: right;\">item 2</li></ol><hr />" +
-                "<ol><li style=\"text-align: right;\">item 3</li><li>item 4</li></ol>",
+        Assert.assertEquals("<ol><li>item 1</li><li style=\"text-align:right;\">item 2</li></ol><hr />" +
+                "<ol><li style=\"text-align:right;\">item 3</li><li>item 4</li></ol>",
                 editText.toHtml())
     }
 
@@ -976,7 +976,7 @@ class AztecToolbarTest {
 
         editText.setSelection(1)
         alignRightButton.performClick()
-        Assert.assertEquals("<blockquote style=\"text-align: right;\">Quote<br>newline</blockquote>",
+        Assert.assertEquals("<blockquote style=\"text-align:right;\">Quote<br>newline</blockquote>",
                 editText.toHtml())
     }
 
@@ -987,7 +987,7 @@ class AztecToolbarTest {
 
         editText.setSelection(1)
         alignCenterButton.performClick()
-        Assert.assertEquals("<pre style=\"text-align: center;\">test<br>newline</pre>",
+        Assert.assertEquals("<pre style=\"text-align:center;\">test<br>newline</pre>",
                 editText.toHtml())
     }
 
@@ -999,7 +999,7 @@ class AztecToolbarTest {
         editText.setSelection(7)
         alignLeftButton.performClick()
         Assert.assertEquals("<code>Code</code>" +
-                "<p style=\"text-align: left;\"><code>newline</code></p>",
+                "<p style=\"text-align:left;\"><code>newline</code></p>",
                 editText.toHtml())
     }
 
@@ -1010,7 +1010,7 @@ class AztecToolbarTest {
 
         editText.setSelection(3)
         alignRightButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\"><!-- Comment --></p>", editText.toHtml())
+        Assert.assertEquals("<p style=\"text-align:right;\"><!-- Comment --></p>", editText.toHtml())
 
         alignRightButton.performClick()
         Assert.assertEquals("<p><!-- Comment --></p>", editText.toHtml())
@@ -1023,21 +1023,21 @@ class AztecToolbarTest {
 
         editText.setSelection(editText.text.indexOf("a"))
         alignRightButton.performClick()
-        Assert.assertEquals("<div style=\"text-align: right;\">a<br><div>b<br><span>c</span><br>d</div></div>",
+        Assert.assertEquals("<div style=\"text-align:right;\">a<br><div>b<br><span>c</span><br>d</div></div>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("c") + 1)
         alignCenterButton.performClick()
-        Assert.assertEquals("<div style=\"text-align: center;\">a<br>" +
-                "<div style=\"text-align: center;\">b<br>" +
-                "<span style=\"text-align: center;\">c</span><br>d</div></div>",
+        Assert.assertEquals("<div style=\"text-align:center;\">a<br>" +
+                "<div style=\"text-align:center;\">b<br>" +
+                "<span style=\"text-align:center;\">c</span><br>d</div></div>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("d"))
         alignLeftButton.performClick()
-        Assert.assertEquals("<div style=\"text-align: left;\">a<br>" +
-                "<div style=\"text-align: left;\">b<br>" +
-                "<span style=\"text-align: center;\">c</span><br>d</div></div>",
+        Assert.assertEquals("<div style=\"text-align:left;\">a<br>" +
+                "<div style=\"text-align:left;\">b<br>" +
+                "<span style=\"text-align:center;\">c</span><br>d</div></div>",
                 editText.toHtml())
     }
 
@@ -1048,24 +1048,24 @@ class AztecToolbarTest {
 
         editText.setSelection(0)
         alignLeftButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: left;\">latin</p>بعبثخز",
+        Assert.assertEquals("<p style=\"text-align:left;\">latin</p>بعبثخز",
                 editText.toHtml())
 
         editText.setSelection(editText.length())
         alignLeftButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: left;\">latin</p>" +
-                "<p style=\"text-align: left;\">بعبثخز</p>",
+        Assert.assertEquals("<p style=\"text-align:left;\">latin</p>" +
+                "<p style=\"text-align:left;\">بعبثخز</p>",
                 editText.toHtml())
 
         alignRightButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: left;\">latin</p>" +
-                "<p style=\"text-align: right;\">بعبثخز</p>",
+        Assert.assertEquals("<p style=\"text-align:left;\">latin</p>" +
+                "<p style=\"text-align:right;\">بعبثخز</p>",
                 editText.toHtml())
 
         editText.setSelection(0)
         alignRightButton.performClick()
-        Assert.assertEquals("<p style=\"text-align: right;\">latin</p>" +
-                "<p style=\"text-align: right;\">بعبثخز</p>",
+        Assert.assertEquals("<p style=\"text-align:right;\">latin</p>" +
+                "<p style=\"text-align:right;\">بعبثخز</p>",
                 editText.toHtml())
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -20,8 +20,8 @@ import org.wordpress.aztec.spans.AztecStyleBoldSpan
 class CssStyleAttributeTest : AndroidTestCase() {
 
     private val EMPTY_STYLE_HTML = "<b>bold</b>"
-    private val HTML = "<b style=\"name: value;\">bold</b>"
-    private val COMPLEX_HTML = "<b style=\"a: b; name: value;\">bold</b>"
+    private val HTML = "<b style=\"name:value;\">bold</b>"
+    private val COMPLEX_HTML = "<b style=\"a:b; name:value;\">bold</b>"
 
     private lateinit var parser: AztecParser
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
@@ -21,14 +21,14 @@ class CssUnderlinePluginTest {
     lateinit var editText: AztecText
 
     private val REGULAR_UNDERLINE_HTML = "<u>Underline</u>"
-    private val REGULAR_UNDERLINE_WITH_STYLES_HTML = "<u style=\"color: green;\">Underline</u>"
-    private val CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML = "<span style=\"color: green; text-decoration: underline;\">Underline</span>"
-    private val COMPLEX_HTML = "<span style=\"test: value\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</span>"
-    private val COMPLEX_REGULAR_DIV_HTML = "<div style=\"test: value;\">$REGULAR_UNDERLINE_WITH_STYLES_HTML</div>"
-    private val COMPLEX_CSS_DIV_HTML = "<div style=\"test: value;\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</div>"
-    private val CSS_STYLE_UNDERLINE_WITH_EVEN_MORE_STYLES_REORDERED_HTML = "<span style=\"color: green; text-decoration: underline; test: value;\">Underline</span>"
-    private val CSS_UNDERLINE_INSIDE_BOLD = "<b><span style=\"color: lime; text-decoration: underline;\">Underline</span></b>"
-    private val CSS_UNDERLINE_OUTSIDE_BOLD = "<span style=\"color: lime; text-decoration: underline;\"><b>Underline</b></span>"
+    private val REGULAR_UNDERLINE_WITH_STYLES_HTML = "<u style=\"color:green;\">Underline</u>"
+    private val CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML = "<span style=\"color:green; text-decoration:underline;\">Underline</span>"
+    private val COMPLEX_HTML = "<span style=\"test:value\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</span>"
+    private val COMPLEX_REGULAR_DIV_HTML = "<div style=\"test:value;\">$REGULAR_UNDERLINE_WITH_STYLES_HTML</div>"
+    private val COMPLEX_CSS_DIV_HTML = "<div style=\"test:value;\">$CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML</div>"
+    private val CSS_STYLE_UNDERLINE_WITH_EVEN_MORE_STYLES_REORDERED_HTML = "<span style=\"color:green; text-decoration:underline; test:value;\">Underline</span>"
+    private val CSS_UNDERLINE_INSIDE_BOLD = "<b><span style=\"color:lime; text-decoration:underline;\">Underline</span></b>"
+    private val CSS_UNDERLINE_OUTSIDE_BOLD = "<span style=\"color:lime; text-decoration:underline;\"><b>Underline</b></span>"
 
     /**
      * Initialize variables.


### PR DESCRIPTION
### Fix #714

Before this PR we were adding a space after a `:` in styles, for readability reason, without checking if the `:` char was used in URLs instead. In this PR i've just removed the code that adds the space, without doing regexp or other kind of hacks that check if the space was inside an URL or not.

Also updated CSS tests, and added a new test for GB cover block (that was the original reporter of the problem).

