### PR TITLE
Reorder repositories in build.gradle to fix Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ buildscript {
     }
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
The order of the repositories in `build.gradle` files matter and it seems that recently `google()` needs to come before `jcenter()` for some reason. 

To test:
Run ./gradlew --refresh-dependencies and if it succeeds we're good. Travis will do that for us, so it'll mostly serve as a double check.