### PR TITLE
Allow preformatted background alpha and tidying to be set from child classes  

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -75,8 +75,8 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         return spanned
     }
 
-    fun fromHtml(source: String, context: Context, shouldSkipTiding: Boolean = false): Spanned {
-        val tidySource = if (shouldSkipTiding) source else tidy(source)
+    fun fromHtml(source: String, context: Context, shouldSkipTidying: Boolean = false): Spanned {
+        val tidySource = if (shouldSkipTidying) source else tidy(source)
 
         val spanned = SpannableStringBuilder(Html.fromHtml(tidySource,
                 AztecTagHandler(context, plugins), context, plugins, ignoredTags))
@@ -90,7 +90,7 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         return spanned
     }
 
-    fun toHtml(text: Spanned, withCursor: Boolean = false, shouldSkipTiding: Boolean = false): String {
+    fun toHtml(text: Spanned, withCursor: Boolean = false, shouldSkipTidying: Boolean = false): String {
         val out = StringBuilder()
 
         val data = SpannableStringBuilder(text)
@@ -107,7 +107,7 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         }
 
         withinHtml(out, data)
-        val tidyOut = if (shouldSkipTiding) out.toString() else tidy(out.toString())
+        val tidyOut = if (shouldSkipTidying) out.toString() else tidy(out.toString())
         val html = postprocessHtml(tidyOut)
         return html
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -75,8 +75,8 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         return spanned
     }
 
-    fun fromHtml(source: String, context: Context): Spanned {
-        val tidySource = tidy(source)
+    fun fromHtml(source: String, context: Context, shouldSkipTiding: Boolean = false): Spanned {
+        val tidySource = if (shouldSkipTiding) source else tidy(source)
 
         val spanned = SpannableStringBuilder(Html.fromHtml(tidySource,
                 AztecTagHandler(context, plugins), context, plugins, ignoredTags))
@@ -90,7 +90,7 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         return spanned
     }
 
-    fun toHtml(text: Spanned, withCursor: Boolean = false): String {
+    fun toHtml(text: Spanned, withCursor: Boolean = false, shouldSkipTiding: Boolean = false): String {
         val out = StringBuilder()
 
         val data = SpannableStringBuilder(text)
@@ -107,7 +107,8 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         }
 
         withinHtml(out, data)
-        val html = postprocessHtml(tidy(out.toString()))
+        val tidyOut = if (shouldSkipTiding) out.toString() else tidy(out.toString())
+        val html = postprocessHtml(tidyOut)
         return html
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -90,6 +90,7 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         return spanned
     }
 
+    @JvmOverloads
     fun toHtml(text: Spanned, withCursor: Boolean = false, shouldSkipTidying: Boolean = false): String {
         val out = StringBuilder()
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1148,7 +1148,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     open fun shouldSkipTidying(): Boolean {
-        return false
+        return true
     }
 
     override fun afterTextChanged(text: Editable) {
@@ -1199,9 +1199,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
-        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTidying()))
+        var returned = parser.fromHtml(cleanSource, context, shouldSkipTidying())
+        builder.append(returned)
+
+        var lengt3 = builder.length
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
+
+        var lengt2 = builder.length
 
         switchToAztecStyle(builder, 0, builder.length)
         disableTextChangedListener()
@@ -1213,8 +1218,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val cursorPosition = consumeCursorPosition(builder)
         setSelection(0)
 
+        var lengt4 = builder.length
+
         setTextKeepState(builder)
         enableTextChangedListener()
+
+        var length = text.length
+
+        var lastIndex = text.lastIndexOf(Constants.ZWJ_CHAR, length-1)
 
         setSelection(cursorPosition)
 
@@ -1323,6 +1334,17 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     // platform agnostic HTML
     // default behavior returns HTML from this text
     fun toPlainHtml(withCursorTag: Boolean = false): String {
+        var length = text.length
+        var lenth2 = text.toString().length
+
+        //println("ivasavic index " + lenth2)
+        for (j in 0 until lenth2) {
+            print("index " + j)
+            //print("  decimal: " + text.toString().get(j))
+            print("  char: " + text.toString().get(j).toInt())
+            println("")
+        }
+
         return toPlainHtml(text, withCursorTag)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1144,7 +1144,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     fun shouldSkipTinying(): Boolean {
         val containsQuote = blockFormatter.containsQuote()
         val containsPreformat = blockFormatter.containsPreformat()
-        return isInGutenbergMode && containsQuote && containsPreformat
+        return isInGutenbergMode && (containsQuote || containsPreformat)
     }
 
     override fun afterTextChanged(text: Editable) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1146,7 +1146,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
-    open fun shouldSkipTinying(): Boolean {
+    open fun shouldSkipTidying(): Boolean {
         return false
     }
 
@@ -1198,7 +1198,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
-        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTinying()))
+        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTidying()))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 
@@ -1363,7 +1363,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         Format.postProcessSpannedText(output, isInCalypsoMode)
 
-        return EndOfBufferMarkerAdder.removeEndOfTextMarker(parser.toHtml(output, withCursorTag, shouldSkipTinying()))
+        return EndOfBufferMarkerAdder.removeEndOfTextMarker(parser.toHtml(output, withCursorTag, shouldSkipTidying()))
     }
 
     // default behavior returns formatted HTML from this text

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1141,10 +1141,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
-    fun shouldSkipTinying(): Boolean {
-        val containsQuote = blockFormatter.containsQuote()
-        val containsPreformat = blockFormatter.containsPreformat()
-        return isInGutenbergMode && (containsQuote || containsPreformat)
+    open fun shouldSkipTinying(): Boolean {
+        return false
     }
 
     override fun afterTextChanged(text: Editable) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1141,6 +1141,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
+    fun shouldSkipTinying(): Boolean {
+        val containsQuote = blockFormatter.containsQuote()
+        val containsPreformat = blockFormatter.containsPreformat()
+        return isInGutenbergMode && containsQuote && containsPreformat
+    }
+
     override fun afterTextChanged(text: Editable) {
         if (isTextChangedListenerDisabled()) {
             subWatcherNestingLevel()
@@ -1189,7 +1195,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
-        builder.append(parser.fromHtml(cleanSource, context))
+        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTinying()))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 
@@ -1354,7 +1360,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         Format.postProcessSpannedText(output, isInCalypsoMode)
 
-        return EndOfBufferMarkerAdder.removeEndOfTextMarker(parser.toHtml(output, withCursorTag))
+        return EndOfBufferMarkerAdder.removeEndOfTextMarker(parser.toHtml(output, withCursorTag, shouldSkipTinying()))
     }
 
     // default behavior returns formatted HTML from this text

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -710,6 +710,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return inputConnectionRef?.get()!!
     }
 
+    // We are exposing this method in order to allow subclasses to set their own alpha value
+    // for preformatted background
     open fun getPreformatBackgroundAlpha(styles: TypedArray): Float {
         return styles.getFraction(R.styleable.AztecText_preformatBackgroundAlpha, 1, 1, 0f)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1148,7 +1148,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     open fun shouldSkipTidying(): Boolean {
-        return true
+        return false
     }
 
     override fun afterTextChanged(text: Editable) {
@@ -1199,14 +1199,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
-        var returned = parser.fromHtml(cleanSource, context, shouldSkipTidying())
-        builder.append(returned)
-
-        var lengt3 = builder.length
+        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTidying()))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
-
-        var lengt2 = builder.length
 
         switchToAztecStyle(builder, 0, builder.length)
         disableTextChangedListener()
@@ -1218,14 +1213,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val cursorPosition = consumeCursorPosition(builder)
         setSelection(0)
 
-        var lengt4 = builder.length
-
         setTextKeepState(builder)
         enableTextChangedListener()
-
-        var length = text.length
-
-        var lastIndex = text.lastIndexOf(Constants.ZWJ_CHAR, length-1)
 
         setSelection(cursorPosition)
 
@@ -1334,17 +1323,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     // platform agnostic HTML
     // default behavior returns HTML from this text
     fun toPlainHtml(withCursorTag: Boolean = false): String {
-        var length = text.length
-        var lenth2 = text.toString().length
-
-        //println("ivasavic index " + lenth2)
-        for (j in 0 until lenth2) {
-            print("index " + j)
-            //print("  decimal: " + text.toString().get(j))
-            print("  char: " + text.toString().get(j).toInt())
-            println("")
-        }
-
         return toPlainHtml(text, withCursorTag)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.res.TypedArray
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
@@ -414,7 +415,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         verticalParagraphMargin),
                 BlockFormatter.PreformatStyle(
                         styles.getColor(R.styleable.AztecText_preformatBackground, 0),
-                        styles.getFraction(R.styleable.AztecText_preformatBackgroundAlpha, 1, 1, 0f),
+                        getPreformatBackgroundAlpha(styles),
                         styles.getColor(R.styleable.AztecText_preformatColor, 0),
                         verticalParagraphMargin)
         )
@@ -704,6 +705,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         // return the existing inputConnection
         return inputConnectionRef?.get()!!
+    }
+
+    open fun getPreformatBackgroundAlpha(styles: TypedArray): Float {
+        return styles.getFraction(R.styleable.AztecText_preformatBackgroundAlpha, 1, 1, 0f)
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {


### PR DESCRIPTION
### Fix 

This PR adds a method that can change preformatted background alpha color from the child class 
and also adds method which can control tidying in AztecParser (we want to avoid tidying for `pre`block.

Related PR's:
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/18777
Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1615
WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10868

### Test
Test 1:
1. Run AztecEditor Demo app and check that background color isn't changed (should have 75% of alpha)
2. Run AztecEditor Demo app and check that `<br>` tags on the end of the text are removed from `pre` after app is started.

Test 2:
1. Run Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1442/
where value is set to 0, and see that background is transparent.
2. Run Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1442/
with `pre` block with multiple `<br>` tags on the end of the text and check that they aren't removed.

### Review
@daniloercoli 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.