### PR TITLE
Resolved clipboard issue on Android 7.0

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1559,8 +1559,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     deleteInlineStyleFromTheBeginning()
                 }
             }
-            // Fix for crash when pasting text on Samsung Devices running Android 8 & 7.
-            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
+            // Fix for crash when pasting text on Samsung Devices running Android 7 & 8.
+            // Android 7 Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/10872
+            // Android 8 Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
             clipboardIdentifier -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < Build.VERSION_CODES.P
                         && Build.MANUFACTURER.toLowerCase().equals("samsung")) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1562,7 +1562,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             // Fix for crash when pasting text on Samsung Devices running Android 8 & 7.
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
             clipboardIdentifier -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < 28
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < Build.VERSION_CODES.P
                         && Build.MANUFACTURER.toLowerCase().equals("samsung")) {
                     // Nope return true
                     Toast.makeText(context, context.getString(R.string.samsung_disabled_custom_clipboard, Build.VERSION.RELEASE), Toast.LENGTH_LONG).show()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1559,13 +1559,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     deleteInlineStyleFromTheBeginning()
                 }
             }
-            // Fix for crash when pasting text on Samsung Devices running Android 8.
+            // Fix for crash when pasting text on Samsung Devices running Android 8 & 7.
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
             clipboardIdentifier -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Build.VERSION.SDK_INT < 28
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < 28
                         && Build.MANUFACTURER.toLowerCase().equals("samsung")) {
                     // Nope return true
-                    Toast.makeText(context, R.string.samsung_disabled_custom_clipboard, Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, context.getString(R.string.samsung_disabled_custom_clipboard, Build.VERSION.RELEASE), Toast.LENGTH_LONG).show()
                 } else {
                     return super.onTextContextMenuItem(id)
                 }

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 
     <!-- GENERAL -->
     <string name="cursor_moved">Cursor moved</string>
-    <string name="samsung_disabled_custom_clipboard">Sorry, this feature is disabled on Android 8. Please use the Paste action instead.</string>
+    <string name="samsung_disabled_custom_clipboard">Sorry, this feature is disabled on Android %1$s. Please use the Paste action instead.</string>
 
     <!-- LINK DIALOG -->
     <string name="link_dialog_title">Insert link</string>


### PR DESCRIPTION
### Fix
https://github.com/wordpress-mobile/WordPress-Android/issues/10872

This solution shows a warning instead of crashing when clipboard functionality is utilized on Samsung devices running Android 7.0.

### Test
Use testing instructions as described [here](https://github.com/wordpress-mobile/WordPress-Android/issues/8827#issuecomment-453113443)

**Note**

This hasn't been tested on a device as yet as I was unable to secure a Samsung device with the specifications and doing it using an emulator wasn't causing the same result. 

### Review
@malinajirka 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.