### PR TITLE
Add option to disable collapsing of whitespaces

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -68,18 +68,21 @@ class AztecParser @JvmOverloads constructor(val plugins: List<IAztecPlugin> = li
         val tidySource = tidy(source)
 
         val spanned = SpannableString(Html.fromHtml(tidySource,
-                AztecTagHandler(context, plugins), context, plugins, ignoredTags))
+                AztecTagHandler(context, plugins), context, plugins, ignoredTags, true))
 
         postprocessSpans(spanned)
 
         return spanned
     }
 
-    fun fromHtml(source: String, context: Context, shouldSkipTidying: Boolean = false): Spanned {
+    fun fromHtml(source: String,
+                 context: Context,
+                 shouldSkipTidying: Boolean = false,
+                 shouldIgnoreWhitespace: Boolean = true): Spanned {
         val tidySource = if (shouldSkipTidying) source else tidy(source)
 
         val spanned = SpannableStringBuilder(Html.fromHtml(tidySource,
-                AztecTagHandler(context, plugins), context, plugins, ignoredTags))
+                AztecTagHandler(context, plugins), context, plugins, ignoredTags, shouldIgnoreWhitespace))
 
         addVisualNewlinesToBlockElements(spanned)
         markBlockElementsAsParagraphs(spanned)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1118,6 +1118,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return false
     }
 
+    open fun shouldIgnoreWhitespace(): Boolean {
+        return true
+    }
+
     override fun afterTextChanged(text: Editable) {
         if (isTextChangedListenerDisabled()) {
             subWatcherNestingLevel()
@@ -1168,7 +1172,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
-        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTidying()))
+        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTidying(), shouldIgnoreWhitespace()))
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -1260,4 +1260,14 @@ class AztecParserTest : AndroidTestCase() {
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlParagraphWithMultipleWhitespace_isNotEqual() {
+        val input = "<p>   Hello There!</p>"
+        val inputAfterParser = "<p>Hello There!</p>"
+        val span = SpannableString(mParser.fromHtml(input, RuntimeEnvironment.application.applicationContext))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(output, inputAfterParser)
+    }
 }


### PR DESCRIPTION
Create an option in Aztec to allow configuration of the whitespace removal, also known as text sanitization.

This shouldn't affect the Aztec editor and the option should only be activated on special use cases, for example, the Gutenberg editor: wordpress-mobile/gutenberg-mobile#2127

To test:

Start the demo app
See if all content still looks correct on the multiple demos

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.