### PR TITLE
Fix onEnter keyListener for GB-mobile

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EnterPressedWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EnterPressedWatcher.kt
@@ -31,8 +31,9 @@ class EnterPressedWatcher(aztecText: AztecText) : TextWatcher {
             // if new text length is longer than original text by 1
             if (textBefore?.length == newTextCopy.length - 1) {
                 // now check that the inserted character is actually a NEWLINE
-                if (newTextCopy[this.start] == Constants.NEWLINE && aztecKeyListener.onEnterKey()) {
+                if (newTextCopy[this.start] == Constants.NEWLINE) {
                     text.replace(start, start + 1, "")
+                    aztecKeyListener.onEnterKey()
                 }
             }
         }


### PR DESCRIPTION
This PR fixes an issue where the `onEnterKey` key listener was called with the wrong text.

In details, `TextWatcher(s)` work after the text is inserted into the field. In this particular case we emit the `onEnter key pressed event` but the text in the Aztec field already contained the `\n`, and then client will read the wrong value from it, if the read happens before the TextWatcher changes the actual text in the field. 

To reproduce the problem make sure to use a device, or an emulator that uses TextWatcher to detect the Enter.key event. Samsung devices may use the standard KeyListener instead, since the keyboard is recognized as HW keyboard. Nexus 5X instead should be ok.


Will produce a PR in AztecWrapper and gb-mobile later.