### PR TITLE
Treat div, figure, figcaption and section as block level html elements

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -113,7 +113,9 @@ open class MainActivity : AppCompatActivity(),
                         "</div>" +
                         "<br>"
         private val GUTENBERG_CODE_BLOCK = "<!-- wp:core/image {\"id\":316} -->\n" +
-                "<figure class=\"wp-block-image\"><img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/98/WordPress_blue_logo.svg/1200px-WordPress_blue_logo.svg.png\" alt=\"\" /></figure>\n" +
+                "<figure class=\"wp-block-image\"><img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/98/WordPress_blue_logo.svg/1200px-WordPress_blue_logo.svg.png\" alt=\"\" />\n" +
+                "  <figcaption>The WordPress logo!</figcaption>\n" +
+                "</figure>\n" +
                 "<!-- /wp:core/image -->"
         private val PREFORMAT =
                 "<pre>" +

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -41,6 +41,7 @@ import org.wordpress.aztec.spans.AztecQuoteSpan
 import org.wordpress.aztec.spans.AztecStrikethroughSpan
 import org.wordpress.aztec.spans.AztecUnorderedListSpan
 import org.wordpress.aztec.spans.AztecVideoSpan
+import org.wordpress.aztec.spans.HiddenHtmlBlock
 import org.wordpress.aztec.spans.HiddenHtmlSpan
 import org.wordpress.aztec.spans.IAztecAttributedSpan
 import org.wordpress.aztec.spans.IAztecNestable
@@ -75,8 +76,12 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
                 handleElement(output, opening, AztecStrikethroughSpan(tag, AztecAttributes(attributes)))
                 return true
             }
-            DIV, SPAN, FIGURE, FIGCAPTION, SECTION -> {
+            SPAN -> {
                 handleElement(output, opening, HiddenHtmlSpan(tag, AztecAttributes(attributes), nestingLevel))
+                return true
+            }
+            DIV, FIGURE, FIGCAPTION, SECTION -> {
+                handleElement(output, opening, HiddenHtmlBlock(tag, AztecAttributes(attributes), nestingLevel))
                 return true
             }
             LIST_UL -> {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlBlock.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlBlock.kt
@@ -1,0 +1,14 @@
+package org.wordpress.aztec.spans
+
+import android.text.Layout
+import org.wordpress.aztec.AztecAttributes
+
+class HiddenHtmlBlock(tag: String, override var attributes: AztecAttributes = AztecAttributes(),
+                      override var nestingLevel: Int) : IAztecBlockSpan {
+    override var endBeforeBleed: Int = -1
+    override var startBeforeCollapse: Int = -1
+
+    override var align: Layout.Alignment? = null
+
+    override val TAG: String = tag
+}

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -1019,23 +1019,23 @@ class AztecToolbarTest {
     @Test
     @Throws(Exception::class)
     fun hiddenElementAlignment() {
-        editText.fromHtml("<div>a<br><div>b<br><span>c</span><br>d</div></div>")
+        editText.fromHtml("<div>a<div>b<br><span>c</span><br>d</div></div>")
 
         editText.setSelection(editText.text.indexOf("a"))
         alignRightButton.performClick()
-        Assert.assertEquals("<div style=\"text-align:right;\">a<br><div>b<br><span>c</span><br>d</div></div>",
+        Assert.assertEquals("<div style=\"text-align:right;\">a<div>b<br><span>c</span><br>d</div></div>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("c") + 1)
         alignCenterButton.performClick()
-        Assert.assertEquals("<div style=\"text-align:center;\">a<br>" +
+        Assert.assertEquals("<div style=\"text-align:center;\">a" +
                 "<div style=\"text-align:center;\">b<br>" +
                 "<span style=\"text-align:center;\">c</span><br>d</div></div>",
                 editText.toHtml())
 
         editText.setSelection(editText.text.indexOf("d"))
         alignLeftButton.performClick()
-        Assert.assertEquals("<div style=\"text-align:left;\">a<br>" +
+        Assert.assertEquals("<div style=\"text-align:left;\">a" +
                 "<div style=\"text-align:left;\">b<br>" +
                 "<span style=\"text-align:center;\">c</span><br>d</div></div>",
                 editText.toHtml())


### PR DESCRIPTION
### Fix #724 

This PR specializes the support for the `div`, `figure`, `figcaption` and `section` html elements to be compatible with block-level elements rather than inline-level elements that were implemented as so far. Besides, the HTML spec has them as block-level.

With this fix, placing the cursor at the beginning or the end of the respective span will make any text be included in the span. For example, adding text anywhere inside or the edges of the `figcaption` will have the text included in the caption as normal.

### Test
1. Load the following html snippet in html mode:
```html
<!-- wp:image {"align":"center"} -->
<figure class="wp-block-image aligncenter">
  <img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" />
  <figcaption>If your theme supports it, you'll see the "wide" button on the image toolbar. Give it a try.
  </figcaption>
</figure>
<!-- /wp:image -->
```
2. Switch to visual mode and place the cursor in the very beginning of the caption (there might be a couple of spaces there so, make sure the cursor is at the start of the line), or the very end
3. Insert one or more characters
4. Switch to html mode and notice that the character(s) entered lie inside the `<figcaption></figcaption>` element