### PR TITLE
Change image/video/audio onTapped interfaces for AztecAttributes immutability

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -791,11 +791,12 @@ open class MainActivity : AppCompatActivity(),
         mediaUploadDialog!!.show()
     }
 
-    override fun onImageTapped(attrs: AztecAttributes, naturalWidth: Int, naturalHeight: Int) {
+    override fun onImageTapped(attrs: AztecAttributes, naturalWidth: Int, naturalHeight: Int) : AztecAttributes {
         ToastUtils.showToast(this, "Image tapped!")
+        return attrs
     }
 
-    override fun onVideoTapped(attrs: AztecAttributes) {
+    override fun onVideoTapped(attrs: AztecAttributes) : AztecAttributes {
         val url = if (attrs.hasAttribute(ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC)) {
             attrs.getValue(ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC)
         } else {
@@ -817,6 +818,7 @@ open class MainActivity : AppCompatActivity(),
                 }
             }
         }
+        return attrs
     }
 
     override fun onVideoInfoRequested(attrs: AztecAttributes) {
@@ -836,7 +838,7 @@ open class MainActivity : AppCompatActivity(),
         }
     }
 
-    override fun onAudioTapped(attrs: AztecAttributes) {
+    override fun onAudioTapped(attrs: AztecAttributes) : AztecAttributes {
         val url = attrs.getValue("src")
         url?.let {
             try {
@@ -853,6 +855,7 @@ open class MainActivity : AppCompatActivity(),
                 }
             }
         }
+        return attrs
     }
 
     override fun onMediaDeleted(attrs: AztecAttributes) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -291,15 +291,15 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     interface OnImageTappedListener {
-        fun onImageTapped(attrs: AztecAttributes, naturalWidth: Int, naturalHeight: Int)
+        fun onImageTapped(attrs: AztecAttributes, naturalWidth: Int, naturalHeight: Int) : AztecAttributes
     }
 
     interface OnVideoTappedListener {
-        fun onVideoTapped(attrs: AztecAttributes)
+        fun onVideoTapped(attrs: AztecAttributes) : AztecAttributes
     }
 
     interface OnAudioTappedListener {
-        fun onAudioTapped(attrs: AztecAttributes)
+        fun onAudioTapped(attrs: AztecAttributes) : AztecAttributes
     }
 
     interface OnMediaDeletedListener {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecAudioSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecAudioSpan.kt
@@ -20,6 +20,10 @@ class AztecAudioSpan(context: Context, drawable: Drawable?, override var nesting
     }
 
     override fun onClick() {
-        onAudioTappedListener?.onAudioTapped(attributes)
+        val newAttributes =
+                onAudioTappedListener?.onAudioTapped(attributes)
+        if (newAttributes != null) {
+            attributes = newAttributes
+        }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
@@ -15,6 +15,10 @@ class AztecImageSpan(context: Context, drawable: Drawable?,
     override val TAG: String = "img"
 
     override fun onClick() {
-        onImageTappedListener?.onImageTapped(attributes, getWidth(imageDrawable), getHeight(imageDrawable))
+        val newAttributes =
+                onImageTappedListener?.onImageTapped(attributes, getWidth(imageDrawable), getHeight(imageDrawable))
+        if (newAttributes != null) {
+            attributes = newAttributes
+        }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -20,6 +20,10 @@ class AztecVideoSpan(context: Context, drawable: Drawable?, override var nesting
     }
 
     override fun onClick() {
-        onVideoTappedListener?.onVideoTapped(attributes)
+        val newAttributes =
+                onVideoTappedListener?.onVideoTapped(attributes)
+        if (newAttributes != null) {
+            attributes = newAttributes
+        }
     }
 }


### PR DESCRIPTION
This PR changes image/video/audio `onTapped` interfaces for `AztecAttributes`'s immutability in case the attributes passed to these listeners get modified during listener calls, needed after attributes immutability change in PR #751

### Test
Steps provided in WPAndroid PR.

### Review
@planarvoid @malinajirka

cc @loremattei 