### PR TITLE
Add the ability to set a backspace listener

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -16,7 +16,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     private var imageGetter: Html.ImageGetter? = null
     private var videoThumbnailGetter: Html.VideoThumbnailGetter? = null
     private var imeBackListener: AztecText.OnImeBackListener? = null
-    private var onEnterListener: AztecText.OnEnterListener? = null
+    private var onKeyListener: AztecText.OnKeyListener? = null
     private var onTouchListener: View.OnTouchListener? = null
     private var historyListener: IHistoryListener? = null
     private var onImageTappedListener: AztecText.OnImageTappedListener? = null
@@ -86,8 +86,8 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
         return this
     }
 
-    fun setOnEnterListener(enterListener: AztecText.OnEnterListener): Aztec {
-        this.onEnterListener = enterListener
+    fun setOnKeyListener(keyListener: AztecText.OnKeyListener): Aztec {
+        this.onKeyListener = keyListener
         initEnterListener()
         return this
     }
@@ -179,8 +179,8 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     }
 
     private fun initEnterListener() {
-        if (onEnterListener != null) {
-            visualEditor.setOnEnterListener(onEnterListener!!)
+        if (onKeyListener != null) {
+            visualEditor.setOnKeyListener(onKeyListener!!)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -153,7 +153,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             if (drawable is BitmapDrawable) {
                 bitmap = drawable.bitmap
                 bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageWidthForVisualEditor)
-            } else if (drawable is VectorDrawableCompat || drawable is VectorDrawable) {
+            } else if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && (drawable is VectorDrawableCompat || drawable is VectorDrawable) ) ||
+                    drawable is VectorDrawableCompat) {
                 bitmap = Bitmap.createBitmap(maxImageWidthForVisualEditor, maxImageWidthForVisualEditor, Bitmap.Config.ARGB_8888)
                 val canvas = Canvas(bitmap)
                 drawable.setBounds(0, 0, canvas.width, canvas.height)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -312,7 +312,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     interface OnKeyListener {
         fun onEnterKey() : Boolean
-        fun onBackSpaceKey() : Boolean
+        fun onBackspaceKey() : Boolean
     }
 
     constructor(context: Context) : super(context) {
@@ -431,9 +431,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     // Setup the keyListener(s) for Backspace and Enter key.
-    // Backspace: Call the keyListeners if backspace happens at the start of text. If listener return false
-    // we remove the style here.
-    // Enter: Ask the listener if we need to insert or not the char.
+    // Backspace: If listener does return false we remove the style here
+    // Enter: Ask the listener if we need to insert or not the char
     private fun setupBackspaceAndEnterDetection() {
         //hardware keyboard
         setOnKeyListener { _, _, event ->
@@ -503,7 +502,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_DEL) {
             // Check if the external lister has consumed the backspace pressed event
             // In that case stop the execution and do not delete styles later
-            if (onKeyListener?.onBackSpaceKey() == true) {
+            if (onKeyListener?.onBackspaceKey() == true) {
                 // There listener has consumed the event
                 return true
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -430,24 +430,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         isViewInitialized = true
     }
 
-    // Setup the keyListener for Backspace and Enter key.
-    // Backspace: Ask the key listener if we need to process the event.
-    // If we need to process the event here, when no characters are deleted (eg. at 0 index of EditText)
-    // it will check to remove style.
+    // Setup the keyListener(s) for Backspace and Enter key.
+    // Backspace: Call the keyListeners if backspace happens at the start of text. If listener return false
+    // we remove the style here.
     // Enter: Ask the listener if we need to insert or not the char.
     private fun setupBackspaceAndEnterDetection() {
         //hardware keyboard
         setOnKeyListener { _, _, event ->
             handleBackspaceAndEnter(event)
-        }
-
-        //software keyboard InputFilter(s) below
-        val externalBackspaceDetector = InputFilter { source, _, _, _, _, _ ->
-            if (onKeyListener?.onBackSpaceKey() == true) {
-                ""
-            } else {
-                source
-            }
         }
 
         val emptyEditTextBackspaceDetector = InputFilter { source, start, end, dest, dstart, dend ->
@@ -503,7 +493,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             }
         }
 
-        filters = arrayOf(externalBackspaceDetector, emptyEditTextBackspaceDetector, detectEnterKeyInputFilter)
+        filters = arrayOf(emptyEditTextBackspaceDetector, detectEnterKeyInputFilter)
     }
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -227,7 +227,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     private var onAudioTappedListener: OnAudioTappedListener? = null
     private var onMediaDeletedListener: OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: OnVideoInfoRequestedListener? = null
-    private var onEnterListener: OnEnterListener? = null
+    private var onKeyListener: OnKeyListener? = null
     var externalLogger: AztecLog.ExternalLogger? = null
 
     private var isViewInitialized = false
@@ -309,7 +309,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         fun onVideoInfoRequested(attrs: AztecAttributes)
     }
 
-    interface OnEnterListener {
+    interface OnKeyListener {
         fun onEnterKey() : Boolean
     }
 
@@ -468,7 +468,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 isHandlingEnterEvent = true
                 for (i in end - 1 downTo start) {
                     val currentChar = source[i]
-                    if (currentChar == '\n' && onEnterListener?.onEnterKey() == true) {
+                    if (currentChar == '\n' && onKeyListener?.onEnterKey() == true) {
                         source.replace(i, i + 1, "")
                     }
                 }
@@ -479,7 +479,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 val filteredStringBuilder = StringBuilder()
                 for (i in start until end) {
                     val currentChar = source[i]
-                    if (currentChar == '\n' && onEnterListener?.onEnterKey() == true) {
+                    if (currentChar == '\n' && onKeyListener?.onEnterKey() == true) {
                         // nothing
                     } else {
                         filteredStringBuilder.append(currentChar)
@@ -495,7 +495,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_ENTER) {
-            return onEnterListener?.onEnterKey() ?: false
+            return onKeyListener?.onEnterKey() ?: false
         }
 
         var wasStyleRemoved = false
@@ -759,8 +759,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         this.onSelectionChangedListener = onSelectionChangedListener
     }
 
-    fun setOnEnterListener(listener: OnEnterListener) {
-        this.onEnterListener = listener
+    fun setOnKeyListener(listener: OnKeyListener) {
+        this.onKeyListener = listener
     }
 
     fun setOnImeBackListener(listener: OnImeBackListener) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -511,7 +511,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             return onKeyListener?.onEnterKey() ?: false
         }
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_DEL) {
-            return onKeyListener?.onBackSpaceKey() ?: false
+            // Check if the external lister has consumed the backspace pressed event
+            // In that case stop the execution and do not delete styles later
+            if (onKeyListener?.onBackSpaceKey() == true) {
+                // There listener has consumed the event
+                return true
+            }
         }
 
         var wasStyleRemoved = false

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '3.0.1'
+        gradlePluginVersion = '3.1.3'
         kotlinVersion = '1.2.41'
         supportLibVersion = '27.1.1'
         tagSoupVersion = '1.2.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 11 09:10:29 CEST 2018
+#Tue Oct 23 14:31:33 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
This PR adds the ability to set a backspace lister to Aztec, so that consuming apps can override what happens when backspace is pressed. This is needed in the ReactNative Wrapper of Aztec, and mobile Gutenberg.

To test this PR, setup a lister in AztecText->init:
```
        setOnKeyListener(object : OnKeyListener {
            override fun onBackspaceKey() : Boolean {
                return true
            }
            override fun onEnterKey() : Boolean {
                return true
            }
        })
```

**Note**
Software keyboard: Aztec calls the backspace listener only when the cursor is set the at beginning of it, and backspace is pressed. This is OK for us at the moment, otherwise we needed to change additional code that can introduce regressions.

HW keyboard: Listener are always called.

_** Is up to the listener to check where is the caret and act accordingly.  **_


_Minor update_
In order to fix build issues on Travis, I've also updated Gradle to 4.4, and the Gradle plugins to 3.1.3.
The new version "promoted" a warning to error and then I fixed it with an ugly SDK check. See below: 
```
(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && (drawable is VectorDrawableCompat || drawable is VectorDrawable) ) ||
                    drawable is VectorDrawableCompat) {
```

Didn't want to update minSDK to 21 as suggested by AS.

cc @mzorz 

