### PR TITLE
Allow paragraph spans that do not extend AlignmentSpan

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -44,6 +44,7 @@ import org.wordpress.aztec.spans.AztecMediaSpan
 import org.wordpress.aztec.spans.AztecURLSpan
 import org.wordpress.aztec.spans.AztecVisualLinebreak
 import org.wordpress.aztec.spans.CommentSpan
+import org.wordpress.aztec.spans.IAztecAlignmentSpan
 import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
 import org.wordpress.aztec.spans.IAztecInlineSpan
@@ -415,7 +416,7 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
     private fun withinNestable(out: StringBuilder, text: Spanned, start: Int, end: Int,
                                nestable: IAztecParagraphStyle, parents: ArrayList<IAztecNestable>?, nestingLevel: Int) {
 
-        if (nestable.shouldParseAlignmentToHtml()) {
+        if (nestable is IAztecAlignmentSpan && nestable.shouldParseAlignmentToHtml()) {
             CssStyleFormatter.removeStyleAttribute(nestable.attributes, CssStyleFormatter.CSS_TEXT_ALIGN_ATTRIBUTE)
 
             nestable.align?.let {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -45,7 +45,7 @@ import org.wordpress.aztec.spans.HiddenHtmlBlock
 import org.wordpress.aztec.spans.HiddenHtmlSpan
 import org.wordpress.aztec.spans.IAztecAttributedSpan
 import org.wordpress.aztec.spans.IAztecNestable
-import org.wordpress.aztec.spans.ParagraphSpan
+import org.wordpress.aztec.spans.createParagraphSpan
 import org.wordpress.aztec.util.getLast
 import org.xml.sax.Attributes
 import java.util.ArrayList
@@ -118,7 +118,7 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
                 return true
             }
             PARAGRAPH -> {
-                handleElement(output, opening, ParagraphSpan(nestingLevel, AztecAttributes(attributes)))
+                handleElement(output, opening, createParagraphSpan(nestingLevel, AztecAttributes(attributes)))
                 return true
             }
             LINE -> {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -20,12 +20,13 @@ import org.wordpress.aztec.spans.AztecOrderedListSpan
 import org.wordpress.aztec.spans.AztecPreformatSpan
 import org.wordpress.aztec.spans.AztecQuoteSpan
 import org.wordpress.aztec.spans.AztecUnorderedListSpan
+import org.wordpress.aztec.spans.IAztecAlignmentSpan
 import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.spans.IAztecCompositeBlockSpan
 import org.wordpress.aztec.spans.IAztecLineBlockSpan
 import org.wordpress.aztec.spans.IAztecNestable
-import org.wordpress.aztec.spans.IAztecParagraphStyle
 import org.wordpress.aztec.spans.ParagraphSpan
+import org.wordpress.aztec.spans.createParagraphSpan
 import org.wordpress.aztec.util.SpanWrapper
 import java.util.Arrays
 
@@ -279,21 +280,6 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
         }
     }
 
-    fun getOuterBlockSpanType(textFormat: ITextFormat): Class<out IAztecBlockSpan> {
-        when (textFormat) {
-            AztecTextFormat.FORMAT_ORDERED_LIST -> return AztecOrderedListSpan::class.java
-            AztecTextFormat.FORMAT_UNORDERED_LIST -> return AztecUnorderedListSpan::class.java
-            AztecTextFormat.FORMAT_QUOTE -> return AztecQuoteSpan::class.java
-            AztecTextFormat.FORMAT_HEADING_1,
-            AztecTextFormat.FORMAT_HEADING_2,
-            AztecTextFormat.FORMAT_HEADING_3,
-            AztecTextFormat.FORMAT_HEADING_4,
-            AztecTextFormat.FORMAT_HEADING_5,
-            AztecTextFormat.FORMAT_HEADING_6 -> return AztecHeadingSpan::class.java
-            else -> return ParagraphSpan::class.java
-        }
-    }
-
     // TODO: Come up with a better way to init spans and get their classes (all the "make" methods)
     fun makeBlock(textFormat: ITextFormat, nestingLevel: Int, attrs: AztecAttributes = AztecAttributes()): List<IAztecBlockSpan> {
         when (textFormat) {
@@ -307,7 +293,7 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
             AztecTextFormat.FORMAT_HEADING_5,
             AztecTextFormat.FORMAT_HEADING_6 -> return Arrays.asList(AztecHeadingSpan(nestingLevel, textFormat, attrs, headerStyle))
             AztecTextFormat.FORMAT_PREFORMAT -> return Arrays.asList(AztecPreformatSpan(nestingLevel, attrs, preformatStyle))
-            else -> return Arrays.asList(ParagraphSpan(nestingLevel, attrs))
+            else -> return Arrays.asList(createParagraphSpan(nestingLevel, attrs))
         }
     }
 
@@ -335,7 +321,7 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
             AztecTextFormat.FORMAT_HEADING_5,
             AztecTextFormat.FORMAT_HEADING_6 -> makeBlockSpan(AztecHeadingSpan::class.java, textFormat, nestingLevel, attrs)
             AztecTextFormat.FORMAT_PREFORMAT -> makeBlockSpan(AztecPreformatSpan::class.java, textFormat, nestingLevel, attrs)
-            else -> ParagraphSpan(nestingLevel, attrs)
+            else -> createParagraphSpan(nestingLevel, attrs)
         }
     }
 
@@ -347,7 +333,7 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
             AztecQuoteSpan::class.java -> AztecQuoteSpan(nestingLevel, attrs, quoteStyle)
             AztecHeadingSpan::class.java -> AztecHeadingSpan(nestingLevel, textFormat, attrs, headerStyle)
             AztecPreformatSpan::class.java -> AztecPreformatSpan(nestingLevel, attrs, preformatStyle)
-            else -> ParagraphSpan(nestingLevel, attrs)
+            else -> createParagraphSpan(nestingLevel, attrs)
         }
     }
 
@@ -509,13 +495,13 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
 
             val alignment = getAlignment(textFormat,
                     editableText.subSequence(boundsOfSelectedText.start until boundsOfSelectedText.endInclusive))
-            editableText.setSpan(ParagraphSpan(nestingLevel, AztecAttributes(), alignment),
+            editableText.setSpan(createParagraphSpan(nestingLevel, AztecAttributes(), alignment),
                     boundsOfSelectedText.start, boundsOfSelectedText.endInclusive, Spanned.SPAN_PARAGRAPH)
         }
     }
 
-    private fun changeAlignment(it: IAztecParagraphStyle, blockElementType: ITextFormat?) {
-        val wrapper = SpanWrapper<IAztecParagraphStyle>(editableText, it)
+    private fun changeAlignment(it: IAztecAlignmentSpan, blockElementType: ITextFormat?) {
+        val wrapper = SpanWrapper(editableText, it)
         it.align = getAlignment(blockElementType, editableText.substring(wrapper.start until wrapper.end))
 
         editableText.setSpan(it, wrapper.start, wrapper.end, wrapper.flags)
@@ -905,10 +891,10 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
         return getAlignedSpans(textFormat, selStart, selEnd).isNotEmpty()
     }
 
-    private fun getAlignedSpans(textFormat: ITextFormat?, selStart: Int = selectionStart, selEnd: Int = selectionEnd): List<IAztecParagraphStyle> {
+    private fun getAlignedSpans(textFormat: ITextFormat?, selStart: Int = selectionStart, selEnd: Int = selectionEnd): List<IAztecAlignmentSpan> {
         if (selStart < 0 || selEnd < 0) return emptyList()
 
-        return editableText.getSpans(selStart, selEnd, IAztecParagraphStyle::class.java)
+        return editableText.getSpans(selStart, selEnd, IAztecAlignmentSpan::class.java)
                 .filter {
                     textFormat == null || it.align == getAlignment(textFormat,
                         editableText.substring(editableText.getSpanStart(it) until editableText.getSpanEnd(it)))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -6,6 +6,7 @@ import android.text.Layout
 import android.text.Spannable
 import android.text.style.ForegroundColorSpan
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.spans.IAztecAlignmentSpan
 import org.wordpress.aztec.spans.IAztecAttributedSpan
 import org.wordpress.aztec.spans.IAztecParagraphStyle
 import org.wordpress.aztec.util.ColorConverter
@@ -47,18 +48,20 @@ class CssStyleFormatter {
         }
 
         private fun processAlignment(blockSpan: IAztecParagraphStyle, text: Editable, start: Int, end: Int) {
-            val alignment = getStyleAttribute(blockSpan.attributes, CSS_TEXT_ALIGN_ATTRIBUTE)
-            if (!alignment.isBlank()) {
-                val direction = TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR
-                val isRtl = direction.isRtl(text, start, end - start)
+            if (blockSpan is IAztecAlignmentSpan) {
+                val alignment = getStyleAttribute(blockSpan.attributes, CSS_TEXT_ALIGN_ATTRIBUTE)
+                if (!alignment.isBlank()) {
+                    val direction = TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR
+                    val isRtl = direction.isRtl(text, start, end - start)
 
-                val align = when (alignment) {
-                    "right" -> if (isRtl) Layout.Alignment.ALIGN_NORMAL else Layout.Alignment.ALIGN_OPPOSITE
-                    "center" -> Layout.Alignment.ALIGN_CENTER
-                    else -> if (!isRtl) Layout.Alignment.ALIGN_NORMAL else Layout.Alignment.ALIGN_OPPOSITE
+                    val align = when (alignment) {
+                        "right" -> if (isRtl) Layout.Alignment.ALIGN_NORMAL else Layout.Alignment.ALIGN_OPPOSITE
+                        "center" -> Layout.Alignment.ALIGN_CENTER
+                        else -> if (!isRtl) Layout.Alignment.ALIGN_NORMAL else Layout.Alignment.ALIGN_OPPOSITE
+                    }
+
+                    blockSpan.align = align
                 }
-
-                blockSpan.align = align
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -8,6 +8,7 @@ import org.jsoup.nodes.Document
 import org.wordpress.aztec.spans.AztecQuoteSpan
 import org.wordpress.aztec.spans.AztecVisualLinebreak
 import org.wordpress.aztec.spans.EndOfParagraphMarker
+import org.wordpress.aztec.spans.IAztecAlignmentSpan
 import org.wordpress.aztec.spans.IAztecParagraphStyle
 import org.wordpress.aztec.spans.ParagraphSpan
 import org.wordpress.aztec.util.CleaningUtils
@@ -356,8 +357,12 @@ object Format {
 
             // we don't care about actual ParagraphSpan in calypso that don't have attributes or are empty (paragraphs are made from double newline)
             text.getSpans(0, text.length, ParagraphSpan::class.java)
-                    .filter { it.attributes.isEmpty() && it.align == null || text.getSpanStart(it) == text.getSpanEnd(it) - 1 }
-                    .forEach {
+                    .filter {
+                        val hasNoAttributes = it.attributes.isEmpty()
+                        val isAligned = it is IAztecAlignmentSpan && it.align != null
+                        val isEmpty = text.getSpanStart(it) == text.getSpanEnd(it) - 1
+                        (hasNoAttributes && !isAligned) || isEmpty
+                    }.forEach {
                         text.removeSpan(it)
                     }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -18,7 +18,7 @@ class AztecHeadingSpan @JvmOverloads constructor(
         override var attributes: AztecAttributes,
         var headerStyle: BlockFormatter.HeaderStyle = BlockFormatter.HeaderStyle(0),
         override var align: Layout.Alignment? = null
-    ) : MetricAffectingSpan(), IAztecLineBlockSpan, LineHeightSpan, UpdateLayout {
+    ) : MetricAffectingSpan(), IAztecAlignmentSpan, IAztecLineBlockSpan, LineHeightSpan, UpdateLayout {
     override val TAG: String
         get() = heading.tag
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
@@ -5,7 +5,8 @@ import org.wordpress.aztec.AztecAttributes
 
 class AztecListItemSpan(override var nestingLevel: Int,
                         override var attributes: AztecAttributes = AztecAttributes(),
-                        override var align: Layout.Alignment? = null) : IAztecCompositeBlockSpan {
+                        override var align: Layout.Alignment? = null
+    ) : IAztecAlignmentSpan, IAztecCompositeBlockSpan {
     override val TAG = "li"
 
     override var endBeforeBleed: Int = -1

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -10,8 +10,12 @@ import org.wordpress.aztec.Constants
 
 abstract class AztecListSpan(override var nestingLevel: Int,
                              var verticalPadding: Int = 0,
-                             override var align: Layout.Alignment? = null) : LeadingMarginSpan.Standard(0),
-        LineHeightSpan, UpdateLayout, IAztecBlockSpan {
+                             override var align: Layout.Alignment? = null
+    ) : LeadingMarginSpan.Standard(0),
+        LineHeightSpan,
+        UpdateLayout,
+        IAztecAlignmentSpan,
+        IAztecBlockSpan {
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -18,7 +18,13 @@ class AztecPreformatSpan(
         override var attributes: AztecAttributes = AztecAttributes(),
         var preformatStyle: BlockFormatter.PreformatStyle = BlockFormatter.PreformatStyle(0, 0f, 0, 0),
         override var align: Layout.Alignment? = null
-    ) : IAztecBlockSpan, LeadingMarginSpan, LineBackgroundSpan, LineHeightSpan, TypefaceSpan("monospace") {
+    ) : IAztecAlignmentSpan,
+        IAztecBlockSpan,
+        LeadingMarginSpan,
+        LineBackgroundSpan,
+        LineHeightSpan,
+        TypefaceSpan("monospace")
+    {
     override val TAG: String = "pre"
 
     override var endBeforeBleed: Int = -1

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -41,8 +41,14 @@ class AztecQuoteSpan(
         override var nestingLevel: Int,
         override var attributes: AztecAttributes = AztecAttributes(),
         var quoteStyle: BlockFormatter.QuoteStyle = BlockFormatter.QuoteStyle(0, 0, 0f, 0, 0, 0, 0),
-        override var align: Layout.Alignment? = null)
-    : QuoteSpan(), LineBackgroundSpan, IAztecBlockSpan, LineHeightSpan, UpdateLayout {
+        override var align: Layout.Alignment? = null
+    ) : QuoteSpan(),
+        LineBackgroundSpan,
+        IAztecAlignmentSpan,
+        IAztecBlockSpan,
+        LineHeightSpan,
+        UpdateLayout
+    {
 
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlBlock.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlBlock.kt
@@ -3,8 +3,9 @@ package org.wordpress.aztec.spans
 import android.text.Layout
 import org.wordpress.aztec.AztecAttributes
 
-class HiddenHtmlBlock(tag: String, override var attributes: AztecAttributes = AztecAttributes(),
-                      override var nestingLevel: Int) : IAztecBlockSpan {
+class HiddenHtmlBlock(tag: String,
+                      override var attributes: AztecAttributes = AztecAttributes(),
+                      override var nestingLevel: Int) : IAztecAlignmentSpan, IAztecBlockSpan {
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlSpan.kt
@@ -3,8 +3,9 @@ package org.wordpress.aztec.spans
 import android.text.Layout
 import org.wordpress.aztec.AztecAttributes
 
-class HiddenHtmlSpan(tag: String, override var attributes: AztecAttributes = AztecAttributes(),
-                     override var nestingLevel: Int) : IAztecParagraphStyle {
+class HiddenHtmlSpan(tag: String,
+                     override var attributes: AztecAttributes = AztecAttributes(),
+                     override var nestingLevel: Int) : IAztecAlignmentSpan, IAztecParagraphStyle {
     override var align: Layout.Alignment? = null
 
     override val TAG: String = tag

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecAlignmentSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecAlignmentSpan.kt
@@ -1,0 +1,13 @@
+package org.wordpress.aztec.spans
+
+import android.text.Layout
+import android.text.style.AlignmentSpan
+
+interface IAztecAlignmentSpan : AlignmentSpan {
+
+    var align: Layout.Alignment?
+
+    override fun getAlignment(): Layout.Alignment = align ?: Layout.Alignment.ALIGN_NORMAL
+
+    fun shouldParseAlignmentToHtml(): Boolean = true
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecParagraphStyle.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecParagraphStyle.kt
@@ -1,22 +1,8 @@
 package org.wordpress.aztec.spans
 
-import android.text.Layout
-import android.text.style.AlignmentSpan
-
 /**
  * Marks spans that are going to be parsed with {@link org.wordpress.aztec.AztecParser#withinHtml()}
  * Created in order to distinguish between spans that implement ParagraphStyle for various reasons, but have separate
  * parsing logic, like  {@link org.wordpress.aztec.spans.AztecHeadingSpan}
  **/
-interface IAztecParagraphStyle : AlignmentSpan, IAztecSpan, IAztecNestable {
-
-    var align: Layout.Alignment?
-
-    override fun getAlignment(): Layout.Alignment {
-        return align ?: Layout.Alignment.ALIGN_NORMAL
-    }
-
-    fun shouldParseAlignmentToHtml(): Boolean {
-        return true
-    }
-}
+interface IAztecParagraphStyle : IAztecSpan, IAztecNestable

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
@@ -3,14 +3,35 @@ package org.wordpress.aztec.spans
 import android.text.Layout
 import org.wordpress.aztec.AztecAttributes
 
-class ParagraphSpan(
+fun createParagraphSpan(nestingLevel: Int,
+                        attributes: AztecAttributes = AztecAttributes(),
+                        align: Layout.Alignment? = null) : IAztecBlockSpan =
+        if (align == null) {
+            ParagraphSpan(nestingLevel, attributes)
+        } else {
+            ParagraphSpanAligned(align, nestingLevel, attributes)
+        }
+
+/**
+ * This class is the same as the {@link ParagraphSpanAligned except it does not implement
+ * AlignmentSpan (via IAztecAlignmentSpan). This is necessary because IAztecParagraphSpan implements
+ * AlignmentSpan which has a getAlignment method that returns a non-null Layout.Alignment. Since this
+ * cannot be null it will always override the view's gravity. By having a class that does not implement
+ * AlignmentSpan the view's gravity can control.
+ */
+open class ParagraphSpan(
         override var nestingLevel: Int,
-        override var attributes: AztecAttributes = AztecAttributes(),
-        override var align: Layout.Alignment? = null
-    ) : IAztecBlockSpan {
+        override var attributes: AztecAttributes = AztecAttributes()
+) : IAztecBlockSpan {
 
     override var TAG: String = "p"
 
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 }
+
+class ParagraphSpanAligned(
+        override var align: Layout.Alignment?,
+        nestingLevel: Int,
+        attributes: AztecAttributes = AztecAttributes()
+) : ParagraphSpan(nestingLevel, attributes), IAztecAlignmentSpan

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.plugins.wpcomments.spans
 
-import android.text.Layout
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.spans.IAztecBlockSpan
 
@@ -10,7 +9,6 @@ class GutenbergCommentSpan(
         override var attributes: AztecAttributes = AztecAttributes()
 ) : IAztecBlockSpan {
     override val TAG: String = "wp:"
-    override var align: Layout.Alignment? = null
     override var startBeforeCollapse: Int = -1
     override var endBeforeBleed: Int = -1
 

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/spans/CaptionShortcodeSpan.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/spans/CaptionShortcodeSpan.kt
@@ -7,6 +7,7 @@ import android.text.style.StyleSpan
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Constants
+import org.wordpress.aztec.spans.IAztecAlignmentSpan
 import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.util.SpanWrapper
 
@@ -15,7 +16,7 @@ class CaptionShortcodeSpan @JvmOverloads constructor(override var attributes: Az
                                                      override var nestingLevel: Int,
                                                      private val aztecText: AztecText? = null,
                                                      override var align: Layout.Alignment? = null)
-    : StyleSpan(Typeface.ITALIC), IAztecBlockSpan {
+    : StyleSpan(Typeface.ITALIC), IAztecAlignmentSpan, IAztecBlockSpan {
 
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1


### PR DESCRIPTION
### Summary

This PR makes it possible to have a `ParagraphSpan` ("span" in the sense of implementing Android's `Spanned` interface, not html spans) that do not override the `View`'s gravity. The `View`'s gravity was being overriden because `ParagraphSpan` implemented [Android's `AlignmentSpan` interface](https://developer.android.com/reference/android/text/style/AlignmentSpan), which overrides gravity and sets the text's alignment. 

This PR allows paragraphs to not implement `AlignmentSpan` by removing `AlignmentSpan` from a relatively central/high position in our inheritance hierarchy and instead we now only implement that interface in the specific classes where alignment is needed. This allows the creation of two types of "paragraph" spans. One that does not implement `AlignmentSpan` (for use when there is no alignment set on the span, which is the case for Gutenberg which uses the view's gravity to control alignment) and one that does implement `AlignmentSpan` (for use when alignment is being set on the span, i.e., the classic editor). 

Although this PR changes quite a few files, many of those changed files are only updates to explicitly implement the `AlignmentSpan` interface since it is no longer a part of the inheritance hierarchy.  
 
### Description

#### Problem with using Android's text spans

Paragraph alignment for the gutenberg-mobile editor ([gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1266), [gutenberg PR](https://github.com/WordPress/gutenberg/pull/17577)) does not work on Android because Aztec assigns alignment to individual spans, whereas Gutenberg assigns alignment at the view/block level. Assigning alignment at the span level creates difficulties around things like the merging of two blocks with different alignments. You can end up with a single block that has the text using the alignment from its previous blocks. In other words, a single block may now contain two spans with different alignments, whereas Gutenberg blocks are only allowed to have a single alignment. 

In other circumstances, I ran into plain parsing errors where we would end up with invalid html output by Aztec (i.e. missing closing tags), or all the text for a given view would be lost. 

At a higher level, a `Span` doesn't seem like the right abstraction for setting alignment on the entire view like Gutenberg wants to do. 

#### Gravity instead of Span

Using the view's gravity to set alignment makes sense from the Gutenberg perspective both because it fits better with the single-alignment-for-the-entire-view approach of Gutenberg blocks and because it avoids a significant amount of complexity with parsing an alignment across multiple different spans but then outputting the appropriate alignment property for the entire view. In fact, using gravity for alignment means that, for purposes of gutenberg, AztecAndroid-Editor doesn't have to handle alignment at all—it just needs to not interfere with gravity (that's right, I'm talking about you `AlignmentSpan`). 

In fact, if we only had to support Gutenberg, we could just remove all alignment logic from this library since Gutenberg just uses the view's gravity. I actually think this may be the biggest point in favor of using gravity. We undoubtedly could find a way to make the `Span`-based approach work, but it would almost certainly involve a significant increase in complexity in Aztec's parsing. On the other hand, using gravity will allow us to (eventually) reduce the complexity in Aztec.

A final issue with the spans implementation is that they do not update the alignment of the view's placeholder text like gravity does.

FWIW, iOS is also [currently setting alignment at the view level for gutenberg-mobile](https://github.com/mchowning/gutenberg-mobile/commit/5dd53d9e09f01ce5348094a87a5734c517e3dead) instead of at the level of text spans, so gravity seems more consistent with that

#### Issue with gravity being overridden any time a `<p>` tag is present

The gravity-based approach did not work for paragraph blocks though because paragraph blocks use the `<p>` tag which gets parsed into a `ParagraphSpan` by Aztec (caption blocks do not send a `<p>` tag down to Aztec). `ParagraphSpans` implement the `AlignmentSpan` interface. When a `Span` implements `AlignmentSpan` it must return a non-null [`Layout.Alignment`](https://developer.android.com/reference/android/text/Layout.Alignment). Because there is not a "no alignment" `Layout.Alignment` value (the options are `ALIGN_NORMAL`, `ALIGN_CENTER`, `ALIGN_OPPOSITE`), we were defaulting any "no alignment" scenario to be `ALIGN_NORMAL` which would override the view's gravity for the purposes of the text's alignment.

Internally, the android system is checking for spans that implement the `AlignmentSpan` interface, so this PR removes the requirement that `ParagraphSpans` implement the `AlignmentSpan` interface. This was accomplished by removing the `AlignmentSpan` from the root `IAztecParagraphStyle` interface. The portion of that interface that dealt with the alignment was extracted to an `IAztecAlignmentSpan` interface (which implements `AlignmentSpan`). All the classes that previously implemented `IAztecParagraphStyle` (and there were quite a few of these) were updated to also implement `IAztecAlignmentSpan` in order to maintain previous behavior. 

In the case of the `ParagraphSpan`, I have broken that into two classes:

1. A base `ParagraphSpan` class that is the same as the previous `ParagraphSpan` class _except_ that it does not implement `IAztecAlignmentSpan`; and 
2. A `ParagraphSpanAligned` class that both extends `ParagraphSpan` and implements `IAztecAlignmentSpan`. 

I then created a builder method that has the same signature as the previous `ParagraphSpan` constructor, and returns the appropriate paragraph-based span class based on whether or not the method's `align` parameter is null. Because `AlignmentSpan`'s cannot have a null alignment we were previously treating null as equivalent to `ALIGN_NORMAL` (which is why the view's gravity was being overridden). The intended result is that anytime an align parameter is passed, the behavior will be exactly the same as before, and anytime a null align parameter is passed, you will get the same behavior _except for the fact that the returned paragraph span class will not implement `AlignemntSpan`_.

### Test

#### Test for Regressions

This PR makes changes to quite a few classes. Although these changes seem safe because they are mostly just refactoring to move the `AlignmentSpan` out of the class hierarchy and instead implementing `AlignmentSpan` by applying it to the specific classes that need it, there is certainly a risk of regressions and it would be a good idea to give a bit of a smoke test to the Aztec editor to make sure that there have not been any regressions.

#### Testing Alignment set via gravity

The code adding gravity based alignment to paragraph blocks is not merged into Gutenberg ([PR](https://github.com/WordPress/gutenberg/pull/17577)), but you can download an apk [here](https://cloudup.com/cPFaAXc_ZAP) of the WordPress that was created using this version of Aztec along with the code from [this PR](https://github.com/WordPress/gutenberg/pull/17577) to test the use of gravity to set alignment for paragraph blocks in the Gutenberg editor. 

### Make sure strings will be translated

- [X] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.