### PR TITLE
Update CHANGELOG and README for v.1.3.34 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.34](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.34)
+### Added
+- Added the ability to report to the host app the IndexOutOfBounds exception
+ in android.text.DynamicLayout.getBlockIndex(DynamicLayout.java:646) under Android 8.XX (#861)
+
 ## [1.3.33](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.33)
 ### Fixed
 - IndexOutOfBounds case in DynamicLayout.reflow() under Android 8.0.0 (#834)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.33')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.34')
 }
 ```
 


### PR DESCRIPTION
Update README.md and CHANGELOG.md in preparation for a v1.3.34 release.

This is a trivial PR for the release process so, will self-merge when CI passes.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.