### PR TITLE
Span overlapping on Chromebooks

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -80,9 +80,10 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
         if (sizeRect.width() > 0) {
             return sizeRect.width()
         } else {
-            // This code was crucial to get good results for overlapping issue
-            val size = super.getSize(paint, text, start, end, metrics)
-            return size
+            // This block of code was added in order to resolve
+            // span overlap issue on Chromebook devices
+            // -> https://github.com/wordpress-mobile/AztecEditor-Android/pull/835
+            return super.getSize(paint, text, start, end, metrics)
         }
     }
 
@@ -94,9 +95,10 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
         val layout = textView?.layout
 
         if (measuring || layout == null) {
-            // if we're in pre-layout phase, just return a tiny rect
-            // It looks like if we return 1 for right and bottom
-            // it will cause overlap
+            // if we're in pre-layout phase, just return an empty rect
+            // Update: Previous version of this code was: return Rect(0, 0, 1, 1)
+            // but we needed to change it as it caused span overlap issue on Chromebook
+            // devices -> https://github.com/wordpress-mobile/AztecEditor-Android/pull/835
             return Rect(0, 0, 0, 0)
         }
 
@@ -114,14 +116,6 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
         if (width > maxWidth) {
             width = maxWidth
             height = (width / aspectRatio).toInt()
-        }
-
-        // Note: This is not a solution just a temp code
-        // to demonstrate that for some reason value 36 ( which is got
-        // from imageDrawable?.intrinsicHeight ) is causing overlap problem
-        // or I think it's causing :D
-        if (height == 36) {
-            return Rect(0, 0, 0, 0)
         }
 
         imageDrawable?.bounds = Rect(0, 0, width, height)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -68,8 +68,8 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
 
     override fun getSize(paint: Paint?, text: CharSequence?, start: Int, end: Int, metrics: Paint.FontMetricsInt?): Int {
         val sizeRect = adjustBounds(start)
+        if (metrics != null && sizeRect.height() > 0) {
 
-        if (metrics != null && sizeRect.width() > 0) {
             metrics.ascent = - sizeRect.height()
             metrics.descent = 0
 
@@ -77,7 +77,13 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
             metrics.bottom = 0
         }
 
-        return sizeRect.width()
+        if (sizeRect.width() > 0) {
+            return sizeRect.width()
+        } else {
+            // This code was crucial to get good results for overlapping issue
+            val size = super.getSize(paint, text, start, end, metrics)
+            return size
+        }
     }
 
     fun adjustBounds(start: Int): Rect {
@@ -89,7 +95,9 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
 
         if (measuring || layout == null) {
             // if we're in pre-layout phase, just return a tiny rect
-            return Rect(0, 0, 1, 1)
+            // It looks like if we return 1 for right and bottom
+            // it will cause overlap
+            return Rect(0, 0, 0, 0)
         }
 
         val line = layout.getLineForOffset(start)
@@ -98,7 +106,6 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
 
         // use the original bounds if non-zero, otherwise try the intrinsic sizes. If those are not available then
         //  just assume maximum size.
-
         var width = if ((imageDrawable?.intrinsicWidth ?: -1) > -1) imageDrawable?.intrinsicWidth ?: -1
         else maxWidth
         var height = if ((imageDrawable?.intrinsicHeight ?: -1) > -1) imageDrawable?.intrinsicHeight ?: -1
@@ -107,6 +114,14 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
         if (width > maxWidth) {
             width = maxWidth
             height = (width / aspectRatio).toInt()
+        }
+
+        // Note: This is not a solution just a temp code
+        // to demonstrate that for some reason value 36 ( which is got
+        // from imageDrawable?.intrinsicHeight ) is causing overlap problem
+        // or I think it's causing :D
+        if (height == 36) {
+            return Rect(0, 0, 0, 0)
         }
 
         imageDrawable?.bounds = Rect(0, 0, width, height)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -82,7 +82,7 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
         } else {
             // This block of code was added in order to resolve
             // span overlap issue on Chromebook devices
-            // -> https://github.com/wordpress-mobile/AztecEditor-Android/pull/835
+            // -> https://github.com/wordpress-mobile/AztecEditor-Android/issues/836
             return super.getSize(paint, text, start, end, metrics)
         }
     }
@@ -98,7 +98,7 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
             // if we're in pre-layout phase, just return an empty rect
             // Update: Previous version of this code was: return Rect(0, 0, 1, 1)
             // but we needed to change it as it caused span overlap issue on Chromebook
-            // devices -> https://github.com/wordpress-mobile/AztecEditor-Android/pull/835
+            // devices -> https://github.com/wordpress-mobile/AztecEditor-Android/issues/836
             return Rect(0, 0, 0, 0)
         }
 


### PR DESCRIPTION
### Fixes: https://github.com/wordpress-mobile/AztecEditor-Android/issues/836

### Summary: 
Text entered into a post below an image is misplaced after free-form resizing the window

Steps to reproduce:
1. Start the Demo Aztec application
2. Play a little bit with window resizing (resize the app couple of times)

Result: Span text will overlap span image

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.