### PR TITLE
Adds onTextContextMenuItemListener

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -72,6 +72,7 @@ open class MainActivity : AppCompatActivity(),
         AztecText.OnAudioTappedListener,
         AztecText.OnMediaDeletedListener,
         AztecText.OnVideoInfoRequestedListener,
+        AztecText.OnTextContextMenuItemListener,
         IAztecToolbarClickListener,
         IHistoryListener,
         OnRequestPermissionsResultCallback,
@@ -394,6 +395,7 @@ open class MainActivity : AppCompatActivity(),
                 .setOnAudioTappedListener(this)
                 .setOnMediaDeletedListener(this)
                 .setOnVideoInfoRequestedListener(this)
+                .setOnTextContextMenuItemListener(this)
                 .addPlugin(WordPressCommentsPlugin(visualEditor))
                 .addPlugin(MoreToolbarButton(visualEditor))
                 .addPlugin(PageToolbarButton(visualEditor))
@@ -855,5 +857,21 @@ open class MainActivity : AppCompatActivity(),
     override fun onMediaDeleted(attrs: AztecAttributes) {
         val url = attrs.getValue("src")
         ToastUtils.showToast(this, "Media Deleted! " + url)
+    }
+
+    override fun onCut() {
+        ToastUtils.showToast(this, "on Cut!")
+    }
+
+    override fun onCopy() {
+        ToastUtils.showToast(this, "on Copy!")
+    }
+
+    override fun onPaste() {
+        ToastUtils.showToast(this, "on Paste!")
+    }
+
+    override fun onPasteAsPlainText() {
+        ToastUtils.showToast(this, "on Paste as plain text!")
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -23,6 +23,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     private var onAudioTappedListener: AztecText.OnAudioTappedListener? = null
     private var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener? = null
+    private var onTextContextMenuItemListener: AztecText.OnTextContextMenuItemListener? = null
     private var plugins: ArrayList<IAztecPlugin> = visualEditor.plugins
     var sourceEditor: SourceViewEditText? = null
 
@@ -121,6 +122,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
         return this
     }
 
+    fun setOnTextContextMenuItemListener(onTextContectMenuItemListener: AztecText.OnTextContextMenuItemListener): Aztec {
+        this.onTextContextMenuItemListener = onTextContectMenuItemListener
+        initOnTextContextMenuListener()
+        return this
+    }
+
     fun setHistoryListener(historyListener: IHistoryListener): Aztec {
         this.historyListener = historyListener
         initHistoryListener()
@@ -204,6 +211,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     private fun initVideoInfoRequestedListener() {
         if (onVideoInfoRequestedListener != null) {
             visualEditor.setOnVideoInfoRequestedListener(onVideoInfoRequestedListener!!)
+        }
+    }
+
+    private fun initOnTextContextMenuListener() {
+        if (onTextContextMenuItemListener != null) {
+            visualEditor.setOnTextContextMenuItemListener(onTextContextMenuItemListener!!)
         }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -225,6 +225,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     private var onAudioTappedListener: OnAudioTappedListener? = null
     private var onMediaDeletedListener: OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: OnVideoInfoRequestedListener? = null
+    private var onTextContextMenuItemListener: OnTextContextMenuItemListener? = null
+
     var externalLogger: AztecLog.ExternalLogger? = null
 
     private var isViewInitialized = false
@@ -303,6 +305,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     interface OnVideoInfoRequestedListener {
         fun onVideoInfoRequested(attrs: AztecAttributes)
+    }
+
+    interface OnTextContextMenuItemListener {
+        fun onCut()
+        fun onCopy()
+        fun onPaste()
+        fun onPasteAsPlainText()
     }
 
     constructor(context: Context) : super(context) {
@@ -729,6 +738,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     fun setOnVideoInfoRequestedListener(listener: OnVideoInfoRequestedListener) {
         this.onVideoInfoRequestedListener = listener
+    }
+
+    fun setOnTextContextMenuItemListener(listener: OnTextContextMenuItemListener) {
+        this.onTextContextMenuItemListener = listener
     }
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
@@ -1310,11 +1323,18 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         when (id) {
-            android.R.id.paste -> paste(text, min, max)
-            android.R.id.pasteAsPlainText -> paste(text, min, max, true)
+            android.R.id.paste -> {
+                paste(text, min, max)
+                onTextContextMenuItemListener?.onPaste()
+            }
+            android.R.id.pasteAsPlainText -> {
+                paste(text, min, max, true)
+                onTextContextMenuItemListener?.onPasteAsPlainText()
+            }
             android.R.id.copy -> {
                 copy(text, min, max)
                 setSelection(max) // dismiss the selection to make the action menu hide
+                onTextContextMenuItemListener?.onCopy()
             }
             android.R.id.cut -> {
                 copy(text, min, max)
@@ -1324,6 +1344,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 if (min == 0) {
                     deleteInlineStyleFromTheBeginning()
                 }
+                onTextContextMenuItemListener?.onCut()
             }
             else -> return super.onTextContextMenuItem(id)
         }


### PR DESCRIPTION
Adds an `onTextContextMenuItemListener` that allows to signal a listener outside Aztec that `onCut`, `onCopy`, `onPaste` and `onPasteAsPlainText` have just happened

### Test
1. Open the demo app
2. Now switch to another app that allows copying content, for example open Chrome and navigate to a page that allows copying formatted content.
3. Select some content and choose `COPY` from the context menu
4. switch back to the Aztec demo app
5. long tap on the content area and choose `PASTE`
6. you should see the pasted content and a toast reading "on Paste!"

The same should happen for the remaining operations cut, copy, paste and paste as plain text.
