### PR TITLE
Update README and CHANGELOG for v1.3.25 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [v1.3.25](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.25)
+### Changed
+- Remove some unneeded logging #806
+### Fixed
+- Don't bail when ZWJ cleanup found end-of-text marker #807
+- Prevent execution of InputFilter for new lines #809
+
 ## [v1.3.24](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.24)
 ### Changed
 - Improvement to how clickable URL spans are handled #793

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.24')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.25')
 }
 ```
 


### PR DESCRIPTION
Releasing v1.3.25 so that we can include https://github.com/wordpress-mobile/AztecEditor-Android/pull/809 in the next WPAndroid version.

v1.3.25 will also include https://github.com/wordpress-mobile/AztecEditor-Android/pull/806 and https://github.com/wordpress-mobile/AztecEditor-Android/pull/807 but I think that is fine since those changes are very small.