### PR TITLE
Remove some unneeded logging

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/UserOperationEvent.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/UserOperationEvent.kt
@@ -78,9 +78,6 @@ abstract class UserOperationEvent(var sequence: EventSequence<TextWatcherEvent> 
             insideHeading = false
         }
 
-        AppLog.d(AppLog.T.EDITOR, "SEQUENCE OBSERVED COMPLETELY, IS IT WITHIN BLOCK?: " +
-                (isInsideList || insideHeading || isInsidePre || isInsideCode))
-
         return isInsideList || insideHeading || isInsidePre || isInsideCode
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/known/space/steps/TextWatcherEventInsertTextDelAfter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/event/sequence/known/space/steps/TextWatcherEventInsertTextDelAfter.kt
@@ -18,17 +18,14 @@ class TextWatcherEventInsertTextDelAfter(beforeEventData: BeforeTextChangedEvent
 
     private fun testBeforeTextChangedEventData(data: BeforeTextChangedEventData): Boolean {
         beforeText = data.textBefore
-        AppLog.d(AppLog.T.EDITOR, "INSERTSPECIAL testBeforeTextChangedEventData: " + (data.count == 0 && data.after > 0))
         return data.count == 0 && data.after > 0
     }
 
     private fun testOnTextChangedEventData(data: OnTextChangedEventData): Boolean {
-        AppLog.d(AppLog.T.EDITOR, "INSERTSPECIAL testOnTextChangedEventData: " + (data.start >= 0 && data.count > 0 && data.textOn!!.length > 0))
         return data.start >= 0 && data.count > 0 && data.textOn!!.length > 0
     }
 
     private fun testAfterTextChangedEventData(data: AfterTextChangedEventData): Boolean {
-        AppLog.d(AppLog.T.EDITOR, "INSERTSPECIAL testAfterTextChangedEventData: " + (EndOfBufferMarkerAdder.safeLength(beforeText!!) == EndOfBufferMarkerAdder.safeLength(data.textAfter!!)))
         return EndOfBufferMarkerAdder.safeLength(beforeText!!) == EndOfBufferMarkerAdder.safeLength(data.textAfter!!)
     }
 


### PR DESCRIPTION
Small PR that removes unneeded logging that convolutes the logs being sent to Fabric, sometimes occupying space that some other information would find useful.