### PR TITLE
[WP-Android 8828] - Detect ArrayIndexOutOfBoundsException exception

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -47,10 +47,17 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, priv
 
         // Detect ArrayIndexOutOfBoundsException on Android 8, and report it to the parent app
         // See: https://github.com/wordpress-mobile/WordPress-Android/issues/8828
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1
-                && ex is ArrayIndexOutOfBoundsException) {
+        if (ex is ArrayIndexOutOfBoundsException) {
             val stackTrace = Log.getStackTraceString(ex)
-            if (stackTrace.contains("android.text.DynamicLayout.getBlockIndex(DynamicLayout.java:646)")) {
+            var detected = false
+            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O &&
+                    stackTrace.contains("android.text.DynamicLayout.getBlockIndex(DynamicLayout.java:646)")) {
+                detected = true
+            } else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O_MR1 &&
+                    stackTrace.contains("android.text.DynamicLayout.getBlockIndex(DynamicLayout.java:648)")) {
+                detected = true
+            }
+            if (detected) {
                 visualEditor.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -3,7 +3,7 @@ package org.wordpress.aztec
 import android.os.Build
 import android.util.Log
 import org.wordpress.android.util.AppLog
-import org.wordpress.aztec.util.DynamicLayoutGetBlockIndexOutOfBoundsException
+import org.wordpress.aztec.exceptions.DynamicLayoutGetBlockIndexOutOfBoundsException
 import org.wordpress.aztec.util.AztecLog
 import java.lang.Thread.UncaughtExceptionHandler
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -1,6 +1,9 @@
 package org.wordpress.aztec
 
+import android.os.Build
+import android.util.Log
 import org.wordpress.android.util.AppLog
+import org.wordpress.aztec.util.DynamicLayoutGetBlockIndexOutOfBoundsException
 import org.wordpress.aztec.util.AztecLog
 import java.lang.Thread.UncaughtExceptionHandler
 
@@ -39,6 +42,16 @@ class AztecExceptionHandler(private val logHelper: ExceptionHandlerHelper?, priv
                 AztecLog.logContentDetails(visualEditor)
             } catch (e: Throwable) {
                 // nop
+            }
+        }
+
+        // Detect ArrayIndexOutOfBoundsException on Android 8, and report it to the parent app
+        // See: https://github.com/wordpress-mobile/WordPress-Android/issues/8828
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1
+                && ex is ArrayIndexOutOfBoundsException) {
+            val stackTrace = Log.getStackTraceString(ex)
+            if (stackTrace.contains("android.text.DynamicLayout.getBlockIndex(DynamicLayout.java:646)")) {
+                visualEditor.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/exceptions/DynamicLayoutGetBlockIndexOutOfBoundsException.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/exceptions/DynamicLayoutGetBlockIndexOutOfBoundsException.kt
@@ -1,4 +1,4 @@
-package org.wordpress.aztec.util
+package org.wordpress.aztec.exceptions
 
 import java.lang.RuntimeException
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/DynamicLayoutGetBlockIndexOutOfBoundsException.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/DynamicLayoutGetBlockIndexOutOfBoundsException.kt
@@ -2,4 +2,4 @@ package org.wordpress.aztec.util
 
 import java.lang.RuntimeException
 
-class DynamicLayoutGetBlockIndexOutOfBoundsException(message:String, cause:Throwable): RuntimeException(message, cause)
+class DynamicLayoutGetBlockIndexOutOfBoundsException(message: String, cause: Throwable) : RuntimeException(message, cause)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/DynamicLayoutGetBlockIndexOutOfBoundsException.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/DynamicLayoutGetBlockIndexOutOfBoundsException.kt
@@ -1,0 +1,5 @@
+package org.wordpress.aztec.util
+
+import java.lang.RuntimeException
+
+class DynamicLayoutGetBlockIndexOutOfBoundsException(message:String, cause:Throwable): RuntimeException(message, cause)


### PR DESCRIPTION
This PR does add the ability to detect the `ArrayIndexOutOfBoundsException` that may happen on Android 8 at the following line of code `android.text.DynamicLayout.getBlockIndex(DynamicLayout.java:646)` due to a bug present in the Android Platform.
When this exact exception is detected, Aztec reports it to the parent app, by wrapping it into a custom Exception.

The reporting to the parent app happens by re-using the external logging capabilities of Aztec, instead of adding another layer of communication between Aztec and the parent app.
The parent app should just check the type of the exception in the "external" logger implementation passed to Aztec.

Make sure strings will be translated:

- [ x ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.