### PR TITLE
Update changelog and readme for 1.3.37 & 1.3.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.3.38](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.38)
+### Fixed
+- When text changes, only disable selection listener if text is empty
+
+## [1.3.37](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.37)
+### Fixed
+- Resolved clipboard issue on Android 7
+### Changed
+- Improved TalkBack handling of formatting toolbar
+- Added ability to register an observer for all the changes to the AztecText object
+
 ## [1.3.36](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.36)
 ### Changed
 - Implement start and reversed in lists

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.36')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.38')
 }
 ```
 


### PR DESCRIPTION
Updating the changelog and readme in preparation for 1.3.37 & 1.3.38 releases.

Make sure strings will be translated:

- [X] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.