### PR TITLE
Add a condition that prevents invalid span bounds

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -177,7 +177,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle) : AztecFormat
     }
 
     private fun applySpan(span: IAztecInlineSpan, start: Int, end: Int, type: Int) {
-        if (start > end) {
+        if (start > end || start < 0 || end > editableText.length) {
             // If an external logger is available log the error there.
             val extLogger = editor.externalLogger
             if (extLogger != null) {


### PR DESCRIPTION
Prevents wordpress-mobile/WordPress-Android#11309 (and possibly a few others) by checking for < 0 and > text.length span bounds. If it's detected the state is logged and the style is not applied.