### PR TITLE
Don't bail when ZWJ cleanup found end-of-text marker

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -335,8 +335,9 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         do {
             lastIndex = text.lastIndexOf(Constants.ZWJ_CHAR, lastIndex)
             if (lastIndex == text.length - 1) {
-                // ZWJ at the end of text will serve as end-of-text marker so, let it be and finish.
-                return
+                // ZWJ at the end of text will serve as end-of-text marker so, let it be and continue cleaning up ZWJs
+                lastIndex--
+                continue
             }
 
             if (lastIndex > -1) {


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/845

This PR fixes an Aztec issue where the ZWJ cleanup function was bailing too early if the end-of-text marker was found. Instead, cleanup needs to continue and remove the rest of the ZWJs if any.

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/868

### To test
Use the gutenberg-mobile PR and follow the steps there, thanks!