### PR TITLE
[GB-Mobile Integration] Fix for Backspace does not outdent nested list item

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -501,10 +501,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             if (isHandlingBackspaceEvent) {
                 // It's already handling a backspace event. Do nothing.
             } else if (end != 0 || start != 0) {
-                // Not a backspace event
+                // Not a text erase event
             } else if (selectionStart != selectionEnd) {
                 // there is something selected on the editor, let's make Aztec do the work
             } else if (onAztecKeyListener != null) {
+                // There is a listener set, let's use it
                 isHandlingBackspaceEvent = true
 
                 // Prevent the forced backspace from being added to the history stack
@@ -513,6 +514,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 handleBackspaceAndEnter(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL), start, end, dstart, dend)
                 isHandlingBackspaceEvent = false
             } else if (dstart == 0 && dend == 0) {
+                // Fallback to the old Aztec implementation that does check only the beginnning of the field
                 // Make sure we're at the beginning of the editor field
                 isHandlingBackspaceEvent = true
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -499,12 +499,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         val backspaceDetector = InputFilter { source, start, end, dest, dstart, dend ->
             if (isHandlingBackspaceEvent) {
-               // It's already handling a backspace event. Do nothing.
+                // It's already handling a backspace event. Do nothing.
             } else if (end != 0 || start != 0) {
                 // Not a backspace event
-            } else if (selectionStart != 0 || selectionEnd != 0) {
+            } else if (selectionStart != selectionEnd) {
                 // there is something selected on the editor, let's make Aztec do the work
-            } else if(onAztecKeyListener != null) {
+            } else if (onAztecKeyListener != null) {
                 isHandlingBackspaceEvent = true
 
                 // Prevent the forced backspace from being added to the history stack


### PR DESCRIPTION
This PR is the first step required to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1027

@mkevins has reported the problem with backspace and nested lists, and already proposed a solution [here](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1027#issuecomment-495557004). In this PR I started from scratch, but ended up with similar code.

Please, test this PR by pointing the experimental branch here https://github.com/wordpress-mobile/gutenberg-mobile/tree/experimental/fix-backspace-outdent-on-nested-lists to the full hash `fbf98c1af64552a01f1ae203d295b79b8362c629` of this branch.

- Test both the Google GBoard and the AOSP keyboard.
- Also test on real devices, and emulators by using the external OS keyboard as input (in order to simulate HW keyboard).

### Review
@mkevins 


Note: I run both kotlin unit tests, and Java connected tests on this PR without finding any issue.