### PR TITLE
Fix/update develop changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [1.3.11](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.11) - 2018-11-08
+### Fixed
+- Fixed: Repeating characters in the editor
 ## [1.3.10](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.10) - 2018-10-23
 ### Fixed
 - Fixed: crash when deleting text (span handling)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.10')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.11')
 }
 ```
 


### PR DESCRIPTION
### Fix
Brings the latest version in documentation to `develop`.
There was a hotfix in `1.3.11`, the fix for which was already merged in `develop` in https://github.com/wordpress-mobile/AztecEditor-Android/pull/761, so this PR only cherry-picks the commit with the changelog as indicated instead of re-merging the branch which would end up in a duplicate change, and updates the `README.md` with the version.

### Test
N/A (only documentation changed)

### Review
@loremattei 