### PR TITLE
Fix for crash on Samsung Clipboard ListView on Android 8.X

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -47,6 +47,7 @@ import android.text.TextWatcher
 import android.text.style.SuggestionSpan
 import android.util.AttributeSet
 import android.util.DisplayMetrics
+import android.util.Log
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -1385,6 +1386,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             max = Math.max(0, Math.max(selectionStart, selectionEnd))
         }
 
+        //
+        var clipboardIdentifier = resources.getIdentifier("android:id/clipboard", "id", context.packageName)
+
         when (id) {
             android.R.id.paste -> paste(text, min, max)
             android.R.id.pasteAsPlainText -> paste(text, min, max, true)
@@ -1403,8 +1407,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             }
             // Fix for crash when pasting text on Samsung Devices running Android 8.
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
-            16908904,
-            16908874 -> {
+            clipboardIdentifier -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Build.VERSION.SDK_INT < 28
                         && Build.MANUFACTURER.toLowerCase().equals("samsung")) {
                     // Nope return true

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -47,7 +47,6 @@ import android.text.TextWatcher
 import android.text.style.SuggestionSpan
 import android.util.AttributeSet
 import android.util.DisplayMetrics
-import android.util.Log
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -1386,7 +1385,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             max = Math.max(0, Math.max(selectionStart, selectionEnd))
         }
 
-        //
         var clipboardIdentifier = resources.getIdentifier("android:id/clipboard", "id", context.packageName)
 
         when (id) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -55,6 +55,7 @@ import android.view.WindowManager
 import android.view.inputmethod.BaseInputConnection
 import android.widget.CheckBox
 import android.widget.EditText
+import android.widget.Toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -1400,7 +1401,18 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     deleteInlineStyleFromTheBeginning()
                 }
             }
-            else -> return super.onTextContextMenuItem(id)
+            // Fix for crash when pasting text on Samsung Devices running Android 8.
+            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
+            16908904,
+            16908874 -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Build.VERSION.SDK_INT < 28
+                        && Build.MANUFACTURER.toLowerCase().equals("samsung")) {
+                    // Nope return true
+                    Toast.makeText(context, R.string.samsung_disabled_custom_clipboard, Toast.LENGTH_LONG).show()
+                } else {
+                    return super.onTextContextMenuItem(id)
+                }
+            } else -> return super.onTextContextMenuItem(id)
         }
 
         return true

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 
     <!-- GENERAL -->
     <string name="cursor_moved">Cursor moved</string>
+    <string name="samsung_disabled_custom_clipboard">Sorry, this feature is disabled on Android 8. Please use the Paste action instead.</string>
 
     <!-- LINK DIALOG -->
     <string name="link_dialog_title">Insert link</string>


### PR DESCRIPTION
This PR fixes a crash that happens when pasting text on Samsung Devices running Android 8.
The issue only happens if you use the custom Samsung `Clipboard` feature - 
Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827

Steps to reproduce:

Make sure you have Samsung device with Android 8.x
- Start the demo app
- Hold down finger over the screen until a menu with: PASTE, CLIPBOARD doesn't show up.
- Click on CLIPBOARD
- See the Toast message and that the custom list view doesn't show

The solution implemented in this PR is the less invasive, and easy to remove later, other viable fixes are listed here https://github.com/wordpress-mobile/WordPress-Android/issues/8827#issuecomment-454520085 

Note: we will update the Aztec ref in the Android app soon, with the next GB-mobile release, so no need to update it now on both projects.

cc @marecar3  since you've already investigate the problem.

Note 2: If we find a nice way to disable HW acceleration, on selected devices only, we may need to remove this fix, and try if it's crashing again when HW acceleration is OFF. Since this could be similar to #8828.