### PR TITLE
Updated Changelog and README files for release v1.3.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.40](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.40)
+### Changed
+- Adds support to to customise styles for the Aztec Toolbar
+
 ## [1.3.39](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.39)
 ### Fixed
 - Move media button initialization to avoid crash when advanced toolbar is enabled and media button is disabled

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.39')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.40')
 }
 ```
 


### PR DESCRIPTION
Updating the changelog and readme in preparation for 1.3.40 release. This release includes support to customise styles for the Aztec Toolbar.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.