### PR TITLE
Update Gradle to 4.10.3 and Android Gradle Plugin to 3.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - extra-google-m2repository
     - platform-tools
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
 
 env:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "org.wordpress.aztec"

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '3.1.3'
+        gradlePluginVersion = '3.3.1'
         kotlinVersion = '1.3.11'
         kotlinCoroutinesVersion = '1.1.0'
         supportLibVersion = '27.1.1'

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 before_install:
    - yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
-   - yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.3"
+   - yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;28.0.3"

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This updates Gradle and the Android Gradle Plugin to recent versions. It was also necessary to update the build tools to `28.0.3`.

A similar change has been live in WPAndroid and FluxC for some time: https://github.com/wordpress-mobile/WordPress-Android/pull/9044, https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1119

This will be helpful when moving the project to CircleCI as recent Gradle versions are more memory efficient.