### PR TITLE
Updated changelog and README for v.1.3.44 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.44](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.44)
+### Changed
+- Updated strikethrough to default to `<s>` tag (#919)
+
 ## [1.3.43](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.3.43)
 ### Changed
 - Fixed the add image icon in Aztec Toolbar (#908)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.43')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.44')
 }
 ```
 


### PR DESCRIPTION
### Updates before tagging v.1.3.44 release

This release includes one update for defaulting strikethrough to the `<s>` tag instead of `<del>`. See PR https://github.com/wordpress-mobile/AztecEditor-Android/pull/919



Make sure strings will be translated:

- [X] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.