### PR TITLE
Android 8.x dymanic layout crash preventer

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -458,7 +458,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         // https://android-review.googlesource.com/c/platform/frameworks/base/+/634929
         val dynamicLayoutCrashPreventer = InputFilter { source, start, end, dest, dstart, dend ->
             var temp : CharSequence? = null
-            if (!bypassCrashPreventerInputFilter  && dstart == dend && dest.length > dend+1) {
+            if (!bypassCrashPreventerInputFilter && dstart == dend && dest.length > dend+1) {
                 // dstart == dend means this is an insertion
                 // if there are any images right after the destination position, hack the text
                 val spans = dest.getSpans(dstart, dend+1, AztecImageSpan::class.java)
@@ -472,7 +472,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     // the original Image later so to not have a duplicate.
                     // use Spannable to copy / keep the current spans
                     temp = SpannableStringBuilder(source).append(dest.subSequence(dend, dend+1))
-
 
                     // delete the original AztecImageSpan
                     text.delete(dend, dend+1)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -457,7 +457,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         // problem is fixed at the Android OS level as described in the following url
         // https://android-review.googlesource.com/c/platform/frameworks/base/+/634929
         val dynamicLayoutCrashPreventer = InputFilter { source, start, end, dest, dstart, dend ->
-            var temp = source
+            var temp : CharSequence? = null
             if (!bypassCrashPreventerInputFilter  && dstart == dend && dest.length > dend+1) {
                 // dstart == dend means this is an insertion
                 // if there are any images right after the destination position, hack the text

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcherAPI25AndHigher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcherAPI25AndHigher.kt
@@ -17,6 +17,10 @@ class DeleteMediaElementWatcherAPI25AndHigher(aztecText: AztecText) : TextWatche
             return
         }
 
+        if (aztecTextRef.get()?.isMediaDeletedListenerDisabled() ?: true) {
+            return
+        }
+
         if (count > 0) {
             deleted = true
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcherPreAPI25.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcherPreAPI25.kt
@@ -14,6 +14,10 @@ class DeleteMediaElementWatcherPreAPI25(aztecText: AztecText) : TextWatcher {
             return
         }
 
+        if (aztecTextRef.get()?.isMediaDeletedListenerDisabled() ?: true) {
+            return
+        }
+
         if (count > 0) {
             aztecTextRef.get()?.text?.getSpans(start, start + count, AztecMediaSpan::class.java)
                     ?.forEach {


### PR DESCRIPTION
### Fix
This PR tackles the symptom (not the culprit) identified as the cause in #729.
The culprit having been identified as laying in the lower level within the Android OS itself https://android-review.googlesource.com/c/platform/frameworks/base/+/634929, and for which a real solution means to fix it at that level (see https://github.com/wordpress-mobile/WordPress-Android/issues/8828#issuecomment-474876535 for alternatives explored around a real solution to the specific problem), we can't do much about it.
As discussed elsewhere, I decided to try and approach the issue from the _symptom_ point of view, and try and workaround the problem without affecting functionality.

The problem was narrowed down and isolated (symptom-wise) as per the following statement:

```
"the Editor crashes when inserting anything right before an image."
```

One of the proposed approaches was to just overwrite `onDraw()` (where the crash is about to happen) and just filter out any non-acceptable values (that is, anything below 0) for coordinates as suggested in https://github.com/wordpress-mobile/AztecEditor-Android/issues/729#issuecomment-430105339. I think at that point however, it would mean that previous calculations were wrong for some reason, and while I haven't dove in too deep it might also mean some state variables (i.e. class members in `DynamicLayout`) could end up keeping a wrongly calculated state, thus generating another problem later on.

Due to these reasons, I decided a different approach would be to:

- a) first, see if we can programmatically detect the exact moment when the problem statement above is `true`
- b) then, somehow make the `TextView` to reflow / recalculate the view elements as appropriate.

One of the first ideas that came to mind was to make use of the already in place mechanism of `TextWatchers` to go ahead and make any needed changes. However, `TextWatcher` only is an observer that cannot affect the flow of events - that means that whatever is going to happen is still going to happen, you only get to listen to what's going on and only do something with it _after the fact_.

Then, we have `InputFilter`. This effectively is a mechanism in place that allows you to look into what's about to happen (text change) and decide on what should be replaced and what not.

I observed that initializing `AztecText` with actually _anything_ before an Image is not a problem (only insertion is), so I thought "ok, what if we replace not the specific part that normally would get replaced, but make it look like a block and replace _both_ the thing being modified _and_ the Image together?".

Unfortunately that's not exactly possible from within an `InputFilter`. When an insertion happens, the `Editable` will call its whatever `InputFilter`s have been set, passing them the place where the insertion needs to happen, and what the source string (or `Spannable`) to insert is. What this means is, even if we return the block of "inserted char" plus the Image right next to it, the whole block still will try to get inserted before the original image, causing the crash anyway.

#### What this PR does
So, we'd have to first keep a copy of the image span, then delete the original image span, then insert the block of "inserted text plus image" and, for the run of this inputFilter (when the case is first detected), just return an empty string, actually preventing the original change from happening. This is exactly what the `InputFilter` in this PR is doing and, so far so good, seems to be working.

We're effectively artificially re-creating the change as an insertion of "original insertion plus Image" and then making a substitution, if that makes sense.

### Test
1. start the demo app
2. place the cursor at the  beginning, right before the image
3. enter anything
4. observe it doesn't crash

Other things I've tested:
- [x] test with other pluggable keyboards (tried 3rd party such as SwiftKey)
- [x] test with different types of content in between image and insertion (heading, list, quote, another image, etc)
- [x] test pasting paragraphs (not just typing characters)
- [x] tested integration with WPAndroid (used [these steps and can't reproduce](https://github.com/wordpress-mobile/WordPress-Android/issues/9470#issuecomment-476782575))

