### PR TITLE
Fix for repeated characters in the editor

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -455,44 +455,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             source
         }
 
-        val detectEnterKeyInputFilter = InputFilter { source, start, end, dest, dstart, dend ->
-            if (isTextChangedListenerDisabled() || isHandlingEnterEvent || !isViewInitialized) {
-                // If the view is not initialized do nothing and accept the changes
-                null
-            } else if (end > 1 && start == 0 && dstart == 0 && dend == 0) {
-                // When the initial content is set to Aztec accept the changes without checking
-                // This case is just an additional check that should never happen if
-                // you call `fromHTML` since isTextChangedListenerDisabled does the trick
-                null
-            } else
-            //  You sometimes get a SpannableStringBuilder, sometimes a plain String in the source parameter
-            if (source is SpannableStringBuilder) {
-                isHandlingEnterEvent = true
-                for (i in end - 1 downTo start) {
-                    val currentChar = source[i]
-                    if (currentChar == '\n' && onKeyListener?.onEnterKey() == true) {
-                        source.replace(i, i + 1, "")
-                    }
-                }
-                isHandlingEnterEvent = false
-                source
-            } else {
-                isHandlingEnterEvent = true
-                val filteredStringBuilder = StringBuilder()
-                for (i in start until end) {
-                    val currentChar = source[i]
-                    if (currentChar == '\n' && onKeyListener?.onEnterKey() == true) {
-                        // nothing
-                    } else {
-                        filteredStringBuilder.append(currentChar)
-                    }
-                }
-                isHandlingEnterEvent = false
-                filteredStringBuilder.toString()
-            }
-        }
-
-        filters = arrayOf(emptyEditTextBackspaceDetector, detectEnterKeyInputFilter)
+        filters = arrayOf(emptyEditTextBackspaceDetector)
     }
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {


### PR DESCRIPTION
This is an hotfix for #760 that removes the InputFilter used to detect the Enter.Key.

Enter.Key detection logic is only used in Gutenberg-mobile, and we will propose another solution, tested on custom keyboards that are giving us problems with InputFilters, in the next days.

cc @0nko 