### PR TITLE
Update CHANGELOG and README for v.1.3.33 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
- ## [1.3.32](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.32)
- ### Fixed
- - Allow paragraph spans that do not extend AlignmentSpan (#851)
+## [1.3.33](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.33)
+### Fixed
+- IndexOutOfBounds case in DynamicLayout.reflow() under Android 8.0.0 (#834)
+
+## [1.3.32](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.32)
+### Fixed
+- Allow paragraph spans that do not extend AlignmentSpan (#851)
 
 ## [1.3.31](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.31)
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.32')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.33')
 }
 ```
 


### PR DESCRIPTION
Update README.md and CHANGELOG.md in preparation for a v1.3.33 release.

This is a trivial PR for the release process so, will self-merge when CI passes.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.