### PR TITLE
Update CHANGELOG and README for v1.3.27 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [v1.3.27](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.27)
+### Fixed
+- Gutenberg fixes:
+  * Suppress multiple onSelectionChanged events when listener is disabled #817
+  * Avoid trimming spaces around html block elemts
+
+
 ## [v1.3.26](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.26)
 ### Fixed
 - DynamicLayout Crash #813

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.26')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.27')
 }
 ```
 


### PR DESCRIPTION
Update README.md and CHANGELOG.md in preparation for a v1.3.27 release.

This is a trivial PR for the release process so, will self-merge when CI passes.