### PR TITLE
Fix breaking layout on slow window resizing.

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -452,6 +452,17 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         isViewInitialized = true
     }
 
+     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        // layout is changing when app screen is resized (on Chromebooks, etc.)
+        // we need to refresh text to reflect visual changes
+        if (changed) {
+            post {
+                refreshText(false)
+            }
+        }
+        super.onLayout(changed, left, top, right, bottom)
+    }
+
     // Setup the keyListener(s) for Backspace and Enter key.
     // Backspace: If listener does return false we remove the style here
     // Enter: Ask the listener if we need to insert or not the char

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -452,7 +452,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         isViewInitialized = true
     }
 
-     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         // layout is changing when app screen is resized (on Chromebooks, etc.)
         // we need to refresh text to reflect visual changes
         if (changed) {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -648,7 +648,7 @@ class AztecToolbarTest {
     @Throws(Exception::class)
     fun emptySelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
-        editText.setText("")
+        editText.fromHtml("", false)
 
         Assert.assertTrue(TestUtils.safeEmpty(editText))
 


### PR DESCRIPTION
### Fixes #837


### Test
1. Open the Aztec demo app on Chromebook or Emulator
2. Slowly resize the window.
3. Make sure text layout is not breaking in weird ways.

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.