### PR TITLE
Revert "Make AztecAttributes immutable in order to stop crashes"

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -272,19 +272,16 @@ open class MainActivity : AppCompatActivity(),
 
     private fun generateAttributesForMedia(mediaPath: String, isVideo: Boolean): Pair<String, AztecAttributes> {
         val id = Random().nextInt(Integer.MAX_VALUE).toString()
+        val attrs = AztecAttributes()
+        attrs.setValue("src", mediaPath) // Temporary source value.  Replace with URL after uploaded.
+        attrs.setValue("id", id)
+        attrs.setValue("uploading", "true")
 
-        val attributes = if (isVideo) {
-            AztecAttributes().withValues(
-                    "src" to mediaPath,
-                    "id" to id,
-                    "uploading" to "true",
-                    "video" to "true"
-            )
-        } else {
-            AztecAttributes().withValues("src" to mediaPath, "id" to id, "uploading" to "true")
+        if (isVideo) {
+            attrs.setValue("video", "true")
         }
 
-        return Pair(id, attributes)
+        return Pair(id, attrs)
     }
 
     private fun insertMediaAndSimulateUpload(id: String, attrs: AztecAttributes) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
@@ -5,36 +5,21 @@ import org.xml.sax.Attributes
 import org.xml.sax.helpers.AttributesImpl
 
 class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImpl(attributes) {
-    fun withValues(vararg keyValues: Pair<String, String>): AztecAttributes {
-        val aztecAttributes = AztecAttributes(this)
-        keyValues.forEach { (key, value) ->
-            val index = aztecAttributes.getIndex(key)
+    fun setValue(key: String, value: String) {
+        val index = getIndex(key)
 
-            if (index == -1) {
-                try {
-                    aztecAttributes.addAttribute("", key, key, "string", value)
-                } catch (e: ArrayIndexOutOfBoundsException) {
-                    // https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
-                    AppLog.e(AppLog.T.EDITOR,
-                            "Error adding attribute with name: $key and value: $value")
-                    logInternalState()
-                    throw e
-                }
-            } else {
-                aztecAttributes.setValue(index, value)
+        if (index == -1) {
+            try {
+                addAttribute("", key, key, "string", value)
+            } catch (e: ArrayIndexOutOfBoundsException) {
+                // https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
+                AppLog.e(AppLog.T.EDITOR, "Error adding attribute with name: $key and value: $value")
+                logInternalState()
+                throw e
             }
+        } else {
+            setValue(index, value)
         }
-        return aztecAttributes
-    }
-
-    @Deprecated("In order to keep the object immutable",
-            ReplaceWith("withValues(qName)", "org.wordpress.aztec.AztecAttributes.withValues"))
-    override fun addAttribute(uri: String?,
-                              localName: String?,
-                              qName: String?,
-                              type: String?,
-                              value: String?) {
-        super.addAttribute(uri, localName, qName, type, value)
     }
 
     private fun logInternalState() {
@@ -53,31 +38,19 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         return length == 0
     }
 
-    fun withoutValues(vararg keys: String): AztecAttributes {
-        val aztecAttributes = AztecAttributes(this)
-        for (key in keys) {
-            if (aztecAttributes.hasAttribute(key)) {
-                val index = aztecAttributes.getIndex(key)
-                try {
-                    aztecAttributes.removeAttribute(index)
-                } catch (e: ArrayIndexOutOfBoundsException) {
-                    // https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
-                    AppLog.e(AppLog.T.EDITOR,
-                            "Tried to remove attribute: $key that is not in the list")
-                    AppLog.e(AppLog.T.EDITOR, "Reported to be at index: $index")
-                    logInternalState()
-                    throw e
-                }
+    fun removeAttribute(key: String) {
+        if (hasAttribute(key)) {
+            val index = getIndex(key)
+            try {
+                removeAttribute(index)
+            } catch (e: ArrayIndexOutOfBoundsException) {
+                // https://github.com/wordpress-mobile/AztecEditor-Android/issues/705
+                AppLog.e(AppLog.T.EDITOR, "Tried to remove attribute: $key that is not in the list")
+                AppLog.e(AppLog.T.EDITOR, "Reported to be at index: $index")
+                logInternalState()
+                throw e
             }
         }
-        return aztecAttributes
-    }
-
-    @Deprecated("In order to keep the object immutable",
-            ReplaceWith("withoutValues(qName)",
-                    "org.wordpress.aztec.AztecAttributes.withoutValues"))
-    override fun removeAttribute(index: Int) {
-        super.removeAttribute(index)
     }
 
     fun hasAttribute(key: String): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -399,13 +399,13 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
                                nestable: IAztecParagraphStyle, parents: ArrayList<IAztecNestable>?, nestingLevel: Int) {
 
         if (nestable.shouldParseAlignmentToHtml()) {
-            nestable.attributes = CssStyleFormatter.removeStyleAttribute(nestable.attributes, CssStyleFormatter.CSS_TEXT_ALIGN_ATTRIBUTE)
+            CssStyleFormatter.removeStyleAttribute(nestable.attributes, CssStyleFormatter.CSS_TEXT_ALIGN_ATTRIBUTE)
 
             nestable.align?.let {
                 val direction = TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR
                 val isRtl = direction.isRtl(text, start, end - start)
 
-                nestable.attributes = CssStyleFormatter.addStyleAttribute(nestable.attributes,
+                CssStyleFormatter.addStyleAttribute(nestable.attributes,
                         CssStyleFormatter.CSS_TEXT_ALIGN_ATTRIBUTE, nestable.align!!.toCssString(isRtl))
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1189,12 +1189,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     fun toHtml(withCursorTag: Boolean = false): String {
         val html = toPlainHtml(withCursorTag)
 
-        return if (isInCalypsoMode) {
+        if (isInCalypsoMode) {
             // calypso format is a mix of newline characters and html
             // paragraphs and line breaks are added on server, from newline characters
-            Format.addSourceEditorFormatting(html, true)
+            return Format.addSourceEditorFormatting(html, true)
         } else {
-            html
+            return html
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
@@ -106,15 +106,16 @@ class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle) : AztecFormatte
     }
 
     private fun toggleOpenInNewWindowAttributes(openInNewWindow: Boolean = false, attributes: AztecAttributes = AztecAttributes()): AztecAttributes {
-        return if (openInNewWindow) {
-            attributes.withValues("target" to "_blank", "rel" to "noopener")
+        if (openInNewWindow) {
+            attributes.setValue("target", "_blank")
+            attributes.setValue("rel", "noopener")
         } else {
+            attributes.removeAttribute("target")
             if (attributes.hasAttribute("rel") && attributes.getValue("rel") == "noopener") {
-                attributes.withoutValues("target", "rel")
-            } else {
-                attributes.withoutValues("target")
+                attributes.removeAttribute("rel")
             }
         }
+        return attributes
     }
 
     fun editLink(link: String, anchor: String?, openInNewWindow: Boolean = false, start: Int = selectionStart, end: Int = selectionEnd) {
@@ -133,7 +134,7 @@ class LinkFormatter(editor: AztecText, val linkStyle: LinkStyle) : AztecFormatte
         }
 
         val attributes = getAttributes(end, start)
-                .withValues("href" to cleanLink)
+        attributes.setValue("href", cleanLink)
         toggleOpenInNewWindowAttributes(openInNewWindow, attributes)
 
         linkValid(cleanLink, start, newEnd, attributes)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
@@ -22,7 +22,7 @@ class CssUnderlinePlugin : ISpanPostprocessor, ISpanPreprocessor {
     override fun beforeSpansProcessed(spannable: SpannableStringBuilder) {
         spannable.getSpans(0, spannable.length, AztecUnderlineSpan::class.java).filter { it.isCssStyle }.forEach {
             if (!CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE)) {
-                it.attributes = CssStyleFormatter.addStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE, UNDERLINE_STYLE_VALUE)
+                CssStyleFormatter.addStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE, UNDERLINE_STYLE_VALUE)
             }
 
             val start = spannable.getSpanStart(it)
@@ -40,7 +40,7 @@ class CssUnderlinePlugin : ISpanPostprocessor, ISpanPreprocessor {
                     if (hiddenSpan.TAG == SPAN_TAG) {
                         val parentStyle = hiddenSpan.attributes.getValue(CssStyleFormatter.STYLE_ATTRIBUTE)
                         val childStyle = calypsoUnderlineSpan.attributes.getValue(CssStyleFormatter.STYLE_ATTRIBUTE)
-                        hiddenSpan.attributes = hiddenSpan.attributes.withValues(CssStyleFormatter.STYLE_ATTRIBUTE to CssStyleFormatter.mergeStyleAttributes(parentStyle, childStyle))
+                        hiddenSpan.attributes.setValue(CssStyleFormatter.STYLE_ATTRIBUTE, CssStyleFormatter.mergeStyleAttributes(parentStyle, childStyle))
 
                         // remove the extra child span
                         spannable.removeSpan(calypsoUnderlineSpan)
@@ -53,7 +53,7 @@ class CssUnderlinePlugin : ISpanPostprocessor, ISpanPreprocessor {
     override fun afterSpansProcessed(spannable: SpannableStringBuilder) {
         spannable.getSpans(0, spannable.length, HiddenHtmlSpan::class.java).forEach {
             if (it.TAG == SPAN_TAG && CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE)) {
-                it.attributes = CssStyleFormatter.removeStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE)
+                CssStyleFormatter.removeStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE)
                 spannable.setSpan(AztecUnderlineSpan(), spannable.getSpanStart(it), spannable.getSpanEnd(it), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
                 if (it.attributes.isEmpty()) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -86,19 +86,18 @@ class CssStyleFormatter {
             return attributes.hasAttribute(STYLE_ATTRIBUTE) && getMatcher(attributes, styleAttributeName).find()
         }
 
-        fun removeStyleAttribute(attributes: AztecAttributes, styleAttributeName: String): AztecAttributes {
+        fun removeStyleAttribute(attributes: AztecAttributes, styleAttributeName: String) {
             if (attributes.hasAttribute(STYLE_ATTRIBUTE)) {
                 val m = getMatcher(attributes, styleAttributeName)
                 var newStyle = m.replaceAll("")
 
-                return if (newStyle.isBlank()) {
-                    attributes.withoutValues(STYLE_ATTRIBUTE)
+                if (newStyle.isBlank()) {
+                    attributes.removeAttribute(STYLE_ATTRIBUTE)
                 } else {
                     newStyle = newStyle.replace(";".toRegex(), "; ")
-                    attributes.withValues(STYLE_ATTRIBUTE to newStyle.trim())
+                    attributes.setValue(STYLE_ATTRIBUTE, newStyle.trim())
                 }
             }
-            return attributes
         }
 
         fun getStyleAttribute(attributes: AztecAttributes, styleAttributeName: String): String {
@@ -111,7 +110,7 @@ class CssStyleFormatter {
             return styleAttributeValue
         }
 
-        fun addStyleAttribute(attributes: AztecAttributes, styleAttributeName: String, styleAttributeValue: String): AztecAttributes {
+        fun addStyleAttribute(attributes: AztecAttributes, styleAttributeName: String, styleAttributeValue: String) {
             var style = attributes.getValue(STYLE_ATTRIBUTE) ?: ""
             style = style.trim()
 
@@ -120,7 +119,7 @@ class CssStyleFormatter {
             }
 
             style += " $styleAttributeName:$styleAttributeValue;"
-            return attributes.withValues(STYLE_ATTRIBUTE to style.trim())
+            attributes.setValue(STYLE_ATTRIBUTE, style.trim())
         }
 
         fun mergeStyleAttributes(firstStyle: String, secondStyle: String): String {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -80,7 +80,7 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     open fun getHtml(): String {
         val sb = StringBuilder("<$TAG ")
 
-        attributes = attributes.withoutValues("aztec_id")
+        attributes.removeAttribute("aztec_id")
 
         sb.append(attributes)
         sb.trim()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -31,10 +31,10 @@ class AztecURLSpan : URLSpan, IAztecInlineSpan {
     override var attributes: AztecAttributes = AztecAttributes()
 
     constructor(url: String, attributes: AztecAttributes = AztecAttributes()) : super(url) {
-        this.attributes = if (!this.attributes.hasAttribute("href")) {
-            attributes.withValues("href" to url)
-        } else {
-            attributes
+        this.attributes = attributes
+
+        if (!this.attributes.hasAttribute("href")) {
+            this.attributes.setValue("href", url)
         }
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -78,13 +78,13 @@ class CssStyleAttributeTest : AndroidTestCase() {
 
         val span = text.getSpans(0, text.length, AztecStyleBoldSpan::class.java).first()
 
-        span.attributes = CssStyleFormatter.addStyleAttribute(span.attributes, "name", "value")
+        CssStyleFormatter.addStyleAttribute(span.attributes, "name", "value")
 
         Assert.assertEquals(HTML, parser.toHtml(text))
 
         Assert.assertFalse(CssStyleFormatter.containsStyleAttribute(span.attributes, "a"))
 
-        span.attributes = CssStyleFormatter.addStyleAttribute(span.attributes, "a", "b")
+        CssStyleFormatter.addStyleAttribute(span.attributes, "a", "b")
 
         Assert.assertTrue(CssStyleFormatter.containsStyleAttribute(span.attributes, "a"))
 
@@ -100,7 +100,7 @@ class CssStyleAttributeTest : AndroidTestCase() {
 
         Assert.assertTrue(CssStyleFormatter.containsStyleAttribute(span.attributes, "a"))
 
-        span.attributes = CssStyleFormatter.removeStyleAttribute(span.attributes, "a")
+        CssStyleFormatter.removeStyleAttribute(span.attributes, "a")
 
         Assert.assertFalse(CssStyleFormatter.containsStyleAttribute(span.attributes, "a"))
 
@@ -108,7 +108,7 @@ class CssStyleAttributeTest : AndroidTestCase() {
 
         Assert.assertEquals(HTML, parser.toHtml(text))
 
-        span.attributes = CssStyleFormatter.removeStyleAttribute(span.attributes, "name")
+        CssStyleFormatter.removeStyleAttribute(span.attributes, "name")
 
         Assert.assertEquals(EMPTY_STYLE_HTML, parser.toHtml(text))
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
@@ -70,7 +70,7 @@ class CssUnderlinePluginTest {
         editText.fromHtml(CSS_STYLE_UNDERLINE_WITH_OTHER_STYLES_HTML)
 
         val span = editText.text.getSpans(0, editText.length(), AztecUnderlineSpan::class.java).first()
-        span.attributes = CssStyleFormatter.addStyleAttribute(span.attributes, "test", "value")
+        CssStyleFormatter.addStyleAttribute(span.attributes, "test", "value")
 
         Assert.assertEquals(CSS_STYLE_UNDERLINE_WITH_EVEN_MORE_STYLES_REORDERED_HTML, editText.toPlainHtml())
     }

--- a/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
+++ b/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
@@ -21,7 +21,7 @@ import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
 
-/**ImageCaptionTest
+/**
  * Combined test for toolbar and inline styles.
  */
 @RunWith(RobolectricTestRunner::class)

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/CaptionShortcodePlugin.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/CaptionShortcodePlugin.kt
@@ -76,7 +76,7 @@ class CaptionShortcodePlugin @JvmOverloads constructor(private val aztecText: Az
                     }
                 }
 
-                span.attributes = span.attributes.withoutValues(CssStyleFormatter.STYLE_ATTRIBUTE)
+                span.attributes.removeAttribute(CssStyleFormatter.STYLE_ATTRIBUTE)
 
                 if (wrapper.end - wrapper.start == 1) {
                     wrapper.remove()
@@ -88,15 +88,14 @@ class CaptionShortcodePlugin @JvmOverloads constructor(private val aztecText: Az
 
     override fun beforeSpansProcessed(spannable: SpannableStringBuilder) {
         spannable.getSpans(0, spannable.length, CaptionShortcodeSpan::class.java).forEach {
-            it.attributes = if (it.align != null) {
-                it.attributes.withValues(CaptionShortcodePlugin.ALIGN_ATTRIBUTE to
-                                when (it.align) {
-                                    Layout.Alignment.ALIGN_NORMAL -> CaptionShortcodePlugin.ALIGN_LEFT_ATTRIBUTE_VALUE
-                                    Layout.Alignment.ALIGN_CENTER -> CaptionShortcodePlugin.ALIGN_CENTER_ATTRIBUTE_VALUE
-                                    else -> CaptionShortcodePlugin.ALIGN_RIGHT_ATTRIBUTE_VALUE
-                                })
-            } else {
-                it.attributes.withoutValues(ALIGN_ATTRIBUTE)
+            it.attributes.removeAttribute(CaptionShortcodePlugin.ALIGN_ATTRIBUTE)
+            if (it.align != null) {
+                it.attributes.setValue(CaptionShortcodePlugin.ALIGN_ATTRIBUTE,
+                        when (it.align) {
+                            Layout.Alignment.ALIGN_NORMAL -> CaptionShortcodePlugin.ALIGN_LEFT_ATTRIBUTE_VALUE
+                            Layout.Alignment.ALIGN_CENTER -> CaptionShortcodePlugin.ALIGN_CENTER_ATTRIBUTE_VALUE
+                            else -> CaptionShortcodePlugin.ALIGN_RIGHT_ATTRIBUTE_VALUE
+                        })
             }
         }
     }

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/VideoPressExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/VideoPressExtensions.kt
@@ -19,7 +19,7 @@ fun AztecText.updateVideoPressThumb(thumbURL: String, videoURL: String, videoPre
                         it.attributes.getValue(ATTRIBUTE_VIDEOPRESS_HIDDEN_ID) == videoPressID) {
 
                     // Set the hidden videopress source. Used when the video is tapped
-                    it.attributes = it.attributes.withValues(ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC to videoURL)
+                    it.attributes.setValue(ATTRIBUTE_VIDEOPRESS_HIDDEN_SRC, videoURL)
                     it.drawable = drawable
                 }
             }

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
@@ -449,7 +449,7 @@ class ImageCaptionTest {
         val changedCaption = editText.getImageCaption(predicate)
         Assert.assertEquals(newCaption, changedCaption)
 
-        val changedHtml = "[caption align=\"alignright\" width=\"100\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />$newCaption[/caption]test<br>test2"
+        val changedHtml = "[caption width=\"100\" align=\"alignright\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />$newCaption[/caption]test<br>test2"
         Assert.assertEquals(changedHtml, editText.toPlainHtml())
 
         editText.removeImageCaption(predicate)
@@ -497,7 +497,7 @@ class ImageCaptionTest {
         Assert.assertTrue(safeEmpty(editText))
 
         val html = "[caption align=\"alignright\" width=\"100\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" /><br>Cap<br>tion<br>[/caption]test<br>test2"
-        val expectedHtml = "[caption align=\"alignright\" width=\"100\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />Cap tion[/caption]test<br>test2"
+        val expectedHtml = "[caption width=\"100\" align=\"alignright\"]<img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />Cap tion[/caption]test<br>test2"
         editText.fromHtml(html)
         Assert.assertEquals(editText.toPlainHtml(), expectedHtml)
     }
@@ -536,15 +536,5 @@ class ImageCaptionTest {
         editText.fromHtml(html)
         editText.text.delete(0, 4)
         Assert.assertEquals(editText.toPlainHtml(), expectedHtml)
-    }
-
-    private fun AztecAttributes.setValue(key: String, value: String) {
-        val index = getIndex(key)
-        System.err.println("ImageCaptionTest: Index is: $index")
-        if (index == -1) {
-            addAttribute("", key, key, "string", value)
-        } else {
-            setValue(index, value)
-        }
     }
 }


### PR DESCRIPTION
Reverts wordpress-mobile/AztecEditor-Android#751

Note: should be ok, used the GH option to create this revert PR 👍 
Note 2: any reviewer will do, no need to have all 3 reviewers, just requested to make sure any of you give it the go 😄 