### PR TITLE
Issue/718 update on first mode switch

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -418,7 +418,9 @@ open class MainActivity : AppCompatActivity(),
         }
 
         if (savedInstanceState == null) {
-            aztec.visualEditor.fromHtml(EXAMPLE)
+            if (!isRunningTest) {
+                aztec.visualEditor.fromHtml(EXAMPLE)
+            }
             aztec.initSourceEditorHistory()
         }
 

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -418,7 +418,7 @@ open class MainActivity : AppCompatActivity(),
         }
 
         if (savedInstanceState == null) {
-            aztec.visualEditor.fromHtml(aztec.sourceEditor?.getPureHtml()!!)
+            aztec.visualEditor.fromHtml(EXAMPLE)
             aztec.initSourceEditorHistory()
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -575,6 +575,12 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private fun syncSourceFromEditor() {
         val editorHtml = editor!!.toPlainHtml(true)
         val sha256 = AztecText.calculateSHA256(editorHtml)
+
+        if (editorContentParsedSHA256LastSwitch.isEmpty()) {
+            // initialize the var if it's the first time we're about to use it
+            editorContentParsedSHA256LastSwitch = sha256
+        }
+
         if (editor!!.hasChanges() != NO_CHANGES || !Arrays.equals(editorContentParsedSHA256LastSwitch, sha256)) {
             sourceEditor!!.displayStyledAndFormattedHtml(editorHtml)
         }
@@ -585,6 +591,12 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         // temp var of the source html to load it to the editor if needed
         val sourceHtml = sourceEditor!!.getPureHtml(true)
         val sha256 = AztecText.calculateSHA256(sourceHtml)
+
+        if (sourceContentParsedSHA256LastSwitch.isEmpty()) {
+            // initialize the var if it's the first time we're about to use it
+            sourceContentParsedSHA256LastSwitch = sha256
+        }
+
         if (sourceEditor!!.hasChanges() != NO_CHANGES || !Arrays.equals(sourceContentParsedSHA256LastSwitch, sha256)) {
             editor!!.fromHtml(sourceHtml)
         }


### PR DESCRIPTION
### Fix #718 

This PR makes sure that the internal sha256 values the AztecToolbar is keeping to monitor whether an editor has changed content since the last time it got in the foreground are initialized right before the first time needed to be used.

The idea there goes like this: The first time switching to the source/html editor, we need to check if the _visual_ editor has changes compared to the original input content _or_ if it has changes since the last time the visual editor got in the foreground. But, since the visual editor was already in the foreground when starting, it makes sense to initialize the sha256 var with the current contents instead of checking against the empty var, as it was happening before this PR.

### Test
1. Load the demo app
2. Attach the debugger and place a breakpoint at [this line](https://github.com/wordpress-mobile/AztecEditor-Android/blob/b6893bc8a2beb15f0027f3499ff47bda98c29983/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt#L585), where the source editor is instructed to load new content
3. Back to the demo app, tap on the mode switch button on the toolbar and observe that the debugger doesn't stop at the breakpoint set in step 2