### PR TITLE
Add jitpack.yml to work around the Google licence issue

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+   - yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
+   - yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.3"


### PR DESCRIPTION
There is currently an issue with Android licences not being accepted correctly (https://issuetracker.google.com/issues/123054726).

This is impacting Jitpack builds, the solution is to explicitly accept the licences in `.jitpack.yml` config (see https://stackoverflow.com/questions/54268074/jitpack-failed-to-install-the-following-android-sdk-packages-as-some-licences-h/54292533#54292533).

You can see the successful build of this commit on Jitpack here: https://jitpack.io/com/github/wordpress-mobile/AztecEditor-Android/a370751c4a2481942b9c228749448e6ca471ed1a/build.log

### Test

Other than checking the Jitpack log above, including Aztec at this commit in a Android project (such as WordPress-Android) verifies it:

```
implementation 'com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:a370751c4a2481942b9c228749448e6ca471ed1a'
```
