### PR TITLE
Add simple tests for BR tags before P closing tag

### DIFF
--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -1164,6 +1164,38 @@ class AztecParserTest : AndroidTestCase() {
         Assert.assertEquals(input, output)
     }
 
+    /**
+     * Currently, this html <p>Hello There!<br></p> after being parsed to span and back to html will become
+     * <p>Hello There!</p>.
+     * This is not a bug, this is how we originally implemented the function that cleans the HTML input
+     * in AztecParser->tidy method.
+     *
+     * Since we're using this editor in Gutenberg Mobile project, where the selection could be sent from
+     * the JS side to the native, we needed to take in consideration this behavior of Aztec in GB-mobile,
+     * and modify the logic that does set the selection accordingly.
+     *
+     * This test just checks that the underlying parser is working as expected.
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlBrBeforePara_isNotEqual() {
+        val input = "<p>Hello There!<br></p>"
+        val expectedOutput = "<p>Hello There!</p>"
+        val span = SpannableString(mParser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(expectedOutput, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlBrBeforePara2_isNotEqual() {
+        val input = "<p>Hello There!<br><br><br><br></p>"
+        val expectedOutput = "<p>Hello There!</p>"
+        val span = SpannableString(mParser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(expectedOutput, output)
+    }
+
     @Test
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlMixedContentInListItem_isEqual() {


### PR DESCRIPTION
Add tests to make sure the underlying parser is working as expected when one or more BR tag(s) are available in the HTML code right before the Paragraph closing tag.

Currently, this html `<p>Hello There!<br></p>` after being parsed to span and back to html will become `<p>Hello There!</p>`.
This is not a bug, this is how we originally implemented the function that cleans the HTML input in [AztecParser->tidy](https://github.com/wordpress-mobile/AztecEditor-Android/blob/b1fad439d56fa6d4aa0b78526fef355c59d00dd3/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt#L650) method.
Since we're using this editor in Gutenberg Mobile project, where the selection could be sent from the JS side to the native, we needed to take in consideration this behavior of Aztec in GB-mobile, and modify the logic that does set the selection accordingly.


Ref GB mobile PR: https://github.com/WordPress/gutenberg/pull/18138

Make sure strings will be translated:

- [ x ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.