### PR TITLE
Avoid trying to delete if only the end-of-text marker is there

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1440,7 +1440,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
             disableTextChangedListener()
 
-            if (min == 0 && max == text.length) {
+            if (min == 0 && (max == text.length || text.toString() == Constants.END_OF_BUFFER_MARKER_STRING)) {
                 setText(Constants.REPLACEMENT_MARKER_STRING)
             } else {
                 editable.delete(min, max)


### PR DESCRIPTION
This PR addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/430

Aztec tries to "clean up" any text already in the buffer if everything is selected, but when the buffer is empty that attempt ends up emitting a "backspace" character in the start of the buffer... and that causes blocks to merge in the context of Gutenberg.

Instead, Aztec should not try to delete anything when pasting if the buffer only has the end-of-buffer marker.

### Test
1. Select something from the demo text and copy it
2. Select all text and delete it
3. Paste the copied text and notice that the paste works fine

This PR description will get updated with links to `react-native-aztec` and gutenberg-mobile PRs for testing against those too.

### Review
@[USER_NAME]