### PR TITLE
Increase kotlin and coroutines version to the next stable

### DIFF
--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -29,9 +29,6 @@ android {
             includeAndroidResources = true
         }
     }
-
-    // enable kotlin coroutines
-    kotlin { experimental { coroutines "enable" } }
 }
 
 dependencies {

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -48,6 +48,6 @@ dependencies {
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.1'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -55,10 +55,9 @@ import android.view.WindowManager
 import android.view.inputmethod.BaseInputConnection
 import android.widget.CheckBox
 import android.widget.EditText
-import kotlinx.coroutines.experimental.Dispatchers
-import kotlinx.coroutines.experimental.android.Main
-import kotlinx.coroutines.experimental.runBlocking
-import kotlinx.coroutines.experimental.withContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.aztec.formatting.BlockFormatter

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
     ext {
         gradlePluginVersion = '3.1.3'
-        kotlinVersion = '1.2.41'
+        kotlinVersion = '1.3.11'
+        kotlinCoroutinesVersion = '1.1.0'
         supportLibVersion = '27.1.1'
         tagSoupVersion = '1.2.1'
         glideVersion = '3.7.0'


### PR DESCRIPTION
Update Kotlin and Coroutines version to use the newly released stable version of coroutines. It's necessary for the same update in WPAndroid 