### PR TITLE
Update README and CHANGELOG for a v1.3.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.19')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.20')
 }
 ```
 


### PR DESCRIPTION
Update README in preparation for a v1.3.20 release.

By the way, CHANGELOG.md was already updated via previous work.

This is trivial PR for the release process so, will self-merge.