### PR TITLE
Make fromHTML of AztecText `open` 

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1012,7 +1012,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return cursorPosition
     }
 
-    fun fromHtml(source: String) {
+    open fun fromHtml(source: String) {
         val builder = SpannableStringBuilder()
         val parser = AztecParser(plugins)
 


### PR DESCRIPTION
Just a small change required to extend `fromHTML` in the Aztec ReactNative wrapper.