### PR TITLE
Added isInit flag to only calculate initial content hash when initializing

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1012,7 +1012,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return cursorPosition
     }
 
-    open fun fromHtml(source: String) {
+    open fun fromHtml(source: String, isInit: Boolean = true) {
         val builder = SpannableStringBuilder()
         val parser = AztecParser(plugins)
 
@@ -1037,7 +1037,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         setSelection(cursorPosition)
 
-        initialEditorContentParsedSHA256 = calculateInitialHTMLSHA(toPlainHtml(false), initialEditorContentParsedSHA256)
+        if (isInit) {
+            initialEditorContentParsedSHA256 = calculateInitialHTMLSHA(toPlainHtml(false), initialEditorContentParsedSHA256)
+        }
 
         loadImages()
         loadVideos()
@@ -1400,7 +1402,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 val oldHtml = toPlainHtml().replace("<aztec_cursor>", "")
                 val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste + "<" + AztecCursorSpan.AZTEC_CURSOR_TAG + ">")
 
-                fromHtml(newHtml)
+                fromHtml(newHtml, false)
                 inlineFormatter.joinStyleSpans(0, length())
             }
         }


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPress-Android/issues/8275

This PR helps preventing a new content hash being calculated on copy/paste operations, which was producing the content to be erroneously evaluated as `NO_CHANGE` when some new piece of text has just been pasted / inserted.

### Fix

For context, `fromHtml()` was calculating the initial hash under the assumption that `fromHtml()`
was only being called when starting AztecText (or moving from HTML to the visual editing view,
which is the same to the effect of considering modifications). However, such a method was also being used in `paste()`, thus making the initial hash be re-initialized and inform `NO_CHANGE` when `hasChanges()` was queried from outside.

As a solution to cover both code flows, `fromHtml()` now accepts a parameter flag `isInit` that is defaulted to `true`, that serves to know whether there should be a request to re-calculate the initial hash.

### Test
0. copy content from somewhere else, i.e. open a page in Chrome and copy some text.
1. start the demo app
2. long tap on some place in the content
3. when the context menu appears, select PASTE
4. observe the content gets pasted and the initial hash does not get replaced (place a breakpoint [here](https://github.com/wordpress-mobile/AztecEditor-Android/compare/develop...fix/paste-hash-calculation#diff-7ca71cd1f009ab8438e0901205001b14R1040) to confirm).

