### PR TITLE
Add task to publish artifacts to local maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$gradlePluginVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'digital.wup:android-maven-publish:3.6.2'
     }
 }
 
@@ -37,6 +38,21 @@ task clean(type: Delete) {
 }
 
 subprojects {
+
+    if (project.name != 'app') {
+        apply plugin: 'digital.wup.android-maven-publish'
+        publishing {
+            publications {
+                mavenAar(MavenPublication) {
+                    groupId 'com.github.wordpress-mobile.WordPress-Aztec-Android'
+                    artifactId project.name
+                    version '123.456.789'
+                    from components.android
+                }
+            }
+        }
+    }
+
     configurations {
         ktlint
     }


### PR DESCRIPTION
Add the ability to easily publish the Android libraries in this repo to a local maven repo for testing how changes integrate with other projects. I added this for the specific use case of testing how changes in the aztec module integrate with the gutenberg-mobile project.

I do not think this change will have any affect on Jitpack publishing this repo since Jitpack uses the tag for the release version numbers. I am not particularly familiar with JitPack though, so let me know if you think there might be any issues.

### Test
1. Make a change to one of these libraries. (I like adding a log message to `AztecText::fromHtml` and which is called frequently in the gutenberg-mobile project)
2. Run `./gradlew publishToMavenLocal` to publish all of the libraries from this repo to your local maven repository.
3. In a project that depends on these libraries (for example, [gutenberg-mobile](https://github.com/wordpress-mobile/gutenberg-mobile), 
    1. Update the version of the aztec dependencies to be `123.456.789` (in gutenberg-mobile, you would do that [here](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/react-native-aztec/android/build.gradle#L15)); and
    2. add `mavenLocal()` to the **_top_** of the relevant repository block (in gutenberg-mobile, you would do that [here](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/react-native-aztec/android/build.gradle#L81)). It is important that `mavenLocal()` is at the top so that gradle checks there first for the dependency before going to, for example, jcenter.
4. Build and run that project, and check that the change you made to the library in this repo is reflected.

Make sure strings will be translated:

- [X] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.