### PR TITLE
Add support for creating links that open in a new window

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditLinkPage.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/pages/EditLinkPage.kt
@@ -18,6 +18,7 @@ class EditLinkPage : BasePage() {
     private var okButton: ViewInteraction
     private var cancelButton: ViewInteraction
     private var removeButton: ViewInteraction
+    private var openInNewWindowCheckbox: ViewInteraction
 
     override val trait: ViewInteraction
         get() = onView(withText("Insert link"))
@@ -25,6 +26,7 @@ class EditLinkPage : BasePage() {
     init {
         urlField = onView(withId(R.id.linkURL))
         nameField = onView(withId(R.id.linkText))
+        openInNewWindowCheckbox = onView(withId(R.id.openInNewWindow))
         okButton = onView(withId(android.R.id.button1))
         cancelButton = onView(withId(android.R.id.button2))
         removeButton = onView(withId(android.R.id.button3))
@@ -55,6 +57,12 @@ class EditLinkPage : BasePage() {
         nameField.check(ViewAssertions.matches(withText(expected)))
         label("Verified expected name contents")
 
+        return this
+    }
+
+    fun toggleOpenInNewWindow(): EditLinkPage {
+        openInNewWindowCheckbox.perform(click())
+        label("Toggled open in a new window checkbox")
         return this
     }
 

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/LinkTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/LinkTests.kt
@@ -34,6 +34,26 @@ class LinkTests : BaseTest() {
     }
 
     @Test
+    fun testAddLinkWithOpenExternal() {
+        val text = "sample link"
+        val url = "https://github.com/wordpress-mobile/AztecEditor-Android"
+        val html = "<a target=\"_blank\" rel=\"noopener\" href=\"$url\">$text</a>"
+
+        EditorPage()
+                .makeLink()
+
+        EditLinkPage()
+                .updateURL(url)
+                .updateName(text)
+                .toggleOpenInNewWindow()
+                .ok()
+
+        EditorPage()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
     fun testMixedLinkFormatting() {
         val text1 = "sample "
         val text2 = "link"
@@ -93,6 +113,28 @@ class LinkTests : BaseTest() {
 
         EditLinkPage()
                 .updateName(text2)
+                .ok()
+
+        EditorPage()
+                .toggleHtml()
+                .verifyHTML(html)
+    }
+
+    @Test
+    fun testToggleOpenInNewWindowLink() {
+        val text = "sample link"
+        val url1 = "https://github.com/wordpress-mobile/AztecEditor-Android"
+        val link = "<a href=\"$url1\" rel=\"noopener\" target=\"_blank\">$text</a>"
+        val html = "<a href=\"$url1\">$text</a>"
+
+        EditorPage()
+                .toggleHtml()
+                .insertHTML(link)
+                .toggleHtml()
+                .makeLink()
+
+        EditLinkPage()
+                .toggleOpenInNewWindow()
                 .ok()
 
         EditorPage()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -52,6 +52,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import android.view.inputmethod.BaseInputConnection
+import android.widget.CheckBox
 import android.widget.EditText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.ImageUtils
@@ -1419,14 +1420,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
-    fun link(url: String, anchor: String) {
+    fun link(url: String, anchor: String, openInNewWindow: Boolean = false) {
         history.beforeTextChanged(this@AztecText)
         if (TextUtils.isEmpty(url) && linkFormatter.isUrlSelected()) {
             removeLink()
         } else if (linkFormatter.isUrlSelected()) {
-            linkFormatter.editLink(url, anchor, linkFormatter.getUrlSpanBounds().first, linkFormatter.getUrlSpanBounds().second)
+            linkFormatter.editLink(url, anchor, openInNewWindow, linkFormatter.getUrlSpanBounds().first, linkFormatter.getUrlSpanBounds().second)
         } else {
-            linkFormatter.addLink(url, anchor, selectionStart, selectionEnd)
+            linkFormatter.addLink(url, anchor, openInNewWindow, selectionStart, selectionEnd)
         }
     }
 
@@ -1454,6 +1455,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         val url = if (TextUtils.isEmpty(presetUrl)) urlAndAnchor.first else presetUrl
         val anchor = if (TextUtils.isEmpty(presetAnchor)) urlAndAnchor.second else presetAnchor
+        val openInNewWindow = urlAndAnchor.third
 
         val builder = AlertDialog.Builder(context)
 
@@ -1461,9 +1463,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         val urlInput = dialogView.findViewById<EditText>(R.id.linkURL)
         val anchorInput = dialogView.findViewById<EditText>(R.id.linkText)
+        val openInNewWindowCheckbox = dialogView.findViewById<CheckBox>(R.id.openInNewWindow)
 
         urlInput.setText(url)
         anchorInput.setText(anchor)
+        openInNewWindowCheckbox.isChecked = openInNewWindow
 
         builder.setView(dialogView)
         builder.setTitle(R.string.link_dialog_title)
@@ -1472,7 +1476,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             val linkText = TextUtils.htmlEncode(correctUrl(urlInput.text.toString().trim { it <= ' ' }))
             val anchorText = anchorInput.text.toString().trim { it <= ' ' }
 
-            link(linkText, anchorText)
+            link(linkText, anchorText, openInNewWindowCheckbox.isChecked)
         })
 
         if (linkFormatter.isUrlSelected()) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -129,6 +129,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val LINK_DIALOG_VISIBLE_KEY = "LINK_DIALOG_VISIBLE_KEY"
         val LINK_DIALOG_URL_KEY = "LINK_DIALOG_URL_KEY"
         val LINK_DIALOG_ANCHOR_KEY = "LINK_DIALOG_ANCHOR_KEY"
+        val LINK_DIALOG_OPEN_NEW_WINDOW_KEY = "LINK_DIALOG_OPEN_NEW_WINDOW_KEY"
 
         val HISTORY_LIST_KEY = "HISTORY_LIST_KEY"
         val HISTORY_CURSOR_KEY = "HISTORY_CURSOR_KEY"
@@ -596,8 +597,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         if (isLinkDialogVisible) {
             val retainedUrl = customState.getString(LINK_DIALOG_URL_KEY, "")
             val retainedAnchor = customState.getString(LINK_DIALOG_ANCHOR_KEY, "")
-
-            showLinkDialog(retainedUrl, retainedAnchor)
+            val retainedOpenInNewWindow = customState.getString(LINK_DIALOG_OPEN_NEW_WINDOW_KEY, "")
+            showLinkDialog(retainedUrl, retainedAnchor, retainedOpenInNewWindow)
         }
 
         val isBlockEditorDialogVisible = customState.getBoolean(BLOCK_DIALOG_VISIBLE_KEY, false)
@@ -644,9 +645,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
             val urlInput = addLinkDialog!!.findViewById<EditText>(R.id.linkURL)
             val anchorInput = addLinkDialog!!.findViewById<EditText>(R.id.linkText)
+            val openInNewWindowCheckbox = addLinkDialog!!.findViewById<CheckBox>(R.id.openInNewWindow)
 
             bundle.putString(LINK_DIALOG_URL_KEY, urlInput?.text?.toString())
             bundle.putString(LINK_DIALOG_ANCHOR_KEY, anchorInput?.text?.toString())
+            bundle.putString(LINK_DIALOG_OPEN_NEW_WINDOW_KEY, if (openInNewWindowCheckbox != null && openInNewWindowCheckbox.isChecked) "checked=true" else "checked=false")
         }
 
         if (blockEditorDialog != null && blockEditorDialog!!.isShowing) {
@@ -1450,12 +1453,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     @SuppressLint("InflateParams")
-    fun showLinkDialog(presetUrl: String = "", presetAnchor: String = "") {
+    fun showLinkDialog(presetUrl: String = "", presetAnchor: String = "", presetOpenInNewWindow: String = "" ) {
         val urlAndAnchor = linkFormatter.getSelectedUrlWithAnchor()
 
         val url = if (TextUtils.isEmpty(presetUrl)) urlAndAnchor.first else presetUrl
         val anchor = if (TextUtils.isEmpty(presetAnchor)) urlAndAnchor.second else presetAnchor
-        val openInNewWindow = urlAndAnchor.third
+        val openInNewWindow = if (TextUtils.isEmpty(presetOpenInNewWindow)) urlAndAnchor.third else presetOpenInNewWindow == "checked=true"
 
         val builder = AlertDialog.Builder(context)
 

--- a/aztec/src/main/res/layout/dialog_link.xml
+++ b/aztec/src/main/res/layout/dialog_link.xml
@@ -38,4 +38,13 @@
             android:hint="@string/link_enter_url_text"
             android:inputType="text" />
     </android.support.design.widget.TextInputLayout>
+    <CheckBox
+        android:id="@+id/openInNewWindow"
+        android:text="@string/link_open_new_window"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/link_dialog_margin_outer"
+        android:layout_marginLeft="@dimen/link_dialog_margin_outer"
+        android:layout_marginRight="@dimen/link_dialog_margin_outer"
+        android:layout_marginTop="@dimen/link_dialog_margin_inner" />
 </LinearLayout>

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="link_enter_url">URL</string>
     <string name="link_enter_url_text">Link text (optional)</string>
     <string name="create_a_link">Create a link</string>
+    <string name="link_open_new_window">Open link in a new window/tab</string>
 
     <!-- MEDIA -->
     <string name="error_chooser_photo">No app was found to choose a photo</string>


### PR DESCRIPTION
This PR adds the support for creating links that open in a new window.
(Feature request ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5697)

In details, it basically adds a new checkbox field to the LinkDialog and adds `rel` and `target` attributes when needed. I matched the behavior of Calypso.

Once this is merged I will update Aztec ref in WP-Android, and make sure the design will match the app.

### Testing
Test suite is updated, and below are some test cases you can manually try in the demo app.

#### Test 1
1. Start the demo app
2. Add a new link and check the Open in new window box
3. switch to HTML and verify that both `rel` and `target` are there

#### Test 2
1. Start the demo app
2. Find the `link` item in the demo content, and tap on it
3. The Link Dialog should appear and the checkbox is unchecked
4. Check it and confirm
5. Switch to HTML and verify that both `rel` and `target` are there

#### Test 3
1. Start the demo app
2. Find the `link` item in the demo content, and tap on it
3. The Link Dialog should appear and the checkbox is unchecked
4. Check it
5. Rotate the device and verify it's still checked
6. Tap confirm/ok and verify the html produced


### Review
@mzorz @0nko 