### PR TITLE
release/1.3.30.1 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [1.3.30.1](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.30.1)
+### Fixed
+- Hot-fix for lag deleting and inserting text #853 and #854
+
+# Changelog
 ## [1.3.30](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.30)
 ### Added
 - Added the ability to signal undo/redo events to host app

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.30')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.30.1')
 }
 ```
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -452,17 +452,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         isViewInitialized = true
     }
 
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        // layout is changing when app screen is resized (on Chromebooks, etc.)
-        // we need to refresh text to reflect visual changes
-        if (changed) {
-            post {
-                refreshText(false)
-            }
-        }
-        super.onLayout(changed, left, top, right, bottom)
-    }
-
     // Setup the keyListener(s) for Backspace and Enter key.
     // Backspace: If listener does return false we remove the style here
     // Enter: Ask the listener if we need to insert or not the char

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -648,7 +648,7 @@ class AztecToolbarTest {
     @Throws(Exception::class)
     fun emptySelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
-        editText.fromHtml("", false)
+        editText.fromHtml("")
 
         Assert.assertTrue(TestUtils.safeEmpty(editText))
 


### PR DESCRIPTION
This is an hotfix that will be included in wp-android 13.3 to fix the delay and lag on Aztec.

Make sure the delay is not present anymore on demo content on Android 8 devices.