### PR TITLE
Fix/ime iob fix

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -668,6 +668,15 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     override fun onCreateInputConnection(outAttrs: EditorInfo) : InputConnection {
+        // limiting the reuseInputConnection fix for Anroid 8.0.0 for now
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
+            return handleReuseInputConnection(outAttrs)
+        }
+
+        return super.onCreateInputConnection(outAttrs)
+    }
+
+    private fun handleReuseInputConnection(outAttrs: EditorInfo) : InputConnection {
         // initialize inputConnectionEditorInfo
         if (inputConnectionEditorInfo == null) {
             inputConnectionEditorInfo = outAttrs
@@ -688,7 +697,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 // an InputConnectionWrapper of a null target
                 return localInputConnection
             }
-            // if non null, wrap the new InputConnection around our wrapper
+            // if non null, wrap the new InputConnection around our wrapper (used for logging purposes only)
             //inputConnection = AztecTextInputConnectionWrapper(localInputConnection, this)
             inputConnectionRef = WeakReference(localInputConnection)
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -121,6 +121,7 @@ import org.wordpress.aztec.watchers.event.text.BeforeTextChangedEventData
 import org.wordpress.aztec.watchers.event.text.OnTextChangedEventData
 import org.wordpress.aztec.watchers.event.text.TextWatcherEvent
 import org.xml.sax.Attributes
+import java.lang.ref.WeakReference
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.ArrayList
@@ -294,7 +295,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private var focusOnVisible = true
 
-    var inputConnection: InputConnection? = null
+    var inputConnectionRef: WeakReference<InputConnection>? = null
     var inputConnectionEditorInfo: EditorInfo? = null
 
     interface OnSelectionChangedListener {
@@ -673,7 +674,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         // now init the InputConnection, or replace if EditorInfo contains anything different
-        if (inputConnection == null || !EditorInfoUtils.areEditorInfosTheSame(outAttrs, inputConnectionEditorInfo!!)) {
+        if (inputConnectionRef?.get() == null || !EditorInfoUtils.areEditorInfosTheSame(outAttrs, inputConnectionEditorInfo!!)) {
             // we have a new InputConnection to create, save the new EditorInfo data and create it
             // we make a copy of the parameters being received, because super.onCreateInputConnection may make changes
             // to EditorInfo params being sent to it, and we want to preserve the same data we received in order
@@ -689,11 +690,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             }
             // if non null, wrap the new InputConnection around our wrapper
             //inputConnection = AztecTextInputConnectionWrapper(localInputConnection, this)
-            inputConnection = localInputConnection
+            inputConnectionRef = WeakReference(localInputConnection)
         }
 
-        // returnn the existing inputConnection
-        return inputConnection!!
+        // return the existing inputConnection
+        return inputConnectionRef?.get()!!
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/ime/EditorInfoUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/ime/EditorInfoUtils.kt
@@ -1,0 +1,55 @@
+package org.wordpress.aztec.ime
+
+import android.os.Build
+import android.view.inputmethod.EditorInfo
+import java.util.Arrays
+
+object EditorInfoUtils {
+    @JvmStatic
+    fun areEditorInfosTheSame(ed1: EditorInfo, ed2: EditorInfo): Boolean {
+        if (ed1 == ed2) {
+            return true
+        }
+
+        if (ed1.actionId == ed2.actionId
+                && (ed1.actionLabel != null && ed1.actionLabel.equals(ed2.actionLabel) || ed1.actionLabel == null && ed2.actionLabel == null)
+                && ed1.inputType == ed2.inputType
+                && ed1.imeOptions == ed2.imeOptions
+                && (ed1.privateImeOptions != null && ed1.privateImeOptions.equals(ed2.privateImeOptions) || ed1.privateImeOptions == null && ed2.privateImeOptions == null)
+                && ed1.initialSelStart == ed2.initialSelStart
+                && ed1.initialSelEnd == ed2.initialSelEnd
+                && ed1.initialCapsMode == ed2.initialCapsMode
+                && ed1.fieldId == ed2.fieldId
+        ) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                // specific comparisons here
+                if (ed1.contentMimeTypes != null && ed2.contentMimeTypes != null) {
+                    return Arrays.equals(ed1.contentMimeTypes, ed2.contentMimeTypes)
+                }
+            }
+            return true
+        }
+        return false
+    }
+
+    @JvmStatic
+    fun copyEditorInfo(ed1: EditorInfo) : EditorInfo {
+        val copy = EditorInfo()
+        copy.actionId = ed1.actionId
+        copy.actionLabel = ed1.actionLabel?.toString()
+        copy.inputType = ed1.inputType
+        copy.imeOptions = ed1.imeOptions
+        copy.privateImeOptions = ed1.privateImeOptions?.toString()
+        copy.initialSelStart = ed1.initialSelStart
+        copy.initialSelEnd = ed1.initialSelEnd
+        copy.initialCapsMode = ed1.initialCapsMode
+        copy.fieldId = ed1.fieldId
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            // specific comparisons here
+            if (ed1.contentMimeTypes != null) {
+                copy.contentMimeTypes = Arrays.copyOf(ed1.contentMimeTypes, ed1.contentMimeTypes.size)
+            }
+        }
+        return copy
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
@@ -41,7 +41,9 @@ class CssUnderlinePlugin : ISpanPostprocessor, ISpanPreprocessor {
                     if (hiddenSpan.TAG == SPAN_TAG) {
                         val parentStyle = hiddenSpan.attributes.getValue(CssStyleFormatter.STYLE_ATTRIBUTE)
                         val childStyle = calypsoUnderlineSpan.attributes.getValue(CssStyleFormatter.STYLE_ATTRIBUTE)
-                        hiddenSpan.attributes.setValue(CssStyleFormatter.STYLE_ATTRIBUTE, CssStyleFormatter.mergeStyleAttributes(parentStyle, childStyle))
+                        if (parentStyle != null && childStyle != null) {
+                            hiddenSpan.attributes.setValue(CssStyleFormatter.STYLE_ATTRIBUTE, CssStyleFormatter.mergeStyleAttributes(parentStyle, childStyle))
+                        }
 
                         // remove the extra child span
                         spannable.removeSpan(calypsoUnderlineSpan)


### PR DESCRIPTION
### Fix

This PR aims at fixing or alleviating the crash being observed in https://github.com/wordpress-mobile/WordPress-Android/issues/9904

#### Preamble
Long story short as per what I could observe: each time focus is changed, or when the input method is changed (for example, you change the keyboard or tap the microphone on the keyboard), this will create a new input method and the actively focused EditText will be called on its `onCreateInputConnection`. Here, the base implementation (same one as AztecText is using, as it's not overriding that method) will create a new instance and return that one.

By using an `InputConnectionWrapper` and plenty of logs I was able to identify the following situation:

```
2019-07-24 09:36:09.837 19641-19641/org.wordpress.aztec E/WordPress-EDITOR: ATICW beginBatchEdit
 2019-07-24 09:36:09.996 19641-19641/org.wordpress.aztec E/WordPress-EDITOR: ATICW constructor
 2019-07-24 09:36:10.058 19641-19641/org.wordpress.aztec W/IInputConnectionWrapper: endBatchEdit on inactive InputConnection
 2019-07-24 09:36:10.061 19641-19641/org.wordpress.aztec E/WordPress-EDITOR: ATICW constructor
 2019-07-24 09:36:10.063 19641-19641/org.wordpress.aztec W/IInputConnectionWrapper: beginBatchEdit on inactive InputConnection
 2019-07-24 09:36:10.063 19641-19641/org.wordpress.aztec W/IInputConnectionWrapper: getTextBeforeCursor on inactive InputConnection
 2019-07-24 09:36:10.068 19641-19659/org.wordpress.aztec D/EGL_emulation: eglMakeCurrent: 0xa6b04240: ver 3 0 (tinfo 0xa6b03280)
 2019-07-24 09:36:10.079 19641-19641/org.wordpress.aztec W/IInputConnectionWrapper: getTextAfterCursor on inactive InputConnection
```

Then we have this: a `beginBatchEdit` is followed by a constructor call. This means, a new `InputConnection` is going to be established, but also a batch edit has already started on the InputConnection that is being detached. 
This was followed by many entries like this one:
```
2019-07-24 09:36:10.079 19641-19641/org.wordpress.aztec W/IInputConnectionWrapper: getTextAfterCursor on inactive InputConnection
```

At some point this can be followed by an IndexOutOfBounds crash, for example looking in the logs here:

```
2019-07-24 16:28:41.219 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW beginBatchEdit
2019-07-24 16:28:41.219 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW commitText: newCursorPosition: 1 - text: $ - key.length(): 1
2019-07-24 16:28:41.219 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW commitText: newCursorPosition: 1 - text: $
2019-07-24 16:28:41.219 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW commitText: previousSelectionStart: 718 - previousSelectionEnd: 718
2019-07-24 16:28:41.290 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW constructor
2019-07-24 16:28:41.358 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW commitText: currentSelectionStart: 718
2019-07-24 16:28:41.361 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW commitText: noPreviousSelection: true
2019-07-24 16:28:41.361 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW commitText: cursorDidNotMove: true
2019-07-24 16:28:41.361 12148-12148/org.wordpress.aztec E/WordPress-EDITOR: ATICW commitText: cursorMovedBackwardsOrAtBeginningOfInput: false
2019-07-24 16:28:41.361 12148-12148/org.wordpress.aztec W/IInputConnectionWrapper: endBatchEdit on inactive InputConnection

```
These logs were added by using an `InputConnectionWrapper` that didn't affect behavior (just added the logs).

This piece here shows an insertion of a $ character at position 718. When an insertion / addition happens, the new length should be added by one and the new cursor position should be also augmented, as it will stay to the right of the appended/inserted character. The problem we can see here in that log snippet is newCursorPosition should have moved the selection by one (1), but still previousSelectionStart and previousSelectionEnd is 718, and currentSelectionStart after moving should be 718+1=719, but instead it's still 718. See how things can go wrong there? On the other runs where no new constructor call is seen in between, things are added up correctly.

#### What this PR does

This PR just keeps a reference for the latest `InputConnection` created, as long as no new attributes for a new `InputConnection` to be created are sent (so we're working under the premise that there is no need to create a new `InputConnection` if the parameters passed are the same as per the current one).


### Test
have been trying to test this using monkey https://developer.android.com/studio/test/monkey, you can test it the same way issuing a command like this one from Terminal:

`adb -s emulator-5554 shell monkey -p org.wordpress.aztec -v 10000`


To make conditions more convenient for this crash to happen:
1. disable sourceView so there are no switches
https://github.com/wordpress-mobile/AztecEditor-Android/blob/develop/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt#L748
(just comment out that line)
2. disable suggestions so we don't hit the SuggestionPopUP crash first https://github.com/wordpress-mobile/AztecEditor-Android/issues/833
`android:inputType="textNoSuggestions"` add this to the xml https://github.com/wordpress-mobile/AztecEditor-Android/blob/develop/app/src/main/res/layout-v17/activity_main.xml#L26
3. clean wiped fresh Android 8.0 image emulator, clean your clipboard memory as well (issue `echo -n '' | pbcopy` on a terminal window), then run:
4. run `adb -s emulator-5554 shell monkey -p org.wordpress.aztec -v 10000`

Alternatively, you can also try [pinning the Aztec demo screen](https://support.google.com/android/answer/6118421?hl=en) so no unneeded app switches  happen, and in this case do not disable sourceView, as you'll want to have focus to alternate so the new InputConnection is created when switching between EditText:
1. Run and pin the AztecDemo app (check [this](https://support.google.com/android/answer/6118421?hl=en))
2. Folow steps 2-4 above.

If you need to kill the monkey process running in the device/emulator, issue the following command:
`adb shell ps | awk '/com.android.commands.monkey/ { system("adb shell kill " $2) }'`

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.