### PR TITLE
Added cleaning utility to cope with nested <b> tags

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -58,6 +58,7 @@ import org.wordpress.aztec.spans.IAztecInlineSpan;
 import org.wordpress.aztec.spans.IAztecParagraphStyle;
 import org.wordpress.aztec.spans.UnknownClickableSpan;
 import org.wordpress.aztec.spans.UnknownHtmlSpan;
+import org.wordpress.aztec.util.CleaningUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
@@ -187,6 +188,8 @@ public class Html {
             // Should not happen.
             throw new RuntimeException(e);
         }
+
+        source = CleaningUtils.cleanNestedBoldTags(source);
 
         source = preprocessSource(source, plugins);
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -87,6 +87,7 @@ import org.wordpress.aztec.spans.UnknownHtmlSpan
 import org.wordpress.aztec.toolbar.IAztecToolbar
 import org.wordpress.aztec.toolbar.ToolbarAction
 import org.wordpress.aztec.util.AztecLog
+import org.wordpress.aztec.util.CleaningUtils
 import org.wordpress.aztec.util.InstanceStateUtils
 import org.wordpress.aztec.util.SpanWrapper
 import org.wordpress.aztec.util.coerceToHtmlText
@@ -1015,7 +1016,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val builder = SpannableStringBuilder()
         val parser = AztecParser(plugins)
 
-        val cleanSource = Format.removeSourceEditorFormatting(source, isInCalypsoMode)
+        var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
+        cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode)
         builder.append(parser.fromHtml(cleanSource, context))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -10,6 +10,7 @@ import org.wordpress.aztec.spans.AztecVisualLinebreak
 import org.wordpress.aztec.spans.EndOfParagraphMarker
 import org.wordpress.aztec.spans.IAztecParagraphStyle
 import org.wordpress.aztec.spans.ParagraphSpan
+import org.wordpress.aztec.util.CleaningUtils
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -25,6 +26,7 @@ object Format {
         html = html.replace("<aztec_cursor>", "")
 
         val doc = Jsoup.parseBodyFragment(html).outputSettings(Document.OutputSettings().prettyPrint(!isCalypsoFormat))
+        CleaningUtils.cleanNestedBoldTags(doc)
         if (isCalypsoFormat) {
             // remove empty span tags
             doc.select("*")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
@@ -19,7 +19,7 @@ object CleaningUtils {
     }
 
     @JvmStatic
-    fun cleanNestedBoldTags(html: String) :String {
+    fun cleanNestedBoldTags(html: String) : String {
         val doc = Jsoup.parseBodyFragment(html).outputSettings(Document.OutputSettings())
         cleanNestedBoldTags(doc)
         return doc.html()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
@@ -1,0 +1,27 @@
+package org.wordpress.aztec.util
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+
+object CleaningUtils {
+
+    @JvmStatic
+    fun cleanNestedBoldTags(doc: Document) {
+        // clean all nested <b> tags that don't contain anything
+        doc.select("b > b")
+        .filter { !it.hasText() }
+        .forEach { it.remove() }
+
+        // unwrap text in between nested <b> tags that have some text in them
+        doc.select("b > b")
+        .filter { it.hasText() }
+        .forEach { it.unwrap() }
+    }
+
+    @JvmStatic
+    fun cleanNestedBoldTags(html: String) :String {
+        val doc = Jsoup.parseBodyFragment(html).outputSettings(Document.OutputSettings())
+        cleanNestedBoldTags(doc)
+        return doc.html()
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
@@ -2,6 +2,7 @@ package org.wordpress.aztec.util
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.jsoup.parser.Parser
 
 object CleaningUtils {
 
@@ -20,7 +21,7 @@ object CleaningUtils {
 
     @JvmStatic
     fun cleanNestedBoldTags(html: String) : String {
-        val doc = Jsoup.parseBodyFragment(html).outputSettings(Document.OutputSettings())
+        val doc = Jsoup.parse(html, "", Parser.xmlParser()).outputSettings(Document.OutputSettings().prettyPrint(false))
         cleanNestedBoldTags(doc)
         return doc.html()
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -74,6 +74,100 @@ class HtmlFormattingTest : AndroidTestCase() {
     private val HTML_BLOCK_WITH_NEWLINES = "\n\n<div>Division</div>\n\n"
     private val HTML_BLOCK_WITHOUT_NEWLINES = "<div>Division</div>"
 
+    private val HTML_NESTED_BOLD_TAGS = "<b><b><b><b><b><b><b>Test post</b></b></b></b></b></b></b> \n" +
+            "\n" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b>" +
+            "<b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b>" +
+            "</b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b><b></b>" +
+            "<b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b>" +
+            "</b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b></b>" +
+            "<br /><br />Our room with a view[/caption]\n" +
+            "\n" +
+            "Test end"
+
+    private val HTML_NESTED_BOLD_TAGS_VISUAL2HTML_OUTPUT =
+            "<b>Test post</b><b> </b><br><br>Our room with a view[/caption] Test end"
+    private val HTML_NESTED_BOLD_TAGS_HTML_PROCESSING_OUTPUT =
+            "<b>Test post</b> <b></b><br><br>Our room with a view[/caption] Test end"
+
     /**
      * Initialize variables.
      */
@@ -136,5 +230,32 @@ class HtmlFormattingTest : AndroidTestCase() {
         val span = SpannableString(parser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
         val output = Format.removeSourceEditorFormatting(Format.addSourceEditorFormatting(parser.toHtml(span)))
         Assert.assertEquals(HTML_BLOCK_WITHOUT_NEWLINES, output)
+    }
+
+    /**
+     * Test block conversion from HTML to visual mode with nested <b> blocks
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun noNestedBoldTagsConversion() {
+        val input = HTML_NESTED_BOLD_TAGS
+        val span = SpannableString(parser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = Format.removeSourceEditorFormatting(Format.addSourceEditorFormatting(parser.toHtml(span)))
+        Assert.assertEquals(HTML_NESTED_BOLD_TAGS_VISUAL2HTML_OUTPUT, output)
+    }
+
+    /**
+     * Test adding source editor formatting handles nested <b> blocks
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun noNestedBoldTagsFromSource() {
+        val input = HTML_NESTED_BOLD_TAGS
+        val output = Format.removeSourceEditorFormatting(Format.addSourceEditorFormatting(input))
+        Assert.assertEquals(HTML_NESTED_BOLD_TAGS_HTML_PROCESSING_OUTPUT, output)
     }
 }


### PR DESCRIPTION
### Fix
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/7909

This PR makes sure to eliminate any redundant nested `<b>` tags that makes our parser go crazy (i.e. StackOverflow and crashing the hosting app), by:
- removing any nested `<b>`  tags that are empty (no text nodes within them)
- unwrapping any text that is surrounded by nested `<b>` tags to only contain _one surrounding `<b></b>` pair_, which is the minimum needed to express the same result.
Used the syntax as per [Jsoup's  documentation ](https://jsoup.org/cookbook/extracting-data/selector-syntax)

For the tests, 2 tests at minimum are needed: one to test parsing HTML through jsoup (`Format.addSourceEditorFormatting`) and another one that tests the `AztecParser.fromHtml()` handling as well. These produce slightly different outputs that don't belong to this PR to solve (a space character is placed differently depending on what is run first), so I added the custom outputs for each of the tests separately in `HTML_NESTED_BOLD_TAGS_VISUAL2HTML_OUTPUT` and  `HTML_NESTED_BOLD_TAGS_HTML_PROCESSING_OUTPUT` just to follow along.


### Test
1. Feed the demo app with the sample code described in https://github.com/wordpress-mobile/WordPress-Android/issues/7909
2. Run
3. Observe it doesn't crash

