### PR TITLE
Do not reset selection when isInit is true

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1082,15 +1082,18 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         val cursorPosition = consumeCursorPosition(builder)
-        setSelection(0)
+
+        if (!isInit) {
+            setSelection(0)
+        }
 
         setTextKeepState(builder)
         enableTextChangedListener()
 
-        setSelection(cursorPosition)
-
         if (isInit) {
             initialEditorContentParsedSHA256 = calculateInitialHTMLSHA(toPlainHtml(false), initialEditorContentParsedSHA256)
+        } else {
+            setSelection(cursorPosition)
         }
 
         loadImages()


### PR DESCRIPTION
### Fix
This PR fixes extra `onSelectionChange` events being emitted on text change in `react-native-aztec`, causing a rendering loop in https://github.com/wordpress-mobile/gutenberg-mobile/pull/275#issuecomment-452028715

### Test
1. Using https://github.com/wordpress-mobile/gutenberg-mobile/pull/275 along with https://gist.github.com/Tug/0bf5869d3a0477bd4723cc5ed1a909ee, run `yarn android` and check that the issue mentioned in the comment is fixed
2. Check that it does not cause regression in WordPress-Android: 
    - make sure cut&paste is not broken
    - run tests

### Review
@daniloercoli 