### PR TITLE
Compare to end-of-marker only if single-char width

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1440,7 +1440,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
             disableTextChangedListener()
 
-            if (min == 0 && (max == text.length || text.toString() == Constants.END_OF_BUFFER_MARKER_STRING)) {
+            val length = text.length
+            if (min == 0 &&
+                    (max == length || (length == 1 && text.toString() == Constants.END_OF_BUFFER_MARKER_STRING))) {
                 setText(Constants.REPLACEMENT_MARKER_STRING)
             } else {
                 editable.delete(min, max)


### PR DESCRIPTION
Follow up PR to #770 to optimize the costly `.toString()` call to only happen if the text is single-char.

### Test
Follow the steps in https://github.com/wordpress-mobile/AztecEditor-Android/pull/770
