### PR TITLE
Issue/774 caption alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [v1.3.15](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.15)
+### Changed
+- Synced the caption span alignment attribute with its the align property
+
 ## [1.3.14](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.14) - 2019-01-11
 ### Fixed
 - Fixed issue where pasting over the whole text emitted a delete char, causing Gutenberg to remove whole block

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
@@ -45,11 +45,12 @@ fun AztecText.removeImageCaption(attributePredicate: AztecText.AttributePredicat
 
 fun AztecText.hasImageCaption(attributePredicate: AztecText.AttributePredicate): Boolean {
     this.text.getSpans(0, this.text.length, AztecImageSpan::class.java)
-        .firstOrNull {
-            val wrapper = SpanWrapper<AztecImageSpan>(text, it)
-            return text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java)
-                    .map { span -> span as CaptionShortcodeSpan }
-                    .any { span -> attributePredicate.matches(span.attributes) }
+            .firstOrNull {
+                attributePredicate.matches(it.attributes)
+            }
+            ?.let {
+                val wrapper = SpanWrapper(text, it)
+                return text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).isNotEmpty()
         }
 
     return false

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
@@ -47,7 +47,9 @@ fun AztecText.hasImageCaption(attributePredicate: AztecText.AttributePredicate):
     this.text.getSpans(0, this.text.length, AztecImageSpan::class.java)
         .firstOrNull {
             val wrapper = SpanWrapper<AztecImageSpan>(text, it)
-            return text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).isNotEmpty()
+            return text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java)
+                    .map { span -> span as CaptionShortcodeSpan }
+                    .any { span -> attributePredicate.matches(span.attributes) }
         }
 
     return false

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
@@ -57,7 +57,7 @@ fun AztecText.hasImageCaption(attributePredicate: AztecText.AttributePredicate):
 
 fun AztecImageSpan.getCaption(): String {
     textView?.text?.let {
-        val wrapper = SpanWrapper<AztecImageSpan>(textView!!.text, this)
+        val wrapper = SpanWrapper(textView!!.text, this)
         textView!!.text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.let {
             return it.caption
         }
@@ -67,7 +67,7 @@ fun AztecImageSpan.getCaption(): String {
 
 fun AztecImageSpan.getCaptionAttributes(): AztecAttributes {
     textView?.text?.let {
-        val wrapper = SpanWrapper<AztecImageSpan>(textView!!.text, this)
+        val wrapper = SpanWrapper(textView!!.text, this)
         textView!!.text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.let {
             return it.attributes
         }
@@ -78,7 +78,7 @@ fun AztecImageSpan.getCaptionAttributes(): AztecAttributes {
 @JvmOverloads
 fun AztecImageSpan.setCaption(value: String, attrs: AztecAttributes? = null) {
     textView?.text?.let {
-        val wrapper = SpanWrapper<AztecImageSpan>(textView!!.text, this)
+        val wrapper = SpanWrapper(textView!!.text, this)
 
         var captionSpan = textView?.text?.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java)?.firstOrNull()
         if (captionSpan == null) {
@@ -106,7 +106,7 @@ fun AztecImageSpan.setCaption(value: String, attrs: AztecAttributes? = null) {
 
 fun AztecImageSpan.removeCaption() {
     textView?.text?.let {
-        val wrapper = SpanWrapper<AztecImageSpan>(textView!!.text, this)
+        val wrapper = SpanWrapper(textView!!.text, this)
         textView!!.text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.remove()
     }
 }

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
@@ -1,5 +1,6 @@
 package org.wordpress.aztec.plugins.shortcodes.extensions
 
+import android.text.Layout
 import android.text.Spanned
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
@@ -86,7 +87,17 @@ fun AztecImageSpan.setCaption(value: String, attrs: AztecAttributes? = null) {
         captionSpan.caption = value
 
         attrs?.let {
-            captionSpan!!.attributes = attrs
+            captionSpan.attributes = attrs
+
+            if (captionSpan.attributes.hasAttribute(CaptionShortcodePlugin.ALIGN_ATTRIBUTE)) {
+                when (captionSpan.attributes.getValue(CaptionShortcodePlugin.ALIGN_ATTRIBUTE)) {
+                    CaptionShortcodePlugin.ALIGN_RIGHT_ATTRIBUTE_VALUE -> captionSpan.align = Layout.Alignment.ALIGN_OPPOSITE
+                    CaptionShortcodePlugin.ALIGN_CENTER_ATTRIBUTE_VALUE -> captionSpan.align = Layout.Alignment.ALIGN_CENTER
+                    CaptionShortcodePlugin.ALIGN_LEFT_ATTRIBUTE_VALUE -> captionSpan.align = Layout.Alignment.ALIGN_NORMAL
+                }
+            } else {
+                captionSpan.align = null
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #774.

This PR keeps the caption attributes and the align property of the caption span in sync. This is necessary to fix the image alignment property bug (wordpress-mobile/WordPress-Android#8569).

This PR can be tested by a related PR in WPAndroid (trying to change the alignment of an image with a caption).