### PR TITLE
Upgrade to Robolectric v4.3.1

### DIFF
--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation 'androidx.test:core:1.2.0'
 
     androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
  * Testing attribute preservation for supported HTML elements
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class AttributeTest {
     companion object {
         private val HEADING =

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -5,6 +5,7 @@ package org.wordpress.aztec
 import android.test.AndroidTestCase
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
@@ -13,13 +14,12 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowApplication
 
 /**
  * Tests for [AztecParser].
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class AztecParserTest : AndroidTestCase() {
     private var mParser = AztecParser()
     private val HTML_BOLD = "<b>Bold</b><br><br>"
@@ -92,7 +92,7 @@ class AztecParserTest : AndroidTestCase() {
      */
     @Before
     fun init() {
-        context = ShadowApplication.getInstance().applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.aztec.toolbar.AztecToolbar
  * Combined test for toolbar and inline styles.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class AztecToolbarTest {
     lateinit var editText: AztecText
     lateinit var sourceText: SourceViewEditText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
@@ -18,7 +18,7 @@ import org.wordpress.aztec.TestUtils.safeLength
  * Testing interactions of multiple block elements
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class BlockElementsTest {
     lateinit var editText: AztecText
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
@@ -5,6 +5,7 @@ package org.wordpress.aztec
 import android.test.AndroidTestCase
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
+import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
 import org.junit.Before
 import org.junit.Test
@@ -12,11 +13,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowApplication
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class CalypsoFormattingTest : AndroidTestCase() {
     private var parser = AztecParser()
 
@@ -104,7 +104,7 @@ class CalypsoFormattingTest : AndroidTestCase() {
      */
     @Before
     fun init() {
-        context = ShadowApplication.getInstance().applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -12,7 +12,7 @@ import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class ClipboardTest {
     private val HEADING =
             "<h1>Heading 1</h1>" +

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -4,6 +4,7 @@ package org.wordpress.aztec
 
 import android.test.AndroidTestCase
 import android.text.SpannableString
+import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
 import org.junit.Before
 import org.junit.Test
@@ -11,12 +12,11 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowApplication
 import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecStyleBoldSpan
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(16, 21, 25))
+@Config(sdk = intArrayOf(16, 21, 25))
 class CssStyleAttributeTest : AndroidTestCase() {
 
     private val EMPTY_STYLE_HTML = "<b>bold</b>"
@@ -27,7 +27,7 @@ class CssStyleAttributeTest : AndroidTestCase() {
 
     @Before
     fun init() {
-        context = ShadowApplication.getInstance().applicationContext
+        context = ApplicationProvider.getApplicationContext()
         parser = AztecParser()
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.aztec.spans.AztecUnderlineSpan
  * Combined test for toolbar and inline styles.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class CssUnderlinePluginTest {
     lateinit var editText: AztecText
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
@@ -20,7 +20,7 @@ import org.wordpress.aztec.toolbar.AztecToolbar
  * Testing heading behaviour.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class HeadingTest {
     lateinit var editText: AztecText
     lateinit var sourceText: SourceViewEditText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
@@ -5,6 +5,7 @@ package org.wordpress.aztec
 import android.test.AndroidTestCase
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
+import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
 import org.junit.Before
 import org.junit.Test
@@ -12,7 +13,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowApplication
 import org.wordpress.aztec.spans.IAztecAttributedSpan
 
 /**
@@ -29,7 +29,7 @@ import org.wordpress.aztec.spans.IAztecAttributedSpan
  * Also tests invalid html style attribute color properties.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(16, 21, 25))
+@Config(sdk = intArrayOf(16, 21, 25))
 class HtmlAttributeStyleColorTest : AndroidTestCase() {
 
     private val HTML_BOLD_STYLE_COLOR = "<b style=\"color:blue;\">Blue</b>"
@@ -45,7 +45,7 @@ class HtmlAttributeStyleColorTest : AndroidTestCase() {
 
     @Before
     fun init() {
-        context = ShadowApplication.getInstance().applicationContext
+        context = ApplicationProvider.getApplicationContext()
         parser = AztecParser()
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -4,6 +4,7 @@ package org.wordpress.aztec
 
 import android.test.AndroidTestCase
 import android.text.SpannableString
+import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
 import org.junit.Before
 import org.junit.Test
@@ -11,11 +12,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowApplication
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class HtmlFormattingTest : AndroidTestCase() {
 
     private var parser = AztecParser()
@@ -173,7 +173,7 @@ class HtmlFormattingTest : AndroidTestCase() {
      */
     @Before
     fun init() {
-        context = ShadowApplication.getInstance().applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
@@ -10,7 +10,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class LinkTest {
 
     lateinit var editText: AztecText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ListTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ListTest.kt
@@ -20,7 +20,7 @@ import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
  * This test uses ParameterizedRobolectricTestRunner and runs twice - for ol and ul tags.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class ListTest(listTextFormat: ITextFormat, listHtmlTag: String) {
 
     val listType = listTextFormat

--- a/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
@@ -5,7 +5,7 @@ package org.wordpress.aztec
 // * Testing preformat behavior.
 // */
 //@RunWith(RobolectricTestRunner::class)
-//@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+//@Config(sdk = intArrayOf(23))
 //class PreformatTest {
 //    val tag = "pre"
 //

--- a/aztec/src/test/kotlin/org/wordpress/aztec/QuoteTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/QuoteTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
  * Testing quote behaviour.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class QuoteTest {
 
     val formattingType = AztecTextFormat.FORMAT_QUOTE

--- a/aztec/src/test/kotlin/org/wordpress/aztec/util/ColorConverterTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/util/ColorConverterTest.kt
@@ -11,7 +11,7 @@ import org.wordpress.aztec.BuildConfig
  * Tests for translating various strings to colors using [ColorConverter].
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class ColorConverterTest {
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/util/ColorConverterTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/util/ColorConverterTest.kt
@@ -5,7 +5,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.wordpress.aztec.BuildConfig
 
 /**
  * Tests for translating various strings to colors using [ColorConverter].

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         tagSoupVersion = '1.2.1'
         glideVersion = '4.10.0'
         picassoVersion = '2.5.2'
-        robolectricVersion = '3.5.1'
+        robolectricVersion = '4.3.1'
         jUnitVersion = '4.12'
         jSoupVersion = '1.11.3'
         wordpressUtilsVersion = '1.21'

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
  org.gradle.parallel=true
+
+android.enableUnitTestBinaryResources=true

--- a/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
+++ b/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
@@ -25,7 +25,7 @@ import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
  * Combined test for toolbar and inline styles.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(sdk = intArrayOf(23))
 class CommentsToolbarTest {
 
     lateinit var editText: AztecText

--- a/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
+++ b/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
@@ -12,7 +12,6 @@ import org.robolectric.annotation.Config
 import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.ITextFormat
-import org.wordpress.aztec.plugins.wpcomments.BuildConfig
 import org.wordpress.aztec.plugins.wpcomments.R
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton

--- a/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/WordPressCommentTest.kt
+++ b/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/WordPressCommentTest.kt
@@ -14,7 +14,6 @@ import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Constants
 import org.wordpress.aztec.plugins.TestUtils.backspaceAt
 import org.wordpress.aztec.plugins.TestUtils.safeEmpty
-import org.wordpress.aztec.plugins.wpcomments.BuildConfig
 import org.wordpress.aztec.plugins.wpcomments.CommentsTextFormat
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin
 import org.wordpress.aztec.plugins.wpcomments.spans.WordPressCommentSpan

--- a/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/WordPressCommentTest.kt
+++ b/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/WordPressCommentTest.kt
@@ -25,7 +25,7 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
  * Tests for special comments ([WordPressCommentSpan.Comment.MORE] and [WordPressCommentSpan.Comment.PAGE])
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(25))
+@Config(sdk = intArrayOf(25))
 class WordPressCommentTest {
     lateinit var editText: AztecText
 

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.aztec.plugins.shortcodes.TestUtils.safeEmpty
  * Tests for the audio shortcode plugin
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(25))
+@Config(sdk = intArrayOf(25))
 class AudioShortcodeTest {
     lateinit var editText: AztecText
 

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
@@ -25,7 +25,7 @@ import org.xml.sax.Attributes
  * Tests for the caption shortcode plugin
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(25))
+@Config(sdk = intArrayOf(25))
 class ImageCaptionTest {
     lateinit var editText: AztecText
 

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.aztec.plugins.shortcodes.TestUtils.safeEmpty
  * Tests for the video shortcode plugin
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(25))
+@Config(sdk = intArrayOf(25))
 class VideoShortcodeTest {
     lateinit var editText: AztecText
 


### PR DESCRIPTION
This PR upgrades the Robolectric version trying to fix the unit tests failing on CI with (only one example test shown):

```
org.wordpress.aztec.util.ColorConverterTest > getColorFromNameInvalid FAILED
    org.apache.tools.ant.BuildException
        Caused by: org.apache.maven.artifact.resolver.ArtifactResolutionException
            Caused by: org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException
                Caused by: org.apache.maven.project.ProjectBuildingException
                    Caused by: org.apache.maven.project.ProjectBuildingException
                        Caused by: org.apache.maven.artifact.resolver.ArtifactNotFoundException
                            Caused by: org.apache.maven.wagon.ResourceDoesNotExistException
```

Changes:
* `constants` is removed from the Robolectric config, apparently deprecated
* `ShadowApplication.getInstance().applicationContext` is deprecated and replaced with
`ApplicationProvider.getApplicationContext()` from AndroidX
* Added the `android.enableUnitTestBinaryResources=true` and that produces a few `WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported. The current default is 'false'.` warnings.

### Test
1. Run `/gradlew aztec:testRelease` and all tests should succeed locally
2. CI should be green too

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.