### PR TITLE
Fix `parentStyle must not be null`

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
@@ -45,7 +45,9 @@ class CssUnderlinePlugin(
                     if (hiddenSpan.TAG == SPAN_TAG) {
                         val parentStyle = hiddenSpan.attributes.getValue(CssStyleFormatter.STYLE_ATTRIBUTE)
                         val childStyle = calypsoUnderlineSpan.attributes.getValue(CssStyleFormatter.STYLE_ATTRIBUTE)
-                        hiddenSpan.attributes.setValue(CssStyleFormatter.STYLE_ATTRIBUTE, CssStyleFormatter.mergeStyleAttributes(parentStyle, childStyle))
+                        if (parentStyle != null && childStyle != null) {
+                            hiddenSpan.attributes.setValue(CssStyleFormatter.STYLE_ATTRIBUTE, CssStyleFormatter.mergeStyleAttributes(parentStyle, childStyle))
+                        }
 
                         // remove the extra child span
                         spannable.removeSpan(calypsoUnderlineSpan)


### PR DESCRIPTION
Closes #831 

### Fix
When we reverted this here https://github.com/wordpress-mobile/AztecEditor-Android/pull/882, we unintentionally also removed the fix in https://github.com/wordpress-mobile/AztecEditor-Android/pull/832, because it was stack-added on purpose as explained [in this conversation](https://github.com/wordpress-mobile/AztecEditor-Android/pull/834/files#r310092291) (we could only get to properly test the conditions for https://github.com/wordpress-mobile/AztecEditor-Android/pull/834 with monkeys when _that_ patch was first in place).

This PR just cherry-picks the original commit to restore things.

Copying from the original PR https://github.com/wordpress-mobile/AztecEditor-Android/pull/832:
> Just added a null check that prevents a crash from happening. The formatting will not be added if such a condition is met, but that's far better than crashing.

### Test
No testing needed, but you can run the monkeys to verify (could follow the steps provided in https://github.com/wordpress-mobile/AztecEditor-Android/pull/834)

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.