### PR TITLE
Prevent execution of InputFilter for new lines

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -466,7 +466,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     && dstart == dend && dest.length > dend+1
                     && source != Constants.NEWLINE_STRING) {
                 // dstart == dend means this is an insertion
-                // but avoid handling anything if it's a
+                // avoid handling anything if it's a newline
                 // if there are any images right after the destination position, hack the text
                 val spans = dest.getSpans(dstart, dend+1, AztecImageSpan::class.java)
                 if (spans.isNotEmpty()) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -462,8 +462,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         // https://android-review.googlesource.com/c/platform/frameworks/base/+/634929
         val dynamicLayoutCrashPreventer = InputFilter { source, start, end, dest, dstart, dend ->
             var temp : CharSequence? = null
-            if (!bypassCrashPreventerInputFilter && dstart == dend && dest.length > dend+1) {
+            if (!bypassCrashPreventerInputFilter
+                    && dstart == dend && dest.length > dend+1
+                    && source != Constants.NEWLINE_STRING) {
                 // dstart == dend means this is an insertion
+                // but avoid handling anything if it's a
                 // if there are any images right after the destination position, hack the text
                 val spans = dest.getSpans(dstart, dend+1, AztecImageSpan::class.java)
                 if (spans.isNotEmpty()) {


### PR DESCRIPTION
### Fix
Fixes #808 

This PR avoids handling a `new line` addition within the InputFilter introduced in #801, especially as it was causing a problem in Span handling when such an insertion was properly being made by `FullWidthImageElementWatcher` in its method `insertVisualNewline()`, in occasion of making images separated from paragraphs as per the existing implementation of Aztec in the mentioned `TextWatcher`.

### Explanation
Managed to reproduce this one finding a smaller case - it seemed to me that Aztec was trying to insert an image before a paragraph ending tag, and this is where things seemingly went wrong. Got the hint from looking into the logs of session `5CB4AFF902DF000142875D0BC9D164D7_DNE_0_v2` in case `5c94288ef8b88c296305c342-fabric`.

Using this following HTML code as per a blog Post body on WPAndroid:

`<p style="box-sizing:border-box;">This is just a test.</p>`

1. visual mode, tap and place the cursor right BEFORE the DOT, like this: `This is just a test|.`
2. now, try inserting an image from the device (tap the cross, the media picker shows up, tap on an image, tap the check/done icon on the top-right corner of the screen)
3. observe the crash

First of all, the filter shouldn't be activated by this condition, as this is not what we wanted to capture originally. The situation that we meant to capture was the addition of a character right before an `AztecImageSpan`, and this is effectively an insertion of a character but it's being done artificially (and on purpose) by Aztec during this operation as can be seen in the stacktrace.

```
 at org.wordpress.aztec.AztecText$setupKeyListenersAndInputFilters$dynamicLayoutCrashPreventer$1.filter(AztecText.kt:483)
        at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:514)
        at android.text.SpannableStringBuilder.insert(SpannableStringBuilder.java:224)
        at android.text.SpannableStringBuilder.insert(SpannableStringBuilder.java:222)
        at org.wordpress.aztec.watchers.FullWidthImageElementWatcher.insertVisualNewline(FullWidthImageElementWatcher.kt:34)
        at org.wordpress.aztec.watchers.FullWidthImageElementWatcher.normalizeEditingAroundImageSpans(FullWidthImageElementWatcher.kt:67)
        at org.wordpress.aztec.watchers.FullWidthImageElementWatcher.afterTextChanged(FullWidthImageElementWatcher.kt:30)
        at android.widget.TextView.sendAfterTextChanged(TextView.java:9380)
        at android.widget.TextView$ChangeWatcher.afterTextChanged(TextView.java:11939)
        at android.text.SpannableStringBuilder.sendAfterTextChanged(SpannableStringBuilder.java:1262)
        at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:574)
        at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:504)
        at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:502)
        at org.wordpress.aztec.formatting.LineBlockFormatter.insertMedia(LineBlockFormatter.kt:160)
        at org.wordpress.aztec.formatting.LineBlockFormatter.insertImage(LineBlockFormatter.kt:135)
        at org.wordpress.aztec.AztecText.insertImage(AztecText.kt:1730)
```

See specifically:
```
        at org.wordpress.aztec.watchers.FullWidthImageElementWatcher.insertVisualNewline(FullWidthImageElementWatcher.kt:34)
        at org.wordpress.aztec.watchers.FullWidthImageElementWatcher.normalizeEditingAroundImageSpans(FullWidthImageElementWatcher.kt:67)
```

So, this PR lets that particular situation happen as it shouldn't be captured by the InputFilter.

### Test
Using WPAndroid on Android 8.0 or 8.1, make sure to use the commit hash `aztecVersion = '89f94f0407dffba19227cdfeba8a5981b1570344'`

1. visual mode, tap and place the cursor right BEFORE the DOT, like this: `This is just a test|.`
2. now, try inserting an image from the device (tap the cross, the media picker shows up, tap on an image, tap the check/done icon on the top-right corner of the screen)
3. observe there's not a crash anymore.

Also, verify the case described in https://github.com/wordpress-mobile/AztecEditor-Android/issues/729 doesn't crash.