### PR TITLE
Update CHANGELOG and README for v.1.3.36 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.36](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.36)
+### Changed
+- Implement start and reversed in lists
+- Allow preformatted background alpha and tidying to be set from child classes
+
 ## [1.3.35](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.35)
 ### Changed
 - Update Glide version to 4.10.0

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.35')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.36')
 }
 ```
 


### PR DESCRIPTION
Update README.md and CHANGELOG.md in preparation for a v1.3.36 release.

This is a trivial PR for the release process so, will self-merge when CI passes.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.