### PR TITLE
Last char is when the length is now zero

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/ZeroIndexContentWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/ZeroIndexContentWatcher.kt
@@ -27,7 +27,10 @@ class ZeroIndexContentWatcher(aztecText: AztecText) : TextWatcher {
 
         val aztecText = aztecTextRef.get()
         // last character was removed
-        if (aztecText != null && textChangedEventDetails.inputEnd == 0 && textChangedEventDetails.inputStart == 1) {
+        if (aztecText != null
+                && text.length == 0
+                && textChangedEventDetails.inputEnd == 0
+                && textChangedEventDetails.inputStart == 1) {
             aztecText.disableOnSelectionListener()
         }
     }


### PR DESCRIPTION
Experimental PR to fix the gutenberg-mobile issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1865

## Testing the original issues to be sure this PR doesn't break them

### From https://github.com/wordpress-mobile/AztecEditor-Android/pull/398:

Test 1 (testing the format while the keyboard is closed): ✅
Test 2 (format on the next line): ❌ This test seems to fail anyway even on `develop` (d2baefd3512e3c2e19a6b5a183befb4c8f108949) so, ignoring for this PR
Test 3 (Backspace last char, backspace to clear format): ✅

### From https://github.com/wordpress-mobile/AztecEditor-Android/issues/357:

Test: ⚠️ issue not happening but, the format did not continue to the next line as the test steps mention.

### From https://github.com/wordpress-mobile/AztecEditor-Android/issues/362:

Test: ✅


## To test
Using the gutenberg-mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/1867 confirm that the issue of merging two paragraph blocks (https://github.com/wordpress-mobile/gutenberg-mobile/issues/1865) is not happening anymore.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.