### PR TITLE
Update glide to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         kotlinCoroutinesVersion = '1.1.0'
         supportLibVersion = '27.1.1'
         tagSoupVersion = '1.2.1'
-        glideVersion = '3.7.0'
+        glideVersion = '4.10.0'
         picassoVersion = '2.5.2'
         robolectricVersion = '3.5.1'
         jUnitVersion = '4.12'

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideImageLoader.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideImageLoader.kt
@@ -7,9 +7,9 @@ import android.graphics.drawable.Drawable
 import android.util.DisplayMetrics
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.Request
-import com.bumptech.glide.request.animation.GlideAnimation
 import com.bumptech.glide.request.target.SizeReadyCallback
 import com.bumptech.glide.request.target.Target
+import com.bumptech.glide.request.transition.Transition
 import org.wordpress.aztec.Html
 import org.wordpress.aztec.glideloader.extensions.upscaleTo
 
@@ -20,32 +20,35 @@ class GlideImageLoader(private val context: Context) : Html.ImageGetter {
     }
 
     override fun loadImage(source: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int, minWidth: Int) {
-        Glide.with(context).load(source).asBitmap().into(object : Target<Bitmap> {
+        Glide.with(context).asBitmap().load(source).into(object : Target<Bitmap> {
             override fun onLoadStarted(placeholder: Drawable?) {
                 callbacks.onImageLoading(placeholder)
             }
 
-            override fun onLoadFailed(e: Exception?, errorDrawable: Drawable?) {
+            override fun onLoadFailed(errorDrawable: Drawable?) {
                 callbacks.onImageFailed()
             }
 
-            override fun onResourceReady(resource: Bitmap?, glideAnimation: GlideAnimation<in Bitmap>?) {
+            override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
                 //Upscaling bitmap only for demonstration purposes.
                 //This should probably be done somewhere more appropriate for Glide (?).
-                if (resource != null && resource.width < minWidth) {
+                if (resource.width < minWidth) {
                     return callbacks.onImageLoaded(BitmapDrawable(context.resources, resource.upscaleTo(minWidth)))
                 }
 
                 // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
                 // to correctly set the input density to 160 ourselves.
-                resource?.density = DisplayMetrics.DENSITY_DEFAULT
+                resource.density = DisplayMetrics.DENSITY_DEFAULT
                 callbacks.onImageLoaded(BitmapDrawable(context.resources, resource))
             }
 
             override fun onLoadCleared(placeholder: Drawable?) {}
 
-            override fun getSize(cb: SizeReadyCallback?) {
-                cb?.onSizeReady(maxWidth, Target.SIZE_ORIGINAL)
+            override fun getSize(cb: SizeReadyCallback) {
+                cb.onSizeReady(maxWidth, Target.SIZE_ORIGINAL)
+            }
+
+            override fun removeCallback(cb: SizeReadyCallback) {
             }
 
             override fun setRequest(request: Request?) {

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideLoaderModule.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideLoaderModule.kt
@@ -1,0 +1,106 @@
+package org.wordpress.aztec.glideloader
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Priority
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.data.DataFetcher
+import com.bumptech.glide.load.model.ModelLoader
+import com.bumptech.glide.load.model.ModelLoaderFactory
+import com.bumptech.glide.load.model.MultiModelLoaderFactory
+import com.bumptech.glide.module.LibraryGlideModule
+import com.bumptech.glide.signature.ObjectKey
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+
+@GlideModule
+class GlideLoaderModule: LibraryGlideModule() {
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        registry.append(String::class.java, InputStream::class.java, ThumbnailLoader.Factory(context))
+        super.registerComponents(context, glide, registry)
+    }
+
+    internal class ThumbnailLoader(private val context: Context) : ModelLoader<String, InputStream> {
+        override fun buildLoadData(
+                model: String,
+                width: Int,
+                height: Int,
+                options: Options
+        ): ModelLoader.LoadData<InputStream>? {
+            return ModelLoader.LoadData<InputStream>(ObjectKey(model), VideoThumbnailFetcher(model, context))
+        }
+
+        override fun handles(model: String):Boolean {
+            return true
+        }
+
+        internal class Factory(private val context: Context) : ModelLoaderFactory<String, InputStream> {
+            override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<String, InputStream> {
+                return ThumbnailLoader(context)
+            }
+
+            override fun teardown() = Unit
+        }
+
+        class VideoThumbnailFetcher(val source: String, private val context: Context) : DataFetcher<InputStream> {
+            override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in InputStream>) {
+                val retriever = MediaMetadataRetriever()
+                try {
+
+                    val uri = Uri.parse(source)
+                    val isRemote = uri?.scheme?.startsWith("http", true) ?: false
+                    if (isRemote) {
+                        retriever.setDataSource(source, emptyMap())
+                    } else {
+                        retriever.setDataSource(context, uri)
+                    }
+
+                    if (cancelled) return
+                    val picture = retriever.frameAtTime
+                    if (cancelled) return
+                    if (picture != null) {
+                        val bitmapData = ByteArrayOutputStream().use { bos ->
+                            picture.compress(Bitmap.CompressFormat.JPEG, 90, bos)
+                            bos.toByteArray()
+                        }
+                        if (cancelled) return
+                        stream = ByteArrayInputStream(bitmapData)
+                        return callback.onDataReady(stream)
+                    }
+                } finally {
+                    retriever.release()
+                }
+            }
+
+            override fun getDataClass(): Class<InputStream> {
+                return InputStream::class.java
+            }
+
+            override fun getDataSource(): DataSource {
+                return DataSource.REMOTE
+            }
+
+            var stream: InputStream? = null
+            @Volatile
+            var cancelled = false
+
+            override fun cleanup() = try {
+                stream?.close()
+            } catch (e: IOException) {
+                // Just Ignore it
+            } ?: Unit
+
+            override fun cancel() {
+                cancelled = true
+            }
+        }
+    }
+}

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideLoaderModule.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideLoaderModule.kt
@@ -22,7 +22,7 @@ import java.io.IOException
 import java.io.InputStream
 
 @GlideModule
-class GlideLoaderModule: LibraryGlideModule() {
+class GlideLoaderModule : LibraryGlideModule() {
     override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
         registry.append(String::class.java, InputStream::class.java, ThumbnailLoader.Factory(context))
         super.registerComponents(context, glide, registry)
@@ -38,7 +38,7 @@ class GlideLoaderModule: LibraryGlideModule() {
             return ModelLoader.LoadData<InputStream>(ObjectKey(model), VideoThumbnailFetcher(model, context))
         }
 
-        override fun handles(model: String):Boolean {
+        override fun handles(model: String): Boolean {
             return true
         }
 

--- a/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideVideoThumbnailLoader.kt
+++ b/glide-loader/src/main/java/org/wordpress/aztec/glideloader/GlideVideoThumbnailLoader.kt
@@ -4,25 +4,14 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
-import android.media.MediaMetadataRetriever
-import android.net.Uri
 import android.util.DisplayMetrics
 import com.bumptech.glide.Glide
-import com.bumptech.glide.Priority
-import com.bumptech.glide.load.data.DataFetcher
-import com.bumptech.glide.load.model.GenericLoaderFactory
-import com.bumptech.glide.load.model.ModelLoaderFactory
-import com.bumptech.glide.load.model.stream.StreamModelLoader
 import com.bumptech.glide.request.Request
-import com.bumptech.glide.request.animation.GlideAnimation
 import com.bumptech.glide.request.target.SizeReadyCallback
 import com.bumptech.glide.request.target.Target
+import com.bumptech.glide.request.transition.Transition
 import org.wordpress.aztec.Html
 import org.wordpress.aztec.glideloader.extensions.upscaleTo
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.IOException
-import java.io.InputStream
 
 class GlideVideoThumbnailLoader(private val context: Context) : Html.VideoThumbnailGetter {
 
@@ -30,39 +19,47 @@ class GlideVideoThumbnailLoader(private val context: Context) : Html.VideoThumbn
         loadVideoThumbnail(source, callbacks, maxWidth, 0)
     }
 
-    override fun loadVideoThumbnail(source: String, callbacks: Html.VideoThumbnailGetter.Callbacks, maxWidth: Int, minWidth: Int) {
-
+    override fun loadVideoThumbnail(
+            source: String,
+            callbacks: Html.VideoThumbnailGetter.Callbacks,
+            maxWidth: Int,
+            minWidth: Int
+    ) {
         Glide.with(context)
-                .using(ThumbnailLoader(context))
-                .load(source)
                 .asBitmap()
+                .load(source)
                 .fitCenter()
                 .into(object : Target<Bitmap> {
                     override fun onLoadStarted(placeholder: Drawable?) {
                         callbacks.onThumbnailLoading(placeholder)
                     }
 
-                    override fun onLoadFailed(e: Exception?, errorDrawable: Drawable?) {
+                    override fun onLoadFailed(errorDrawable: Drawable?) {
                         callbacks.onThumbnailFailed()
                     }
 
-                    override fun onResourceReady(resource: Bitmap?, glideAnimation: GlideAnimation<in Bitmap>?) {
+                    override fun onResourceReady(resource: Bitmap, glideAnimation: Transition<in Bitmap>?) {
                         //Upscaling bitmap only for demonstration purposes.
                         //This should probably be done somewhere more appropriate for Glide (?).
-                        if (resource != null && resource.width < minWidth) {
-                            return callbacks.onThumbnailLoaded(BitmapDrawable(context.resources, resource.upscaleTo(minWidth)))
+                        if (resource.width < minWidth) {
+                            return callbacks.onThumbnailLoaded(
+                                    BitmapDrawable(context.resources, resource.upscaleTo(minWidth))
+                            )
                         }
 
-                        // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
-                        // to correctly set the input density to 160 ourselves.
-                        resource?.density = DisplayMetrics.DENSITY_DEFAULT
+                        // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so,
+                        // we need to correctly set the input density to 160 ourselves.
+                        resource.density = DisplayMetrics.DENSITY_DEFAULT
                         callbacks.onThumbnailLoaded(BitmapDrawable(context.resources, resource))
                     }
 
                     override fun onLoadCleared(placeholder: Drawable?) {}
 
-                    override fun getSize(cb: SizeReadyCallback?) {
-                        cb?.onSizeReady(maxWidth, maxWidth)
+                    override fun getSize(cb: SizeReadyCallback) {
+                        cb.onSizeReady(maxWidth, maxWidth)
+                    }
+
+                    override fun removeCallback(cb: SizeReadyCallback) {
                     }
 
                     override fun setRequest(request: Request?) {
@@ -81,65 +78,5 @@ class GlideVideoThumbnailLoader(private val context: Context) : Html.VideoThumbn
                     override fun onDestroy() {
                     }
                 })
-    }
-
-    // Based on a Gist from Stepan Goncharov (https://gist.github.com/stepango/5edcbdb408b0ba87f8383f868961c257)
-    internal class ThumbnailLoader(val context: Context) : StreamModelLoader<String> {
-
-        override fun getResourceFetcher(src: String, width: Int, height: Int) = VideoThumbnailFetcher(src, context)
-
-        internal class Factory : ModelLoaderFactory<String, InputStream> {
-            override fun build(context: Context, factories: GenericLoaderFactory) = ThumbnailLoader(context)
-
-            override fun teardown() = Unit
-        }
-
-        class VideoThumbnailFetcher(val source: String, val context: Context) : DataFetcher<InputStream> {
-            var stream: InputStream? = null
-            @Volatile
-            var cancelled = false
-
-            override fun getId(): String = source
-
-            override fun loadData(priority: Priority): InputStream? {
-                val retriever = MediaMetadataRetriever()
-                try {
-
-                    val uri = Uri.parse(source)
-                    val isRemote = uri?.scheme?.startsWith("http", true) ?: false
-                    if (isRemote) {
-                        retriever.setDataSource(source, emptyMap())
-                    } else {
-                        retriever.setDataSource(context, uri)
-                    }
-
-                    if (cancelled) return null
-                    val picture = retriever.frameAtTime
-                    if (cancelled) return null
-                    if (picture != null) {
-                        val bitmapData = ByteArrayOutputStream().use { bos ->
-                            picture.compress(Bitmap.CompressFormat.JPEG, 90, bos)
-                            bos.toByteArray()
-                        }
-                        if (cancelled) return null
-                        stream = ByteArrayInputStream(bitmapData)
-                        return stream
-                    }
-                } finally {
-                    retriever.release()
-                }
-                return null
-            }
-
-            override fun cleanup() = try {
-                stream?.close()
-            } catch (e: IOException) {
-                // Just Ignore it
-            } ?: Unit
-
-            override fun cancel() {
-                cancelled = true
-            }
-        }
     }
 }


### PR DESCRIPTION
### Fix
Updated the Glide version to 4.10.0 from 3.7.0. There have been a lot of changes in the v4 version of Glide. I followed this guide [here](https://bumptech.github.io/glide/doc/migrating.html#using-modelloader-streammodelloader) to help with the migration.

### Testing
- Run AztecEditor Demo app and verify that photos are loaded and displayed correctly. 
- Run AztecEditor Demo app and verify that videos are loaded and video thumbnail is displayed correctly. 
- Added the commit hash from this PR to the WordPress app to verify that images and videos are loaded correctly.

### Testing
@0nko 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.