### PR TITLE
CircleCI: Use Orb for running Firebase tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@0.0.20
+  android: wordpress-mobile/android@0.0.21
 
 jobs:
   Lint:
@@ -51,20 +51,14 @@ jobs:
       - run:
           name: Decrypt credentials
           command: openssl aes-256-cbc -md sha256 -d -in .firebase.secrets.json.enc -out .firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"
-      - run:
-          name: Authenticate gcloud
-          command: gcloud auth activate-service-account --key-file .firebase.secrets.json
-      - run:
-          name: Run Tests
-          no_output_timeout: 20m
-          command: |
-            gcloud firebase test android run --type instrumentation \
-                                             --app app/build/outputs/apk/debug/app-debug.apk \
-                                             --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
-                                             --device model=Nexus5X,version=26,locale=en,orientation=portrait \
-                                             --project api-project-108380595987 \
-                                             --timeout 10m \
-                                             --verbosity info
+      - android/firebase-test:
+          key-file: .firebase.secrets.json
+          type: instrumentation
+          apk-path: app/build/outputs/apk/debug/app-debug.apk
+          test-apk-path: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+          project: api-project-108380595987
+          timeout: 10m
       - android/save-gradle-cache:
           cache-prefix: connected-tests
 


### PR DESCRIPTION
To avoid duplicating boilerplate across several projects, this now uses the `firebase-test` command I added in https://github.com/wordpress-mobile/circleci-orbs/pull/14.

It also adds gathering tests results and artifacts from the test run in CircleCI.