### PR TITLE
Update strikethrough to default to <s> tag

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/FormattingHistoryTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/FormattingHistoryTests.kt
@@ -232,7 +232,7 @@ class FormattingHistoryTests : BaseHistoryTest() {
     fun testMakeStrikethroughUndoRedo() {
         val snippet1 = "There's no crying in"
         val snippet2 = " baseball!"
-        val html = "$snippet1<del>$snippet2</del>"
+        val html = "$snippet1<s>$snippet2</s>"
         val editorPage = EditorPage()
 
         // Insert first snippet

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/SimpleTextFormattingTests.kt
@@ -46,7 +46,7 @@ class SimpleTextFormattingTests : BaseTest() {
     fun testSimpleStrikethroughFormatting() {
         val text1 = "some"
         val text2 = "text"
-        val html = "$text1<del>$text2</del>"
+        val html = "$text1<s>$text2</s>"
 
         EditorPage()
                 .insertText(text1)
@@ -351,7 +351,7 @@ class SimpleTextFormattingTests : BaseTest() {
     fun testInlineStyleAndSpace() {
         val text1 = "some"
         val text2 = "text "
-        val html = "$text1<del>$text2</del>"
+        val html = "$text1<s>$text2</s>"
 
         EditorPage()
                 .insertText(text1)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStrikethroughSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecStrikethroughSpan.kt
@@ -3,7 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.style.StrikethroughSpan
 import org.wordpress.aztec.AztecAttributes
 
-class AztecStrikethroughSpan(tag: String = "del",
+class AztecStrikethroughSpan(tag: String = "s",
                              override var attributes: AztecAttributes = AztecAttributes())
     : StrikethroughSpan(), IAztecInlineSpan {
     override val TAG = tag

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -176,7 +176,7 @@ class AztecToolbarTest {
         Assert.assertTrue(strikeThroughButton.isChecked)
 
         editText.append("strike")
-        Assert.assertEquals("<del>strike</del>", editText.toHtml())
+        Assert.assertEquals("<s>strike</s>", editText.toHtml())
 
         strikeThroughButton.performClick()
         Assert.assertFalse(strikeThroughButton.isChecked)
@@ -196,7 +196,7 @@ class AztecToolbarTest {
         editText.setSelection(0, editText.length())
         strikeThroughButton.performClick()
         Assert.assertTrue(strikeThroughButton.isChecked)
-        Assert.assertEquals("<del>strike</del>", editText.toHtml())
+        Assert.assertEquals("<s>strike</s>", editText.toHtml())
 
         strikeThroughButton.performClick()
         Assert.assertFalse(strikeThroughButton.isChecked)
@@ -275,14 +275,14 @@ class AztecToolbarTest {
         editText.append("Str")
         strikeThroughButton.performClick()
         editText.append("ike")
-        Assert.assertEquals("<strong>Bo</strong>ld<em>Ita</em>lic<del>Str</del>ike", editText.toHtml())
+        Assert.assertEquals("<strong>Bo</strong>ld<em>Ita</em>lic<s>Str</s>ike", editText.toHtml())
 
         // Underline
         underlineButton.performClick()
         editText.append("Under")
         underlineButton.performClick()
         editText.append("line")
-        Assert.assertEquals("<strong>Bo</strong>ld<em>Ita</em>lic<del>Str</del>ike<u>Under</u>line", editText.toHtml())
+        Assert.assertEquals("<strong>Bo</strong>ld<em>Ita</em>lic<s>Str</s>ike<u>Under</u>line", editText.toHtml())
 
         // Clear text
         editText.setText("")
@@ -306,14 +306,14 @@ class AztecToolbarTest {
         strikeThroughButton.performClick()
         editText.append("ike")
         strikeThroughButton.performClick()
-        Assert.assertEquals("Bo<strong>ld</strong>Ita<em>lic</em>Str<del>ike</del>", editText.toHtml())
+        Assert.assertEquals("Bo<strong>ld</strong>Ita<em>lic</em>Str<s>ike</s>", editText.toHtml())
 
         // Underline
         editText.append("Under")
         underlineButton.performClick()
         editText.append("line")
         underlineButton.performClick()
-        Assert.assertEquals("Bo<strong>ld</strong>Ita<em>lic</em>Str<del>ike</del>Under<u>line</u>", editText.toHtml())
+        Assert.assertEquals("Bo<strong>ld</strong>Ita<em>lic</em>Str<s>ike</s>Under<u>line</u>", editText.toHtml())
     }
 
     /**
@@ -352,7 +352,7 @@ class AztecToolbarTest {
         editText.append("Str")
         strikeThroughButton.performClick()
         editText.append("ike")
-        Assert.assertEquals(" <strong>Bo</strong>ld <em>Ita</em>lic <del>Str</del>ike", editText.toHtml())
+        Assert.assertEquals(" <strong>Bo</strong>ld <em>Ita</em>lic <s>Str</s>ike", editText.toHtml())
 
         // Space
         editText.append(" ")
@@ -362,7 +362,7 @@ class AztecToolbarTest {
         editText.append("Under")
         underlineButton.performClick()
         editText.append("line")
-        Assert.assertEquals(" <strong>Bo</strong>ld <em>Ita</em>lic <del>Str</del>ike <u>Under</u>line", editText.toHtml())
+        Assert.assertEquals(" <strong>Bo</strong>ld <em>Ita</em>lic <s>Str</s>ike <u>Under</u>line", editText.toHtml())
     }
 
     /**
@@ -407,14 +407,14 @@ class AztecToolbarTest {
         strikeThroughButton.performClick()
         Assert.assertTrue(strikeThroughButton.isChecked)
 
-        Assert.assertEquals("<strong>bold</strong> <strong><em>bolditalic</em></strong> <em>italic</em> <del>strike</del> underline normal", editText.toHtml())
+        Assert.assertEquals("<strong>bold</strong> <strong><em>bolditalic</em></strong> <em>italic</em> <s>strike</s> underline normal", editText.toHtml())
 
         editText.setSelection(30, 39)
 
         underlineButton.performClick()
         Assert.assertTrue(underlineButton.isChecked)
 
-        Assert.assertEquals("<strong>bold</strong> <strong><em>bolditalic</em></strong> <em>italic</em> <del>strike</del> <u>underline</u> normal", editText.toHtml())
+        Assert.assertEquals("<strong>bold</strong> <strong><em>bolditalic</em></strong> <em>italic</em> <s>strike</s> <u>underline</u> normal", editText.toHtml())
     }
 
     /**
@@ -447,19 +447,19 @@ class AztecToolbarTest {
         strikeThroughButton.performClick()
         Assert.assertTrue(strikeThroughButton.isChecked)
         editText.append("strike")
-        Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong><em>italic</em><del>strike</del>", editText.toHtml())
+        Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong><em>italic</em><s>strike</s>", editText.toHtml())
         strikeThroughButton.performClick()
         Assert.assertFalse(strikeThroughButton.isChecked)
 
         underlineButton.performClick()
         Assert.assertTrue(underlineButton.isChecked)
         editText.append("underline")
-        Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong><em>italic</em><del>strike</del><u>underline</u>", editText.toHtml())
+        Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong><em>italic</em><s>strike</s><u>underline</u>", editText.toHtml())
         underlineButton.performClick()
         Assert.assertFalse(underlineButton.isChecked)
 
         editText.append("normal")
-        Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong><em>italic</em><del>strike</del><u>underline</u>normal", editText.toHtml())
+        Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong><em>italic</em><s>strike</s><u>underline</u>normal", editText.toHtml())
     }
 
     /**
@@ -470,7 +470,7 @@ class AztecToolbarTest {
     @Test
     @Throws(Exception::class)
     fun testSelection() {
-        editText.fromHtml("<b>bold</b><b><i>bolditalic</i></b><i>italic</i><del>strike</del><u>underline</u>normal")
+        editText.fromHtml("<b>bold</b><b><i>bolditalic</i></b><i>italic</i><s>strike</s><u>underline</u>normal")
 
         // cursor is at bold text
         editText.setSelection(2)
@@ -554,7 +554,7 @@ class AztecToolbarTest {
 
     /**
      * Select part of text with one common style applied to it (bold) and another style (strikethrough)
-     * applied to part of it ("ds" from <b>bold</b><b><del>strike</del></b>) and extend partially
+     * applied to part of it ("ds" from <b>bold</b><b><s>strike</s></b>) and extend partially
      * applied style (strikethrough) to other part of selection.
      *
      * @throws Exception
@@ -562,7 +562,7 @@ class AztecToolbarTest {
     @Test
     @Throws(Exception::class)
     fun extendStyleStrikethroughPartialSelection() {
-        editText.fromHtml("<b>bold</b><b><del>strike</del></b>")
+        editText.fromHtml("<b>bold</b><b><s>strike</s></b>")
 
         val selectedText = editText.text.substring(3, 5)
         Assert.assertEquals("ds", selectedText) // sanity check
@@ -572,7 +572,7 @@ class AztecToolbarTest {
         Assert.assertFalse(strikeThroughButton.isChecked)
 
         strikeThroughButton.performClick()
-        Assert.assertEquals("<b>bol</b><b><del>dstrike</del></b>", editText.toHtml())
+        Assert.assertEquals("<b>bol</b><b><s>dstrike</s></b>", editText.toHtml())
     }
 
     /**
@@ -685,7 +685,7 @@ class AztecToolbarTest {
         editText.setSelection(9, 15)
         strikeThroughButton.performClick()
 
-        Assert.assertEquals("<div class=\"third\"><strong>Div</strong><br><span><em>Span</em></span><br><del>Hidden</del></div>",
+        Assert.assertEquals("<div class=\"third\"><strong>Div</strong><br><span><em>Span</em></span><br><s>Hidden</s></div>",
                 editText.toHtml())
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
@@ -47,11 +47,11 @@ class LinkTest {
     @Test
     @Throws(Exception::class)
     fun insertLinkIntoStyledText() {
-        editText.fromHtml("<del><b>left</b><i>right</i></del>")
+        editText.fromHtml("<s><b>left</b><i>right</i></s>")
         editText.setSelection(4)
         editText.link("http://wordpress.com", "WordPress")
         // Still valid, but order of b and del is switched here for some reason.
-        Assert.assertEquals("<b><del>left</del></b><b><del><a href=\"http://wordpress.com\">WordPress</a></del></b><del><i>right</i></del>", editText.toHtml())
+        Assert.assertEquals("<b><s>left</s></b><b><s><a href=\"http://wordpress.com\">WordPress</a></s></b><s><i>right</i></s>", editText.toHtml())
     }
 
     @Test


### PR DESCRIPTION
Fixes part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/729

### Description
This change updates the strikethrough button to default to `<s> `tag instead of `<del>` tag. This brings AztecEditor-Android inline with [AztecEditor-iOS](https://github.com/wordpress-mobile/AztecEditor-iOS) and [HTML5](https://html.com/tags/s/#:~:text=is%20used%20to%20strike,that%20is%20no%20longer%20correct.) standards. 

### To Test
Case 1:
1. Press Strikethrough button and add some text, note strikethrough works correctly
2. Switch to HTML mode, note that Aztec shows `<s></s>` tag around strikethrough text where it would previously have a `<del>` tag

Case 2:
1. Switch to HTML mode, add some text with a `<del></del>` tag around it (or update text with `<s></s>` around it to be `<del></del>` instead).  
2. Switch back to visual mode and note that text is still displayed as crossed out, as expected.


Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.