### PR TITLE
Updated Changelog and README files for release v1.3.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.43](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.43)
+### Changed
+- Fixed the add image icon in Aztec Toolbar (#908)
+
 ## [1.3.42](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.42)
 ### Changed
 - Update block-based span classes to allow view level alignment rendering (#899)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.41')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.43')
 }
 ```
 


### PR DESCRIPTION
Updating the changelog and readme in preparation for 1.3.43 release. This release includes a fiix for the add image icon in Aztec Toolbar (#908)

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.