### PR TITLE
[GB-Mobile]  SetSpan ends beyond length

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -75,8 +75,8 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         return spanned
     }
 
-    fun fromHtml(source: String, context: Context): Spanned {
-        val tidySource = tidy(source)
+    fun fromHtml(source: String, context: Context, isGutenbergMode: Boolean = false): Spanned {
+        val tidySource = if (isGutenbergMode) { source } else { tidy(source) }
 
         val spanned = SpannableStringBuilder(Html.fromHtml(tidySource,
                 AztecTagHandler(context, plugins), context, plugins, ignoredTags))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1190,7 +1190,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         var cleanSource =  if (isInGutenbergMode) { source } else CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
 
-        builder.append(parser.fromHtml(cleanSource, context))
+        builder.append(parser.fromHtml(cleanSource, context, isInGutenbergMode))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1187,8 +1187,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val builder = SpannableStringBuilder()
         val parser = AztecParser(plugins)
 
-        var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
+        var cleanSource =  if (isInGutenbergMode) { source } else CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
+
         builder.append(parser.fromHtml(cleanSource, context))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1187,7 +1187,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val builder = SpannableStringBuilder()
         val parser = AztecParser(plugins)
 
-        var cleanSource =  if (isInGutenbergMode) { source } else CleaningUtils.cleanNestedBoldTags(source)
+        var cleanSource = if (isInGutenbergMode) { source } else CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
 
         builder.append(parser.fromHtml(cleanSource, context, isInGutenbergMode))


### PR DESCRIPTION
This PR does fix a GB-mobile problem (https://github.com/wordpress-mobile/WordPress-Android/issues/9832) where AztecWrapper tries to set the selection out of the bounds.

More details about the problem are in the comment here: https://github.com/wordpress-mobile/WordPress-Android/issues/9832#issuecomment-545564526 together with testings steps.

In this PR i've just disabled cleaning utils over the HTML passed as input, since the "logic" should all be JS side. Otherwise there could be a miss-match between passed HTML and what is "stored" inside Aztec.

GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1490
WP-Android PR: wordpress-mobile/WordPress-Android#10672


