### PR TITLE
Add the ability to signal redo/undo events via History listener

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -19,9 +19,6 @@ import android.os.Bundle
 import android.os.Environment
 import android.os.Handler
 import android.provider.MediaStore
-import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
-import androidx.core.content.ContextCompat
-import androidx.core.content.FileProvider
 import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.Menu
@@ -32,6 +29,9 @@ import android.widget.PopupMenu
 import android.widget.ToggleButton
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.PermissionUtils
@@ -583,6 +583,10 @@ open class MainActivity : AppCompatActivity(),
         invalidateOptionsHandler.postDelayed(invalidateOptionsRunnable, resources.getInteger(android.R.integer.config_mediumAnimTime).toLong())
     }
 
+    override fun onUndo() {}
+
+    override fun onRedo() {}
+
     private fun onCameraPhotoMediaOptionSelected() {
         if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_CAMERA_PHOTO_PERMISSION_REQUEST_CODE)) {
             val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
@@ -728,6 +732,7 @@ open class MainActivity : AppCompatActivity(),
     }
 
     override fun onToolbarFormatButtonClicked(format: ITextFormat, isKeyboardShortcut: Boolean) {
+        ToastUtils.showToast(this, format.toString())
     }
 
     override fun onToolbarHeadingButtonClicked() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -121,6 +121,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
         editText.requestFocus()
 
         updateActions()
+        historyListener?.onRedo()
     }
 
     fun undo(editText: EditText) {
@@ -143,6 +144,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
         editText.requestFocus()
 
         updateActions()
+        historyListener?.onUndo()
     }
 
     private fun setTextFromHistory(editText: EditText) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/IHistoryListener.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/IHistoryListener.kt
@@ -3,4 +3,6 @@ package org.wordpress.aztec
 interface IHistoryListener {
     fun onRedoEnabled()
     fun onUndoEnabled()
+    fun onUndo()
+    fun onRedo()
 }


### PR DESCRIPTION
This PR does add the ability to signal undo/redo events via History listener to host apps.


Context: It will be used in wp-android to bump analytics about undo/redo actions in the editor


### Test
1. Start the demo app
2. Add a breakpoint [here](https://github.com/wordpress-mobile/AztecEditor-Android/compare/add/undo-redo-events-to-historyListener?expand=1#diff-3af4b1228dfbdd8f17a66315f599bfc0R147)
3. Write something in the editor, and tap Undo. 
4. Make sure Undo is properly called


Make sure strings will be translated:

- [ x ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.