### PR TITLE
CircleCI: Update Orb to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@0.0.21
+  android: wordpress-mobile/android@0.0.27
 
 jobs:
   Lint:


### PR DESCRIPTION
This updates the Orb to the latest to include the latest improvements. In particular, https://github.com/wordpress-mobile/circleci-orbs/pull/18 ensures that there is no chance of leaking credentials from Firebase Test Lab runs.

It is expected that the connected tests will fail until the credentials are updated.

Related to https://github.com/wordpress-mobile/WordPress-Android/pull/9975