### PR TITLE
Issue/fix 854 cant properly insert text on android 7

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -452,17 +452,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         isViewInitialized = true
     }
 
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        // layout is changing when app screen is resized (on Chromebooks, etc.)
-        // we need to refresh text to reflect visual changes
-        if (changed) {
-            post {
-                refreshText(false)
-            }
-        }
-        super.onLayout(changed, left, top, right, bottom)
-    }
-
     // Setup the keyListener(s) for Backspace and Enter key.
     // Backspace: If listener does return false we remove the style here
     // Enter: Ask the listener if we need to insert or not the char

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -648,7 +648,7 @@ class AztecToolbarTest {
     @Throws(Exception::class)
     fun emptySelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
-        editText.fromHtml("", false)
+        editText.fromHtml("")
 
         Assert.assertTrue(TestUtils.safeEmpty(editText))
 


### PR DESCRIPTION
### Fix https://github.com/wordpress-mobile/AztecEditor-Android/issues/854 and #853 

This quick fix is revert of: https://github.com/wordpress-mobile/AztecEditor-Android/pull/838
as I think that at this point the bug in the editor has higher priority then fix for Chromebook device.

### Test
Device: Nexus 5x Android 7 or Android 8

1. Open AztecEditor app
2. Make sure that you have full test content (which is provided by default)
3. Put the cursor on e.g. 'Heading 2' text and try deleting it with backspace or adding a new text

Expected result: Backspace should work as expected and there shouldn't be any lagging/problems when adding a new text.

### Review
@daniloercoli @khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.