### PR TITLE
Crash Media Unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.39](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.39)
+### Fixed
+- Move media button initialization to avoid crash when advanced toolbar is enabled and media button is disabled
+
 ## [1.3.38](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.38)
 ### Fixed
 - When text changes, only disable selection listener if text is empty

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.38')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.39')
 }
 ```
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
-import androidx.core.text.TextUtilsCompat
-import androidx.core.view.ViewCompat
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -23,6 +21,8 @@ import android.widget.PopupMenu.OnMenuItemClickListener
 import android.widget.Toast
 import android.widget.ToggleButton
 import androidx.appcompat.app.AlertDialog
+import androidx.core.text.TextUtilsCompat
+import androidx.core.view.ViewCompat
 import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.AztecText.EditorHasChanges.NO_CHANGES
@@ -33,8 +33,8 @@ import org.wordpress.aztec.plugins.IMediaToolbarButton
 import org.wordpress.aztec.plugins.IToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.util.convertToButtonAccessibilityProperties
-import java.util.Arrays
 import java.util.ArrayList
+import java.util.Arrays
 import java.util.Locale
 
 /**
@@ -819,12 +819,12 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private fun setupMediaToolbar() {
         val mediaToolbarContainer : LinearLayout = findViewById(R.id.media_button_container)
         mediaToolbarContainer.visibility = if (isMediaToolbarAvailable) View.VISIBLE else View.GONE
+        buttonMediaCollapsed = findViewById(R.id.format_bar_button_media_collapsed)
         if (!isMediaToolbarAvailable) return
 
         mediaToolbar = findViewById(R.id.media_toolbar)
         stylingToolbar = findViewById(R.id.styling_toolbar)
 
-        buttonMediaCollapsed = findViewById(R.id.format_bar_button_media_collapsed)
         buttonMediaExpanded = findViewById(R.id.format_bar_button_media_expanded)
 
         if (isMediaToolbarVisible) {


### PR DESCRIPTION
### Fix
Move the initialization of `buttonMediaCollapsed` before the `setupMediaToolbar()` function returns to avoid a crash when `advanced="true"` and `mediaToolbarAvailable="false"` for the `AztecToolbar` view.  Currently, `buttonMediaCollapsed` is not initialized if `mediaToolbarAvailable="false"` due to the `if (!isMediaToolbarAvailable) return` statement being called before the initialization.  If `buttonMediaCollapsed` is not initialized, it's `null` causing a crash [here](https://github.com/wordpress-mobile/AztecEditor-Android/blob/49666d99c683dd9f867382c0cf7cc69266ce757a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt#L796) when `ellipsisSpinRight` is animated.  The `buttonMediaCollapsed` must be used in the animation so the scrolling effect of the entering/exiting buttons is shown while the toolbar is expanding/collapsing.  See the stack trace below for details.

<details>
<summary>
Stack Tace
</summary>
<pre>
2020-03-04 20:28:25.688 24071-24071/org.wordpress.aztec E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.wordpress.aztec, PID: 24071
    kotlin.UninitializedPropertyAccessException: lateinit property buttonMediaCollapsed has not been initialized
        at org.wordpress.aztec.toolbar.AztecToolbar.access$getButtonMediaCollapsed$p(AztecToolbar.kt:45)
        at org.wordpress.aztec.toolbar.AztecToolbar$setAnimations$3.onAnimationStart(AztecToolbar.kt:796)
        at android.view.animation.Animation.dispatchAnimationStart(Animation.java:999)
        at android.view.animation.AnimationSet.getTransformation(AnimationSet.java:392)
        at android.view.animation.Animation.getTransformation(Animation.java:1030)
        at android.view.View.applyLegacyAnimation(View.java:20975)
        at android.view.View.draw(View.java:21091)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4388)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4149)
        at android.view.View.updateDisplayListIfDirty(View.java:20289)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4372)
        at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4345)
        at android.view.View.updateDisplayListIfDirty(View.java:20258)
        at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:575)
        at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:581)
        at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:654)
        at android.view.ViewRootImpl.draw(ViewRootImpl.java:3610)
        at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:3418)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2755)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1721)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7598)
2020-03-04 20:28:25.688 24071-24071/org.wordpress.aztec E/AndroidRuntime:     at android.view.Choreographer$CallbackRecord.run(Choreographer.java:966)
        at android.view.Choreographer.doCallbacks(Choreographer.java:790)
        at android.view.Choreographer.doFrame(Choreographer.java:725)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:951)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
</pre>
</details>

### Test
1. Add `aztec:advanced="true"` and `aztec:mediaToolbarAvailable="false"` to `AztecToolbar` [here](https://github.com/wordpress-mobile/AztecEditor-Android/blob/49666d99c683dd9f867382c0cf7cc69266ce757a/app/src/main/res/layout/activity_main.xml#L8-L13) for API 16 and before or [here](https://github.com/wordpress-mobile/AztecEditor-Android/blob/49666d99c683dd9f867382c0cf7cc69266ce757a/app/src/main/res/layout-v17/activity_main.xml#L8-L13) for API 17 and after.
2. Run sample app.
3. Tap ellipsis button in toolbar.
4. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.