### PR TITLE
Fixed cursor size on new paragraph line

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/EndOfParagraphMarker.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/EndOfParagraphMarker.kt
@@ -4,6 +4,7 @@ import android.graphics.Paint
 import android.text.Spanned
 import android.text.style.LineHeightSpan
 import android.text.style.UpdateLayout
+import org.wordpress.aztec.Constants.ZWJ_CHAR
 
 // Used to mark newline at the end of calypso paragraphs
 class EndOfParagraphMarker(var verticalPadding: Int = 0) : LineHeightSpan, UpdateLayout {
@@ -17,7 +18,11 @@ class EndOfParagraphMarker(var verticalPadding: Int = 0) : LineHeightSpan, Updat
         if (spanned.getSpans(spanEnd, spanEnd, AztecQuoteSpan::class.java).any { spanned.getSpanEnd(it) == spanEnd }) {
             actualPadding = 0
         } else {
-            actualPadding = verticalPadding * 2
+            actualPadding = if (spanned.length >= spanEnd && spanned[spanEnd - 1] == ZWJ_CHAR) {
+                0
+            } else {
+                verticalPadding * 2
+            }
         }
 
         if (end == spanEnd) {


### PR DESCRIPTION
### Fixes #839

This PR fixes the issue with cursor size when you press Enter after typing a text.

### Test
1. Set editor into Calypso mode.
2. Open demo app and clear content of the editor.
3. Type some text and press Enter
4. Notice that the cursor on a new line is of the correct size.


Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.