### PR TITLE
Fix DynamicLayout Crash - Round 2

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -36,7 +36,14 @@ import android.support.graphics.drawable.VectorDrawableCompat
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AlertDialog
 import android.support.v7.widget.AppCompatEditText
-import android.text.*
+import android.text.Editable
+import android.text.InputFilter
+import android.text.InputType
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.TextUtils
+import android.text.TextWatcher
 import android.text.style.SuggestionSpan
 import android.util.AttributeSet
 import android.util.DisplayMetrics
@@ -469,7 +476,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     // create a new Spannable to perform the text change here
                     var newText = SpannableStringBuilder(dest.subSequence(0, dstart))
                             .append(source.subSequence(start, end))
-                            .append(dest.subSequence(dend, dest.length));
+                            .append(dest.subSequence(dend, dest.length))
 
                     // force a history update to ensure the change is recorded
                     history.beforeTextChanged(this@AztecText)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -462,7 +462,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         // https://android-review.googlesource.com/c/platform/frameworks/base/+/634929
         val dynamicLayoutCrashPreventer = InputFilter { source, start, end, dest, dstart, dend ->
             var temp : CharSequence? = null
-            if (!bypassCrashPreventerInputFilter && dend < dest.length) {
+            if (!bypassCrashPreventerInputFilter && dend < dest.length && source != Constants.NEWLINE_STRING) {
 
                 // if there are any images right after the destination position, hack the text
                 val spans = dest.getSpans(dend, dend+1, AztecImageSpan::class.java)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -461,7 +461,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 val spans = dest.getSpans(dend, dend+1, AztecImageSpan::class.java)
                 if (spans.isNotEmpty()) {
 
-                    // prevent this filter from running twice when `text.insert()` gets called a few lines below
+                    // prevent this filter from running recursively
                     disableCrashPreventerInputFilter()
                     // disable MediaDeleted listener before operating on content
                     disableMediaDeletedListener()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -455,7 +455,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         // https://android-review.googlesource.com/c/platform/frameworks/base/+/634929
         val dynamicLayoutCrashPreventer = InputFilter { source, start, end, dest, dstart, dend ->
             var temp : CharSequence? = null
-            if (!bypassCrashPreventerInputFilter) {
+            if (!bypassCrashPreventerInputFilter && dend < dest.length) {
 
                 // if there are any images right after the destination position, hack the text
                 val spans = dest.getSpans(dend, dend+1, AztecImageSpan::class.java)


### PR DESCRIPTION
### Fix
This PR is an attempt to address the issue described here: https://github.com/wordpress-mobile/WordPress-Android/issues/8828. This issue is related to #516 and #729 which were addressed with PR #801. This is a workaround to attempt to avoid encountering the underlying Android OS bug [described here](https://issuetracker.google.com/issues/67102093) and [patched here](https://android-review.googlesource.com/c/platform/frameworks/base/+/634929).

This workaround utilizes an `InputFilter` as in #801. The code in that PR covers many scenarios that lead to a crash, however, there are still some that cannot be addressed with that approach. One limitation of the InputFilter approach is that we may only modify the text being inserted during a change, but cannot modify the text being removed. Also, in that PR, strict criteria must be met before the fix is applied. One such criterion is that the selection must be a caret (i.e. no selection). This means certain edge cases will still encounter the crash.

One odd note is that if we set up the Demo App content with text, followed by two images, and then some more text, we can trigger the crash by deleting the text preceding the image _only after we have edited that text at least once_. Also, even _after_ having edited that text, if we used the `undo` and `redo` buttons to attain the same state, we could then delete the text without a crash.

Somehow, setting the content in full (as occurs when the app first loads) will put the app into a "safe" state. I also noticed that when the first change happens above the images, the images move vertically by a very small amount.

In order to make use of this in a new workaround, we can set the text within the `InputFilter`. This is accomplished by utilizing the `fromHtml` method, passing in the output from `toFormattedHtml`. In order to do so with the new state of the content, we must overload the `toFormattedHtml` method to accept a `Spannable`, whereas the default behavior is to generate the html from the unedited content (which would merely revert our changes, disallowing modification by the user).

The nature of this PR is to expand the number of cases it addresses by relaxing the criteria for which it is applied. This also means that any side effects that such a workaround may introduce have the potential to affect more users. Since an unrecoverable crash is a fairly severe condition, it holds some weight, but, some consideration should also be given to the volume of users that are currently not experiencing this crash. It would be helpful if we could test these changes as thoroughly as possible so ensure we do not introduce any regressions.

### Test
Follow steps here: https://github.com/wordpress-mobile/WordPress-Android/issues/8828#issuecomment-485843440.
Also, here: https://github.com/wordpress-mobile/AztecEditor-Android/issues/516#issue-271419928.
And here: https://github.com/wordpress-mobile/AztecEditor-Android/issues/729#issue-334435899.

Any more tests in those threads would also be good candidates for testing this PR.

### Review
@mzorz