### PR TITLE
Feature / Android8 / Paste as plain text

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1310,8 +1310,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         when (id) {
-            android.R.id.paste,
-            android.R.id.pasteAsPlainText -> paste(text, min, max)
+            android.R.id.paste -> paste(text, min, max)
+            android.R.id.pasteAsPlainText -> paste(text, min, max, true)
             android.R.id.copy -> {
                 copy(text, min, max)
                 setSelection(max) // dismiss the selection to make the action menu hide
@@ -1364,7 +1364,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     // copied from TextView with some changes
-    fun paste(editable: Editable, min: Int, max: Int) {
+    fun paste(editable: Editable, min: Int, max: Int, asPlainText: Boolean = false) {
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clip = clipboard.primaryClip
 
@@ -1394,7 +1394,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             enableTextChangedListener()
 
             if (clip.itemCount > 0) {
-                val textToPaste = clip.getItemAt(0).coerceToHtmlText(AztecParser(plugins))
+                val textToPaste = if (asPlainText) clip.getItemAt(0).coerceToText(context).toString()
+                else clip.getItemAt(0).coerceToHtmlText(AztecParser(plugins))
 
                 val oldHtml = toPlainHtml().replace("<aztec_cursor>", "")
                 val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste + "<" + AztecCursorSpan.AZTEC_CURSOR_TAG + ">")

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -310,4 +310,32 @@ class ClipboardTest {
 
         editText.setCalypsoMode(false)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndPasteAsPlainTextSameInlineStyle() {
+        editText.fromHtml("<b>Bold</b>")
+
+        editText.setSelection(0, editText.length())
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(editText.length())
+        TestUtils.pasteFromClipboardAsPlainText(editText)
+
+        Assert.assertEquals("<b>Bold</b>Bold", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun copyAndReplaceAsPlainText() {
+        editText.fromHtml(LONG_TEXT)
+
+        editText.setSelection(0, editText.length())
+        TestUtils.copyToClipboard(editText)
+
+        editText.setSelection(0, editText.length())
+        TestUtils.pasteFromClipboardAsPlainText(editText)
+
+        Assert.assertEquals(LONG_TEXT_EXPECTED, editText.toHtml())
+    }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/TestUtils.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/TestUtils.kt
@@ -65,6 +65,15 @@ object TestUtils {
     }
 
     /**
+     * Issue a copy as plain text to clipboard key event
+     *
+     * @param text The EditText to issue the key event to
+     */
+    fun pasteFromClipboardAsPlainText(text: AztecText) {
+        text.paste(text.text, text.selectionStart, text.selectionEnd, true)
+    }
+
+    /**
      * Helper for calculating the EditText's length *without* counting the the end-of-text marker char if present
      *
      * @param text The EditText to check for length sans the end-of-text marker char if present


### PR DESCRIPTION
### Fix 653
by adding the ability to use the new Android 8 feature "pasta as plain text" and only paste the text (without any styling elements).

HTML tags, links, everything, is stripped away from the original content, and then the plain text content is pasted in Aztec by preserving the actual style in the editor.

### Test on Android 8 only
1. Open a browser and select Rich text from an HTML page.
2. Go to AztecDemo and paste as plain text the content.
3. You should see the content without any formatting option (no HTML at all when switching to text view).

Note: This features relies on a given Android 8 routine, that returns plain text from the Clipboard. If we need to do something more specialized (like preserving some input tags/style) we may need to write additional code that from clipboard returns a valid string for us.

### Review
@mzorz 