### PR TITLE
Bring enter.key detection back to Aztec by using TextWatcher

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -16,7 +16,7 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     private var imageGetter: Html.ImageGetter? = null
     private var videoThumbnailGetter: Html.VideoThumbnailGetter? = null
     private var imeBackListener: AztecText.OnImeBackListener? = null
-    private var onKeyListener: AztecText.OnKeyListener? = null
+    private var onAztecKeyListener: AztecText.OnAztecKeyListener? = null
     private var onTouchListener: View.OnTouchListener? = null
     private var historyListener: IHistoryListener? = null
     private var onImageTappedListener: AztecText.OnImageTappedListener? = null
@@ -86,9 +86,9 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
         return this
     }
 
-    fun setOnKeyListener(keyListener: AztecText.OnKeyListener): Aztec {
-        this.onKeyListener = keyListener
-        initEnterListener()
+    fun setAztecKeyListener(aztecKeyListener: AztecText.OnAztecKeyListener): Aztec {
+        this.onAztecKeyListener = aztecKeyListener
+        initAztecKeyListener()
         return this
     }
 
@@ -178,9 +178,9 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
         }
     }
 
-    private fun initEnterListener() {
-        if (onKeyListener != null) {
-            visualEditor.setOnKeyListener(onKeyListener!!)
+    private fun initAztecKeyListener() {
+        if (onAztecKeyListener != null) {
+            visualEditor.setAztecKeyListener(onAztecKeyListener!!)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -47,7 +47,6 @@ import android.text.TextWatcher
 import android.text.style.SuggestionSpan
 import android.util.AttributeSet
 import android.util.DisplayMetrics
-import android.util.Log
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -47,6 +47,7 @@ import android.text.TextWatcher
 import android.text.style.SuggestionSpan
 import android.util.AttributeSet
 import android.util.DisplayMetrics
+import android.util.Log
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -460,7 +461,46 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             source
         }
 
-        filters = arrayOf(emptyEditTextBackspaceDetector)
+        val detectEnterKeyInputFilter = InputFilter { source, start, end, dest, dstart, dend ->
+            if (isTextChangedListenerDisabled() || isHandlingEnterEvent || !isViewInitialized) {
+                // If the view is not initialized do nothing and accept the changes
+                null
+            } else if (end > 1 && start == 0 && dstart == 0 && dend == 0) {
+                // When the initial content is set to Aztec accept the changes without checking
+                // This case is just an additional check that should never happen if
+                // you call `fromHTML` since isTextChangedListenerDisabled does the trick
+                null
+            } else
+            //  You sometimes get a SpannableStringBuilder, sometimes a plain String in the source parameter
+                if (source is SpannableStringBuilder) {
+                    isHandlingEnterEvent = true
+                    for (i in end - 1 downTo start) {
+                        val currentChar = source[i]
+                        Log.d("Danilo", "Type : "+Character.getType(currentChar))
+                        if (currentChar == '\n' /*&& onKeyListener?.onEnterKey() == true*/) {
+                            source.replace(i, i + 1, "")
+                        }
+                    }
+                    isHandlingEnterEvent = false
+                    source
+                } else {
+                    isHandlingEnterEvent = true
+                    val filteredStringBuilder = StringBuilder()
+                    for (i in start until end) {
+                        val currentChar = source[i]
+                        Log.d("Danilo", "Type : "+Character.getType(currentChar))
+                        if (currentChar == '\n' /*&& onKeyListener?.onEnterKey() == true*/) {
+                            // nothing
+                        } else {
+                            filteredStringBuilder.append(currentChar)
+                        }
+                    }
+                    isHandlingEnterEvent = false
+                    filteredStringBuilder.toString()
+                }
+        }
+
+        filters = arrayOf(emptyEditTextBackspaceDetector, detectEnterKeyInputFilter)
     }
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -753,7 +753,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     /**
      * Sets the Aztec key listener to be used with this AztecText.
-     * Please note that this lister does hold a copy of the whole text in the editor
+     * Please note that this listener does hold a copy of the whole text in the editor
      * each time a key is pressed.
      */
     fun setAztecKeyListener(listenerAztec: OnAztecKeyListener) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -476,7 +476,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     isHandlingEnterEvent = true
                     for (i in end - 1 downTo start) {
                         val currentChar = source[i]
-                        Log.d("Danilo", "Type : "+Character.getType(currentChar))
                         if (currentChar == '\n' /*&& onKeyListener?.onEnterKey() == true*/) {
                             source.replace(i, i + 1, "")
                         }
@@ -488,7 +487,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     val filteredStringBuilder = StringBuilder()
                     for (i in start until end) {
                         val currentChar = source[i]
-                        Log.d("Danilo", "Type : "+Character.getType(currentChar))
                         if (currentChar == '\n' /*&& onKeyListener?.onEnterKey() == true*/) {
                             // nothing
                         } else {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -466,7 +466,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_ENTER) {
-            // Check if the external lister has consumed the enter pressed event
+            // Check if the external listener has consumed the enter pressed event
             // In that case stop the execution
             if (onAztecKeyListener?.onEnterKey() == true) {
                 return true
@@ -474,7 +474,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_DEL) {
-            // Check if the external lister has consumed the backspace pressed event
+            // Check if the external listener has consumed the backspace pressed event
             // In that case stop the execution and do not delete styles later
             if (onAztecKeyListener?.onBackspaceKey() == true) {
                 // There listener has consumed the event

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -465,8 +465,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_ENTER) {
-            return onKeyListener?.onEnterKey() ?: false
+            // Check if the external lister has consumed the enter pressed event
+            // In that case stop the execution
+            if (onKeyListener?.onEnterKey() == true) {
+                return true
+            }
         }
+
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_DEL) {
             // Check if the external lister has consumed the backspace pressed event
             // In that case stop the execution and do not delete styles later

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -503,6 +503,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     private fun install() {
+        // Keep the enter pressed watcher at the beginning of the watchers list.
+        // We want to intercept Enter.key as soon as possible, and before other listeners start modifying the text.
+        // Also note that this Watchers, when the AztecKeyListener is set, keep hold a copy of the content in the editor.
         EnterPressedWatcher.install(this)
 
         ParagraphBleedAdjuster.install(this)
@@ -748,6 +751,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return this.onAztecKeyListener
     }
 
+    /**
+     * Sets the Aztec key listener to be used with this AztecText.
+     * Please note that this lister does hold a copy of the whole text in the editor
+     * each time a key is pressed.
+     */
     fun setAztecKeyListener(listenerAztec: OnAztecKeyListener) {
         this.onAztecKeyListener = listenerAztec
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EnterPressedWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EnterPressedWatcher.kt
@@ -1,0 +1,49 @@
+
+package org.wordpress.aztec.watchers
+
+import android.text.Editable
+import android.text.SpannableStringBuilder
+import android.text.TextWatcher
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.Constants
+import java.lang.ref.WeakReference
+
+class EnterPressedWatcher(aztecText: AztecText) : TextWatcher {
+
+    private val aztecTextRef: WeakReference<AztecText?> = WeakReference(aztecText)
+    private var textBefore : SpannableStringBuilder? = null
+    private var start: Int = -1
+
+    override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
+        val aztecText = aztecTextRef.get()
+        if (aztecText?.getAztecKeyListener() != null && !aztecText.isTextChangedListenerDisabled()) {
+            // we need to make a copy to preserve the contents as they were before the change
+            textBefore = SpannableStringBuilder(text)
+            this.start = start
+        }
+    }
+
+    override fun afterTextChanged(text: Editable) {
+        val aztecText = aztecTextRef.get()
+        val aztecKeyLister = aztecText?.getAztecKeyListener()
+        if (aztecText != null && !aztecText.isTextChangedListenerDisabled() && aztecKeyLister != null) {
+            val newTextCopy = SpannableStringBuilder(text)
+            // if new text length is longer than original text by 1
+            if (textBefore?.length == newTextCopy.length - 1) {
+                // now check that the inserted character is actually a NEWLINE
+                if (newTextCopy[this.start] == Constants.NEWLINE && aztecKeyLister.onEnterKey()) {
+                    text.replace(start, start + 1, "")
+                }
+            }
+        }
+    }
+
+    override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
+    }
+
+    companion object {
+        fun install(editText: AztecText) {
+            editText.addTextChangedListener(EnterPressedWatcher(editText))
+        }
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EnterPressedWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EnterPressedWatcher.kt
@@ -25,13 +25,13 @@ class EnterPressedWatcher(aztecText: AztecText) : TextWatcher {
 
     override fun afterTextChanged(text: Editable) {
         val aztecText = aztecTextRef.get()
-        val aztecKeyLister = aztecText?.getAztecKeyListener()
-        if (aztecText != null && !aztecText.isTextChangedListenerDisabled() && aztecKeyLister != null) {
+        val aztecKeyListener = aztecText?.getAztecKeyListener()
+        if (aztecText != null && !aztecText.isTextChangedListenerDisabled() && aztecKeyListener != null) {
             val newTextCopy = SpannableStringBuilder(text)
             // if new text length is longer than original text by 1
             if (textBefore?.length == newTextCopy.length - 1) {
                 // now check that the inserted character is actually a NEWLINE
-                if (newTextCopy[this.start] == Constants.NEWLINE && aztecKeyLister.onEnterKey()) {
+                if (newTextCopy[this.start] == Constants.NEWLINE && aztecKeyListener.onEnterKey()) {
                     text.replace(start, start + 1, "")
                 }
             }


### PR DESCRIPTION
`Enter.Key` detection code was added to Aztec a couple of weeks ago by using [InputFilters](https://github.com/wordpress-mobile/AztecEditor-Android/pull/746/files#diff-7ca71cd1f009ab8438e0901205001b14R456).
Unfortunately `InputFilters` can act badly on some combination of keyboard/language, resulting in repeating letters in editor.

This PR proposes an alternative solution to the problem by using `TextWatcher`, that should be safe to use. (Enter.Key detection logic is only used in Gutenberg-mobile at the moment, and placing a textwatcher that does check if the lister is set or not, before processing the text, should also be another +1 for this solution).

To test this PR, setup  a new OnAztecKeyListener in AztecText, and check that no new lines are added to the editor when Enter.Key is pressed on the keyboard of the device.
```
        onAztecKeyListener = object : OnAztecKeyListener {
            override fun onEnterKey() : Boolean {
                Log.d("Test", "testing")
                return true
            }
            override fun onBackspaceKey() : Boolean {
                return false
            }
        }
```


I've tested this with many devices, and languages, and didn't find the repeating letters issues, but wasn't able to replicate the issue even with the old `InputFilters` solution.

Pinging @khaykov , since he was able to replicate the original issue with InputFilters.