### PR TITLE
Add a new dimens and style parameter to change heading vertical space

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -282,6 +282,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     var widthMeasureSpec: Int = 0
 
     var verticalParagraphMargin: Int = 0
+    var verticalHeadingMargin: Int = 0
 
     var maxImagesWidth: Int = 0
     var minImagesWidth: Int = 0
@@ -388,6 +389,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         commentsVisible = styles.getBoolean(R.styleable.AztecText_commentsVisible, commentsVisible)
 
         verticalParagraphMargin = styles.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0)
+        verticalHeadingMargin = styles.getDimensionPixelSize(R.styleable.AztecText_headingVerticalPadding, 0)
 
         inlineFormatter = InlineFormatter(this,
                 InlineFormatter.CodeStyle(
@@ -410,8 +412,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         styles.getDimensionPixelSize(R.styleable.AztecText_quotePadding, 0),
                         styles.getDimensionPixelSize(R.styleable.AztecText_quoteWidth, 0),
                         verticalParagraphMargin),
-                BlockFormatter.HeaderStyle(
-                        verticalParagraphMargin),
+                BlockFormatter.HeaderStyle(verticalHeadingMargin),
                 BlockFormatter.PreformatStyle(
                         styles.getColor(R.styleable.AztecText_preformatBackground, 0),
                         styles.getFraction(R.styleable.AztecText_preformatBackgroundAlpha, 1, 1, 0f),

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
     <declare-styleable name="AztecText">
         <attr name="backgroundColor" format="reference|color" />
         <attr name="blockVerticalPadding" format="reference|dimension" />
+        <attr name="headingVerticalPadding" format="reference|dimension" />
         <attr name="bulletColor" format="reference|color" />
         <attr name="bulletMargin" format="reference|dimension" />
         <attr name="bulletPadding" format="reference|dimension" />

--- a/aztec/src/main/res/values/dimens.xml
+++ b/aztec/src/main/res/values/dimens.xml
@@ -21,6 +21,7 @@
     <dimen name="quote_margin">16dp</dimen>
     <dimen name="quote_width">2dp</dimen>
     <dimen name="block_vertical_padding">8dp</dimen>
+    <dimen name="heading_vertical_padding">8dp</dimen>
     <dimen name="spacing_extra">0dp</dimen>
     <item type="dimen" format="string" name="spacing_multiplier">1.0</item>
 

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -28,6 +28,7 @@
         <item name="android:textCursorDrawable">?attr/textColor</item>
         <item name="backgroundColor">@android:color/transparent</item>
         <item name="blockVerticalPadding">@dimen/block_vertical_padding</item>
+        <item name="headingVerticalPadding">@dimen/heading_vertical_padding</item>
         <item name="bulletColor">@color/blue_medium</item>
         <item name="bulletMargin">@dimen/bullet_margin</item>
         <item name="bulletPadding">@dimen/bullet_padding</item>


### PR DESCRIPTION
### Feature

New parameter to update the heading vertical space from style file.

Current (8dp) | 4dp | 0dp
-|-|-
![Screenshot_1573550923](https://user-images.githubusercontent.com/40213/68660021-b28b4300-0538-11ea-9e43-0eb490bfb262.png) | ![Screenshot_1573550910](https://user-images.githubusercontent.com/40213/68660022-b28b4300-0538-11ea-9414-f14f0d7e5a65.png) | ![Screenshot_1573550891](https://user-images.githubusercontent.com/40213/68660024-b28b4300-0538-11ea-878a-c53a28ba1783.png)


### Test
1. Update `heading_vertical_padding` in `dimens.xml`
2. Run the demo app and check the padding for headings changed.


Note: this is required to fix this issue https://github.com/wordpress-mobile/gutenberg-mobile/issues/992
