### PR TITLE
Added logic to rotate the add button only when selected

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
@@ -22,7 +22,7 @@ enum class ToolbarAction constructor(
             setOf(AztecTextFormat.FORMAT_NONE)),
     ADD_MEDIA_EXPAND(
             R.id.format_bar_button_media_expanded,
-            R.drawable.format_bar_button_media_expanded_selector,
+            R.drawable.format_bar_button_media_collapsed_selector,
             ToolbarActionType.OTHER,
             setOf(AztecTextFormat.FORMAT_NONE)),
     HEADING(R.id.format_bar_button_heading,

--- a/aztec/src/main/res/drawable/format_bar_button_media_collapsed.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_collapsed.xml
@@ -7,9 +7,14 @@
     android:viewportHeight="48"
     android:viewportWidth="48">
 
+    <group
+        android:pivotX="24"
+        android:pivotY="24"
+        android:rotation="45.0">
     <path
         android:fillColor="?attr/toolbarIconNormalColor"
         android:pathData="M24,15.3c4.8,0,8.7,3.9,8.7,8.7s-3.9,8.7-8.7,8.7s-8.7-3.9-8.7-8.7S19.2,15.3,24,15.3 M24,13.1c-6,0-10.9,4.9-10.9,10.9 S18,34.9,24,34.9S34.9,30,34.9,24S30,13.1,24,13.1L24,13.1z M29.5,22.9h-4.4v-4.4h-2.2v4.4h-4.4v2.2h4.4v4.4h2.2v-4.4h4.4V22.9z">
     </path>
+    </group>
 
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_media_collapsed_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_collapsed_disabled.xml
@@ -8,9 +8,14 @@
     android:viewportWidth="48" >
 
     <!-- @color/grey_lighten_20 -->
+    <group
+        android:pivotX="24"
+        android:pivotY="24"
+        android:rotation="45.0">
     <path
         android:fillColor="?attr/toolbarIconDisabledColor"
         android:pathData="M24,15.3c4.8,0,8.7,3.9,8.7,8.7s-3.9,8.7-8.7,8.7s-8.7-3.9-8.7-8.7S19.2,15.3,24,15.3 M24,13.1c-6,0-10.9,4.9-10.9,10.9 S18,34.9,24,34.9S34.9,30,34.9,24S30,13.1,24,13.1L24,13.1z M29.5,22.9h-4.4v-4.4h-2.2v4.4h-4.4v2.2h4.4v4.4h2.2v-4.4h4.4V22.9z" >
     </path>
+    </group>
 
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_media_collapsed_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_collapsed_highlighted.xml
@@ -8,9 +8,14 @@
     android:viewportWidth="48" >
 
     <!-- @color/almost_black -->
+    <group
+        android:pivotX="24"
+        android:pivotY="24"
+        android:rotation="45.0">
     <path
         android:fillColor="?attr/toolbarIconHighlightColor"
         android:pathData="M24,15.3c4.8,0,8.7,3.9,8.7,8.7s-3.9,8.7-8.7,8.7s-8.7-3.9-8.7-8.7S19.2,15.3,24,15.3 M24,13.1c-6,0-10.9,4.9-10.9,10.9 S18,34.9,24,34.9S34.9,30,34.9,24S30,13.1,24,13.1L24,13.1z M29.5,22.9h-4.4v-4.4h-2.2v4.4h-4.4v2.2h4.4v4.4h2.2v-4.4h4.4V22.9z" >
     </path>
+    </group>
 
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_media_expanded.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_expanded.xml
@@ -8,8 +8,7 @@
 
     <group
         android:pivotX="24"
-        android:pivotY="24"
-        android:rotation="45.0">
+        android:pivotY="24">
         <path
             android:fillColor="?attr/toolbarIconNormalColor"
             android:pathData="M24,15.3c4.8,0,8.7,3.9,8.7,8.7s-3.9,8.7-8.7,8.7s-8.7-3.9-8.7-8.7S19.2,15.3,24,15.3 M24,13.1c-6,0-10.9,4.9-10.9,10.9 S18,34.9,24,34.9S34.9,30,34.9,24S30,13.1,24,13.1L24,13.1z M29.5,22.9h-4.4v-4.4h-2.2v4.4h-4.4v2.2h4.4v4.4h2.2v-4.4h4.4V22.9z">

--- a/aztec/src/main/res/drawable/format_bar_button_media_expanded_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_expanded_disabled.xml
@@ -8,8 +8,7 @@
 
     <group
         android:pivotX="24"
-        android:pivotY="24"
-        android:rotation="45.0">
+        android:pivotY="24">
         <path
             android:fillColor="?attr/toolbarIconDisabledColor"
             android:pathData="M24,15.3c4.8,0,8.7,3.9,8.7,8.7s-3.9,8.7-8.7,8.7s-8.7-3.9-8.7-8.7S19.2,15.3,24,15.3 M24,13.1c-6,0-10.9,4.9-10.9,10.9 S18,34.9,24,34.9S34.9,30,34.9,24S30,13.1,24,13.1L24,13.1z M29.5,22.9h-4.4v-4.4h-2.2v4.4h-4.4v2.2h4.4v4.4h2.2v-4.4h4.4V22.9z">

--- a/aztec/src/main/res/drawable/format_bar_button_media_expanded_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_expanded_highlighted.xml
@@ -8,8 +8,7 @@
 
     <group
         android:pivotX="24"
-        android:pivotY="24"
-        android:rotation="45.0">
+        android:pivotY="24">
         <path
             android:fillColor="?attr/toolbarIconHighlightColor"
             android:pathData="M24,15.3c4.8,0,8.7,3.9,8.7,8.7s-3.9,8.7-8.7,8.7s-8.7-3.9-8.7-8.7S19.2,15.3,24,15.3 M24,13.1c-6,0-10.9,4.9-10.9,10.9 S18,34.9,24,34.9S34.9,30,34.9,24S30,13.1,24,13.1L24,13.1z M29.5,22.9h-4.4v-4.4h-2.2v4.4h-4.4v2.2h4.4v4.4h2.2v-4.4h4.4V22.9z">


### PR DESCRIPTION
Fixes #908. This tiny PR adds the fix to animate the "+" image icon after the user clicks it. 

#### Screenshots
##### API 29
<img src="https://user-images.githubusercontent.com/22608780/82790470-bb66b500-9e89-11ea-82b8-65ea56f19525.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82790473-bdc90f00-9e89-11ea-8252-a69c1b284d86.png" width="300"/>

##### API 28
<img src="https://user-images.githubusercontent.com/22608780/82790549-dd603780-9e89-11ea-8210-26900e21edf4.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82790557-e18c5500-9e89-11ea-9891-7614a6e95900.png" width="300"/>

##### API 23
<img src="https://user-images.githubusercontent.com/22608780/82790594-efda7100-9e89-11ea-9557-5be8230281c9.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82790602-f23ccb00-9e89-11ea-8c95-57f4661cbfd4.png" width="300"/>

##### API 21
<img src="https://user-images.githubusercontent.com/22608780/82790632-008ae700-9e8a-11ea-8774-ffe0698b4aaa.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82790644-04b70480-9e8a-11ea-888f-4480e861ce1b.png" width="300"/>

##### API 19
<img src="https://user-images.githubusercontent.com/22608780/82790672-126c8a00-9e8a-11ea-9e6f-5cd9d26a21bb.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82790681-14364d80-9e8a-11ea-8f8d-8dfa7f78ee76.png" width="300"/>

### Review
@malinajirka and @hypest would you be able to take a look at this PR please? 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.