### PR TITLE
Fix empty span handling

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/BlockHandler.kt
@@ -31,6 +31,10 @@ abstract class BlockHandler<SpanType : IAztecBlockSpan>(val clazz: Class<SpanTyp
         this.isReplay = isReplay
         this.nestingLevel = nestingLevel
 
+        if (text.getSpans<SpanType>(inputStart, inputStart + count, clazz).isEmpty()) {
+            return
+        }
+
         // use charsNew to get the spans at the input point. It appears to be more reliable vs the whole Editable.
         var charsNew = text.subSequence(inputStart, inputStart + count) as Spanned
 


### PR DESCRIPTION
Fixes #749 

This PR makes sure to only run `handleTextChanged` in `BlockHandler` if there are spans of the kind to be processed within the passed indexes.

### Test
1. Open the demo app (in the emulator)
2. Select all text
3. Press the delete key
4. Notice the app doesn't crash anymore

