### PR TITLE
Implement start and reversed in lists

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -115,6 +115,9 @@ open class MainActivity : AppCompatActivity(),
                 "    <li>Nine</li>\n" +
                 "    <li>Eight</li>\n" +
                 "</ol>"
+        private val ORDERED_REVERSED_WITH_START_IDENT = "<h4>Reversed Start in 4 List:</h4>" +
+                "<ol reversed>" +
+                "<li>dkfdskfdf\\sd\\</li><li>dfds</li><li>fdf</li><li>dfd</li><li>f</li><li>dsfs<ol><li>fdfd</li><li>f</li><li>dsf</li><li>ds</li><li>d</li><li>g</li><li>sdg</li><li>ds</li></ol></li></ol>\n"
         private val LINE = "<hr />"
         private val UNORDERED = "<ul><li style=\"color:darkred\">Unordered</li><li>Should not have color</li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"
@@ -175,6 +178,7 @@ open class MainActivity : AppCompatActivity(),
                         ORDERED_REVERSED +
                         ORDERED_REVERSED_WITH_START +
                         ORDERED_REVERSED_NEGATIVE_WITH_START +
+                        ORDERED_REVERSED_WITH_START_IDENT +
                         LINE +
                         UNORDERED +
                         QUOTE +

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -109,15 +109,28 @@ open class MainActivity : AppCompatActivity(),
                 "    <li>Nine</li>\n" +
                 "    <li>Eight</li>\n" +
                 "</ol>"
-        private val ORDERED_REVERSED_NEGATIVE_WITH_START = "<h4>Reversed Start in 10 List:</h4>" +
+        private val ORDERED_REVERSED_NEGATIVE_WITH_START = "<h4>Reversed Start in 1 List:</h4>" +
                 "<ol reversed start=\"1\">\n" +
-                "    <li>Ten</li>\n" +
-                "    <li>Nine</li>\n" +
-                "    <li>Eight</li>\n" +
+                "    <li>One</li>\n" +
+                "    <li>Zero</li>\n" +
+                "    <li>Minus One</li>\n" +
                 "</ol>"
-        private val ORDERED_REVERSED_WITH_START_IDENT = "<h4>Reversed Start in 4 List:</h4>" +
+        private val ORDERED_REVERSED_WITH_START_IDENT = "<h4>Reversed Start in 6 List:</h4>" +
                 "<ol reversed>" +
-                "<li>dkfdskfdf\\sd\\</li><li>dfds</li><li>fdf</li><li>dfd</li><li>f</li><li>dsfs<ol><li>fdfd</li><li>f</li><li>dsf</li><li>ds</li><li>d</li><li>g</li><li>sdg</li><li>ds</li></ol></li></ol>\n"
+                "   <li>Six</li>" +
+                "   <li>Five</li>" +
+                "   <li>Four</li>" +
+                "   <li>Three</li>" +
+                "   <li>Two</li>" +
+                "   <li>One<ol>" +
+                "   <li>One</li>" +
+                "   <li>Two</li>" +
+                "   <li>Three</li>" +
+                "   <li>Four</li>" +
+                "   <li>Five</li>" +
+                "   <li>Six</li>" +
+                "   <li>Seven</li> " +
+                "   </ol></li></ol>"
         private val LINE = "<hr />"
         private val UNORDERED = "<ul><li style=\"color:darkred\">Unordered</li><li>Should not have color</li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -109,6 +109,12 @@ open class MainActivity : AppCompatActivity(),
                 "    <li>Nine</li>\n" +
                 "    <li>Eight</li>\n" +
                 "</ol>"
+        private val ORDERED_REVERSED_NEGATIVE_WITH_START = "<h4>Reversed Start in 10 List:</h4>" +
+                "<ol reversed start=\"1\">\n" +
+                "    <li>Ten</li>\n" +
+                "    <li>Nine</li>\n" +
+                "    <li>Eight</li>\n" +
+                "</ol>"
         private val LINE = "<hr />"
         private val UNORDERED = "<ul><li style=\"color:darkred\">Unordered</li><li>Should not have color</li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"
@@ -168,6 +174,7 @@ open class MainActivity : AppCompatActivity(),
                         ORDERED_WITH_START +
                         ORDERED_REVERSED +
                         ORDERED_REVERSED_WITH_START +
+                        ORDERED_REVERSED_NEGATIVE_WITH_START +
                         LINE +
                         UNORDERED +
                         QUOTE +

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -91,6 +91,24 @@ open class MainActivity : AppCompatActivity(),
         private val UNDERLINE = "<u style=\"color:lime\">Underline</u><br>"
         private val STRIKETHROUGH = "<s style=\"color:#ff666666\" class=\"test\">Strikethrough</s><br>" // <s> or <strike> or <del>
         private val ORDERED = "<ol style=\"color:green\"><li>Ordered</li><li>should have color</li></ol>"
+        private val ORDERED_WITH_START = "<h4>Start in 10 List:</h4>" +
+                "<ol start=\"10\">\n" +
+                "    <li>Ten</li>\n" +
+                "    <li>Eleven</li>\n" +
+                "    <li>Twelve</li>\n" +
+                "</ol>"
+        private val ORDERED_REVERSED = "<h4>Reversed List:</h4>" +
+                "<ol reversed>\n" +
+                "    <li>Three</li>\n" +
+                "    <li>Two</li>\n" +
+                "    <li>One</li>\n" +
+                "</ol>"
+        private val ORDERED_REVERSED_WITH_START = "<h4>Reversed Start in 10 List:</h4>" +
+                "<ol reversed start=\"10\">\n" +
+                "    <li>Ten</li>\n" +
+                "    <li>Nine</li>\n" +
+                "    <li>Eight</li>\n" +
+                "</ol>"
         private val LINE = "<hr />"
         private val UNORDERED = "<ul><li style=\"color:darkred\">Unordered</li><li>Should not have color</li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"
@@ -147,6 +165,9 @@ open class MainActivity : AppCompatActivity(),
                         UNDERLINE +
                         STRIKETHROUGH +
                         ORDERED +
+                        ORDERED_WITH_START +
+                        ORDERED_REVERSED +
+                        ORDERED_REVERSED_WITH_START +
                         LINE +
                         UNORDERED +
                         QUOTE +

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -34,7 +34,7 @@ abstract class AztecListSpan(override var nestingLevel: Int,
         }
     }
 
-    fun getIndexOfProcessedLine(text: CharSequence, end: Int): Int {
+    fun getIndexOfProcessedLine(text: CharSequence, end: Int): Int? {
         val spanStart = (text as Spanned).getSpanStart(this)
         val spanEnd = text.getSpanEnd(this)
 
@@ -44,7 +44,7 @@ abstract class AztecListSpan(override var nestingLevel: Int,
             val hasSublist = listText.getSpans(end - spanStart - 1, end - spanStart, AztecListSpan::class.java)
                     .any { it.nestingLevel > nestingLevel }
             if (hasSublist) {
-                return -1
+                return null
             }
         }
 
@@ -55,7 +55,7 @@ abstract class AztecListSpan(override var nestingLevel: Int,
                 .any { it.nestingLevel == nestingLevel + 1 && listText.getSpanStart(it) == startOfLine }
 
         if (!isValidListItem) {
-            return -1
+            return null
         }
 
         // count the list item spans up to the current line with the expected nesting level => item number
@@ -71,7 +71,9 @@ abstract class AztecListSpan(override var nestingLevel: Int,
 
         val listText = text.subSequence(spanStart, spanEnd) as Spanned
 
-        return listText.getSpans(0, listText.length, AztecListItemSpan::class.java).size
+        return listText.getSpans(0, listText.length, AztecListItemSpan::class.java)
+                .filter { it.nestingLevel == nestingLevel + 1 }
+                .size
     }
 
     fun nestingDepth(text: Spanned, index: Int, nextIndex: Int): Int {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -71,11 +71,7 @@ abstract class AztecListSpan(override var nestingLevel: Int,
 
         val listText = text.subSequence(spanStart, spanEnd) as Spanned
 
-        return if (listText.length == 0) {
-            0
-        } else {
-            listText.split("\n").size
-        }
+        return listText.getSpans(0, listText.length, AztecListItemSpan::class.java).size
     }
 
     fun nestingDepth(text: Spanned, index: Int, nextIndex: Int): Int {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -65,6 +65,19 @@ abstract class AztecListSpan(override var nestingLevel: Int,
                 .size
     }
 
+    fun getNumberOfItemsInProcessedLine(text: CharSequence): Int {
+        val spanStart = (text as Spanned).getSpanStart(this)
+        val spanEnd = text.getSpanEnd(this)
+
+        val listText = text.subSequence(spanStart, spanEnd) as Spanned
+
+        return if (listText.length == 0) {
+            0
+        } else {
+            listText.split("\n").size
+        }
+    }
+
     fun nestingDepth(text: Spanned, index: Int, nextIndex: Int): Int {
         val finalNextIndex = if (nextIndex > text.length) index else nextIndex
         return IAztecNestable.getNestingLevelAt(text, index, finalNextIndex)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -61,18 +61,21 @@ class AztecOrderedListSpan(
             0
         }
 
-        val isReversed = attributes.hasAttribute("reversed")
-        val lineIndex = if (start > 0) {
-            if (isReversed) start - (getIndexOfProcessedLine(text, end) - 1)
-            else start + (getIndexOfProcessedLine(text, end) - 1)
-        } else {
-            val number = getNumberOfItemsInProcessedLine(text)
-            if (isReversed) number - (getIndexOfProcessedLine(text, end) - 1)
-            else getIndexOfProcessedLine(text, end)
-        }
+        var textToDraw = ""
+        getIndexOfProcessedLine(text, end)?.let {
+            val isReversed = attributes.hasAttribute("reversed")
+            val lineIndex = if (start > 0) {
+                if (isReversed) start - (it - 1)
+                else start + (it - 1)
+            } else {
+                val number = getNumberOfItemsInProcessedLine(text)
+                if (isReversed) number - (it - 1)
+                else it
+            }
 
-        val textToDraw = if (dir >= 0) lineIndex.toString() + "."
+            textToDraw = if (dir >= 0) lineIndex.toString() + "."
             else "." + lineIndex.toString()
+        }
 
         val width = p.measureText(textToDraw)
         maxWidth = Math.max(maxWidth, width)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -55,14 +55,14 @@ class AztecOrderedListSpan(
         p.color = listStyle.indicatorColor
         p.style = Paint.Style.FILL
 
-        var start = if (attributes.hasAttribute("start") == true) {
+        val start = if (attributes.hasAttribute("start") == true) {
             attributes.getValue("start").toInt()
         } else {
             0
         }
 
         val isReversed = attributes.hasAttribute("reversed")
-        var lineIndex = if (start > 0) {
+        val lineIndex = if (start > 0) {
             if (isReversed) start - (getIndexOfProcessedLine(text, end) - 1)
             else start + (getIndexOfProcessedLine(text, end) - 1)
         } else {
@@ -71,13 +71,9 @@ class AztecOrderedListSpan(
             else getIndexOfProcessedLine(text, end)
         }
 
-        val textToDraw = if (lineIndex > -1) {
-            if (dir >= 0) lineIndex.toString() + "."
+        val textToDraw = if (dir >= 0) lineIndex.toString() + "."
             else "." + lineIndex.toString()
-        } else {
-            ""
-        }
-
+        
         val width = p.measureText(textToDraw)
         maxWidth = Math.max(maxWidth, width)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -55,7 +55,22 @@ class AztecOrderedListSpan(
         p.color = listStyle.indicatorColor
         p.style = Paint.Style.FILL
 
-        val lineIndex = getIndexOfProcessedLine(text, end)
+        var start = if (attributes.hasAttribute("start") == true) {
+            attributes.getValue("start").toInt()
+        } else {
+            0
+        }
+
+        val isReversed = attributes.hasAttribute("reversed")
+        var lineIndex = if (start > 0) {
+            if (isReversed) start - (getIndexOfProcessedLine(text, end) - 1)
+            else start + (getIndexOfProcessedLine(text, end) - 1)
+        } else {
+            val number = getNumberOfItemsInProcessedLine(text)
+            if (isReversed) number - (getIndexOfProcessedLine(text, end))
+            else getIndexOfProcessedLine(text, end)
+        }
+
         val textToDraw = if (lineIndex > -1) {
             if (dir >= 0) lineIndex.toString() + "."
             else "." + lineIndex.toString()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -67,13 +67,13 @@ class AztecOrderedListSpan(
             else start + (getIndexOfProcessedLine(text, end) - 1)
         } else {
             val number = getNumberOfItemsInProcessedLine(text)
-            if (isReversed) number - (getIndexOfProcessedLine(text, end))
+            if (isReversed) number - (getIndexOfProcessedLine(text, end) - 1)
             else getIndexOfProcessedLine(text, end)
         }
 
         val textToDraw = if (dir >= 0) lineIndex.toString() + "."
             else "." + lineIndex.toString()
-        
+
         val width = p.measureText(textToDraw)
         maxWidth = Math.max(maxWidth, width)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -53,7 +53,7 @@ class AztecUnorderedListSpan(
         p.style = Paint.Style.FILL
 
         val lineIndex = getIndexOfProcessedLine(text, end)
-        val textToDraw = if (lineIndex > -1) "\u2022" else ""
+        val textToDraw = if (lineIndex != null) "\u2022" else ""
 
         val width = p.measureText(textToDraw)
 


### PR DESCRIPTION
This PR adds visual support for the reversed and start properties in list.

- [ ] Update tests with new test cases

It does three things:
 - Add to TextList paragraph attributes properties for reversed and start
 - Adds support for parsing of the attributes when reading the HTML
 - Adds support to show visually the attributes effect on display

![list](https://user-images.githubusercontent.com/28219092/69870220-7c2b2300-12af-11ea-9a5c-1cdeb4cf17da.png)

To test:
 - Start the demo app
 - Check that all  lists are showed correctly, specially the new ones with reversed and start attributes.
 - Play around on HTML by changing the attributes of list to see if all is displayed correctly
- Test scenarios
 - Ordered list without start and reversed
 - Ordered list with reversed attribute: check if numbers are updated correctly has members are added
 - Ordered list with start attributed: check if numbers start on the correct number indicated
 - Ordered list with start and reversed: check if numbers are correct
 - In all cases delete lines and see if updates are done correctly.

