### PR TITLE
Add an ENTER-key optional listener to Aztec

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -16,6 +16,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     private var imageGetter: Html.ImageGetter? = null
     private var videoThumbnailGetter: Html.VideoThumbnailGetter? = null
     private var imeBackListener: AztecText.OnImeBackListener? = null
+    private var onEnterListener: AztecText.OnEnterListener? = null
     private var onTouchListener: View.OnTouchListener? = null
     private var historyListener: IHistoryListener? = null
     private var onImageTappedListener: AztecText.OnImageTappedListener? = null
@@ -82,6 +83,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     fun setOnImeBackListener(imeBackListener: AztecText.OnImeBackListener): Aztec {
         this.imeBackListener = imeBackListener
         initImeBackListener()
+        return this
+    }
+
+    fun setOnEnterListener(enterListener: AztecText.OnEnterListener): Aztec {
+        this.onEnterListener = enterListener
+        initEnterListener()
         return this
     }
 
@@ -168,6 +175,12 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     private fun initImeBackListener() {
         if (imeBackListener != null) {
             visualEditor.setOnImeBackListener(imeBackListener!!)
+        }
+    }
+
+    private fun initEnterListener() {
+        if (onEnterListener != null) {
+            visualEditor.setOnEnterListener(onEnterListener!!)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -454,11 +454,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         val detectEnterKeyInputFilter = InputFilter { source, start, end, dest, dstart, dend ->
-            if (isHandlingEnterEvent || !isViewInitialized) {
+            if (isTextChangedListenerDisabled() || isHandlingEnterEvent || !isViewInitialized) {
                 // If the view is not initialized do nothing and accept the changes
                 null
             } else if (end > 1 && start == 0 && dstart == 0 && dend == 0) {
-                // When the initial content is set to Aztec accept the changes
+                // When the initial content is set to Aztec accept the changes without checking
+                // This case is just an additional check that should never happen if
+                // you call `fromHTML` since isTextChangedListenerDisabled does the trick
                 null
             } else
             //  You sometimes get a SpannableStringBuilder, sometimes a plain String in the source parameter

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -227,7 +227,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     private var onAudioTappedListener: OnAudioTappedListener? = null
     private var onMediaDeletedListener: OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: OnVideoInfoRequestedListener? = null
-    var onEnterListener: OnEnterListener? = null
+    private var onEnterListener: OnEnterListener? = null
     var externalLogger: AztecLog.ExternalLogger? = null
 
     private var isViewInitialized = false
@@ -757,6 +757,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     fun setOnSelectionChangedListener(onSelectionChangedListener: OnSelectionChangedListener) {
         this.onSelectionChangedListener = onSelectionChangedListener
+    }
+
+    fun setOnEnterListener(listener: OnEnterListener) {
+        this.onEnterListener = listener
     }
 
     fun setOnImeBackListener(listener: OnImeBackListener) {


### PR DESCRIPTION
Adds an `KEYCODE_ENTER` optional lister to Aztec, so that consuming Apps can override what happens when `ENTER` is pressed in the editor.

The logic was mostly taken by the Backspace detector code, and adapted to detect `KEYCODE_ENTER`.

To test this PR, setup n `OnEnterListener` in `AztecText` like the following below
```
onEnterListener = object : OnEnterListener {
    override fun onEnterKey() : Boolean {
        Log.d("Test", "testing");
        return false
    }
}
```

put a break point in it and see if it's called properly (do not check logCat since it may miss some log calls if you type fast). 


This PR is needed by ReactNativeAztec to intercept KEYCODE_ENTER and act accordingly. I think we can also move this logic into `ReactNativeAztec` if necessary, but having it here offers this feature to other apps too.
