### PR TITLE
Clickable URL Spans

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -24,6 +24,8 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
     private var onAudioTappedListener: AztecText.OnAudioTappedListener? = null
     private var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null
     private var onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener? = null
+    private var onLinkTappedListener: AztecText.OnLinkTappedListener? = null
+    private var isLinkTapEnabled: Boolean = false
     private var plugins: ArrayList<IAztecPlugin> = visualEditor.plugins
     var sourceEditor: SourceViewEditText? = null
 
@@ -134,6 +136,18 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
         return this
     }
 
+    fun setOnLinkTappedListener(onLinkTappedListener: AztecText.OnLinkTappedListener): Aztec {
+        this.onLinkTappedListener = onLinkTappedListener
+        initLinkTappedListener()
+        return this
+    }
+
+    fun setLinkTapEnabled(isLinkTapEnabled: Boolean): Aztec {
+        this.isLinkTapEnabled = isLinkTapEnabled
+        initLinkTapEnabled()
+        return this
+    }
+
     fun addPlugin(plugin: IAztecPlugin): Aztec {
         plugins.add(plugin)
 
@@ -218,5 +232,15 @@ open class Aztec private constructor(val visualEditor: AztecText, val toolbar: I
         if (onVideoInfoRequestedListener != null) {
             visualEditor.setOnVideoInfoRequestedListener(onVideoInfoRequestedListener!!)
         }
+    }
+
+    private fun initLinkTappedListener() {
+        if (onLinkTappedListener != null) {
+            visualEditor.setOnLinkTappedListener(onLinkTappedListener!!)
+        }
+    }
+
+    private fun initLinkTapEnabled() {
+        visualEditor.setLinkTapEnabled(isLinkTapEnabled)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1765,4 +1765,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     override fun dispatchHoverEvent(event: MotionEvent): Boolean {
         return if (accessibilityDelegate.onHoverEvent(event)) true else super.dispatchHoverEvent(event)
     }
+
+    fun setUrlClickable(urlClickable: Boolean){
+        EnhancedMovementMethod.clickableUrlSpan = urlClickable
+    }
+
+    fun setOnUrlClickListener(listener: EnhancedMovementMethod.OnUrlClickListener){
+        EnhancedMovementMethod.urlClickListener = listener
+    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1770,7 +1770,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         EnhancedMovementMethod.clickableUrlSpan = urlClickable
     }
 
-    fun setOnUrlClickListener(listener: EnhancedMovementMethod.OnUrlClickListener){
+    fun setOnUrlClickListener(listener: EnhancedMovementMethod.OnUrlClickListener?){
         EnhancedMovementMethod.urlClickListener = listener
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1766,11 +1766,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return if (accessibilityDelegate.onHoverEvent(event)) true else super.dispatchHoverEvent(event)
     }
 
-    fun setUrlClickable(urlClickable: Boolean){
+    fun setUrlClickable(urlClickable: Boolean) {
         EnhancedMovementMethod.clickableUrlSpan = urlClickable
     }
 
-    fun setOnUrlClickListener(listener: EnhancedMovementMethod.OnUrlClickListener?){
+    fun setOnUrlClickListener(listener: EnhancedMovementMethod.OnUrlClickListener?) {
         EnhancedMovementMethod.urlClickListener = listener
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -321,6 +321,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         fun onBackspaceKey() : Boolean
     }
 
+    interface OnLinkTappedListener {
+        fun onLinkTapped(widget: View, url: String)
+    }
+
     constructor(context: Context) : super(context) {
         init(null)
     }
@@ -783,6 +787,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     fun setOnVideoInfoRequestedListener(listener: OnVideoInfoRequestedListener) {
         this.onVideoInfoRequestedListener = listener
+    }
+
+    fun setOnLinkTappedListener(listener: OnLinkTappedListener) {
+        EnhancedMovementMethod.linkTappedListener = listener
+    }
+
+    fun setLinkTapEnabled(isLinkTapEnabled: Boolean) {
+        EnhancedMovementMethod.isLinkTapEnabled = isLinkTapEnabled
     }
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
@@ -1766,11 +1778,4 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return if (accessibilityDelegate.onHoverEvent(event)) true else super.dispatchHoverEvent(event)
     }
 
-    fun setUrlClickable(urlClickable: Boolean) {
-        EnhancedMovementMethod.clickableUrlSpan = urlClickable
-    }
-
-    fun setOnUrlClickListener(listener: EnhancedMovementMethod.OnUrlClickListener?) {
-        EnhancedMovementMethod.urlClickListener = listener
-    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -5,7 +5,6 @@ import android.text.Spannable
 import android.text.method.ArrowKeyMovementMethod
 import android.text.style.ClickableSpan
 import android.view.MotionEvent
-import android.view.View
 import android.widget.TextView
 import org.wordpress.aztec.spans.AztecMediaClickableSpan
 import org.wordpress.aztec.spans.AztecURLSpan
@@ -15,8 +14,8 @@ import org.wordpress.aztec.spans.UnknownClickableSpan
  * http://stackoverflow.com/a/23566268/569430
  */
 object EnhancedMovementMethod : ArrowKeyMovementMethod() {
-    var clickableUrlSpan = false
-    var urlClickListener: OnUrlClickListener? = null
+    var isLinkTapEnabled = false
+    var linkTappedListener: AztecText.OnLinkTappedListener? = null
 
     override fun onTouchEvent(widget: TextView, text: Spannable, event: MotionEvent): Boolean {
         val action = event.action
@@ -81,17 +80,13 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
                 if (link is AztecMediaClickableSpan || link is UnknownClickableSpan) {
                     link.onClick(widget)
                     return true
-                } else if (link is AztecURLSpan && clickableUrlSpan) {
-                    urlClickListener?.onClick(widget, link.url) ?: link.onClick(widget)
+                } else if (link is AztecURLSpan && isLinkTapEnabled) {
+                    linkTappedListener?.onLinkTapped(widget, link.url) ?: link.onClick(widget)
                     return true
                 }
             }
         }
 
         return super.onTouchEvent(widget, text, event)
-    }
-
-    interface OnUrlClickListener {
-        fun onClick(widget: View, url: String)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -77,11 +77,11 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
                 link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull { text.getSpanStart(it) == off }
             }
 
-            if(link != null) {
+            if (link != null) {
                 if (link is AztecMediaClickableSpan || link is UnknownClickableSpan) {
                     link.onClick(widget)
                     return true
-                } else if(link is AztecURLSpan && clickableUrlSpan){
+                } else if (link is AztecURLSpan && clickableUrlSpan) {
                     urlClickListener?.onClick(widget, link.url) ?: link.onClick(widget)
                     return true
                 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -5,14 +5,19 @@ import android.text.Spannable
 import android.text.method.ArrowKeyMovementMethod
 import android.text.style.ClickableSpan
 import android.view.MotionEvent
+import android.view.View
 import android.widget.TextView
 import org.wordpress.aztec.spans.AztecMediaClickableSpan
+import org.wordpress.aztec.spans.AztecURLSpan
 import org.wordpress.aztec.spans.UnknownClickableSpan
 
 /**
  * http://stackoverflow.com/a/23566268/569430
  */
 object EnhancedMovementMethod : ArrowKeyMovementMethod() {
+    var clickableUrlSpan = false
+    var urlClickListener: OnUrlClickListener? = null
+
     override fun onTouchEvent(widget: TextView, text: Spannable, event: MotionEvent): Boolean {
         val action = event.action
 
@@ -72,14 +77,21 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
                 link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull { text.getSpanStart(it) == off }
             }
 
-            if (link != null && (link is AztecMediaClickableSpan || link is UnknownClickableSpan)) {
-                if (action == MotionEvent.ACTION_UP) {
+            if(link != null) {
+                if (link is AztecMediaClickableSpan || link is UnknownClickableSpan) {
                     link.onClick(widget)
+                    return true
+                } else if(link is AztecURLSpan && clickableUrlSpan){
+                    urlClickListener?.onClick(widget, link.url) ?: link.onClick(widget)
+                    return true
                 }
-                return true
             }
         }
 
         return super.onTouchEvent(widget, text, event)
+    }
+
+    interface OnUrlClickListener {
+        fun onClick(widget: View, url: String)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         picassoVersion = '2.5.2'
         robolectricVersion = '3.5.1'
         jUnitVersion = '4.12'
-        jSoupVersion = '1.10.3'
+        jSoupVersion = '1.11.3'
         wordpressUtilsVersion = '1.21'
         espressoVersion = '3.0.1'
     }


### PR DESCRIPTION
Hi! 
The current implementation of EnhancedMovementMethod only handles AztecMediaClickableSpan and UnknownClickableSpan.
I had to make the following changes to fit my app needs (to also handle AztecURLSpan) and thought this might be useful to others.

### Toggle clickable URL spans
Use case: an editor in **read-only** mode that needs to open urls
```kotlin
visualEditor.setUrlClickable(true)
```

### Set custom onClick listener (optional)
If null, will call the original `onClick()` method.
Use case: If the editor needs to open a Chrome Custom Tab (the default behavior is to open in a external app)
```kotlin
visualEditor.setOnUrlClickListener(object : EnhancedMovementMethod.OnUrlClickListener {
    override fun onClick(widget: View, url: String) {
        openInChromeTab(url)
    }
})
```