### PR TITLE
[Gutenberg] Bypass selection events until listener is re-enabled

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1137,7 +1137,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val parser = AztecParser(plugins)
 
         var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
-        cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode)
+        cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
         builder.append(parser.fromHtml(cleanSource, context))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
@@ -1547,7 +1547,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     }
                 }
 
-        val html = Format.removeSourceEditorFormatting(parser.toHtml(output), isInCalypsoMode)
+        val html = Format.removeSourceEditorFormatting(parser.toHtml(output), isInCalypsoMode, isInGutenbergMode)
 
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
         clipboard.primaryClip = ClipData.newHtmlText("aztec", output.toString(), html)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -246,6 +246,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     var commentsVisible = resources.getBoolean(R.bool.comments_visible)
 
     var isInCalypsoMode = true
+    var isInGutenbergMode = false
 
     var consumeHistoryEvent: Boolean = false
 
@@ -341,6 +342,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     fun setCalypsoMode(isCompatibleWithCalypso: Boolean) {
         isInCalypsoMode = isCompatibleWithCalypso
+    }
+
+    fun setGutenbergMode(isCompatibleWithGutenberg: Boolean) {
+        isInGutenbergMode = isCompatibleWithGutenberg
     }
 
     @SuppressLint("ResourceType")
@@ -860,6 +865,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         if (!isViewInitialized) return
 
         if (isOnSelectionListenerDisabled()) {
+            if (isInGutenbergMode) {
+                return
+            }
+
             enableOnSelectionListener()
             return
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -50,13 +50,13 @@ object Format {
     }
 
     @JvmStatic
-    fun removeSourceEditorFormatting(html: String, isCalypsoFormat: Boolean = false): String {
+    fun removeSourceEditorFormatting(html: String, isCalypsoFormat: Boolean = false, isGutenbergMode: Boolean = false): String {
         if (isCalypsoFormat) {
             val htmlWithoutSourceFormatting = toCalypsoHtml(html)
             val doc = Jsoup.parseBodyFragment(htmlWithoutSourceFormatting.replace("\n", "")).outputSettings(Document.OutputSettings().prettyPrint(false))
             return doc.body().html()
         } else {
-            return replaceAll(html, "\\s*<(/?($block)(.*?))>\\s*", "<$1>")
+            return if (isGutenbergMode) { html } else { replaceAll(html, "\\s*<(/?($block)(.*?))>\\s*", "<$1>") }
         }
     }
 


### PR DESCRIPTION
Up to now, Aztec's `consumeSelectionChangedEvent` flag is set up for activating a codepath where one `onSelectionChanged` event is getting bypassed. With this PR, more than one such events are bypassed. That's needed by Gutenberg where multiple events can be emitted while Gutenberg sets the text in Aztec. So, this PR introduces a "Gutenberg mode" in which all `onSelectionChanged` events are skipped while the flag is `true`.

While at it, using this new "Gutenberg mode" to avoid trimming text for spaces around the edges of html tags. That's needed in order to avoid trimming spaces after a Gutenberg block split.

Following WPAndroid PR : https://github.com/wordpress-mobile/WordPress-Android/pull/9871