### PR TITLE
Accessibility Improvement : Remove focusing of AztecText control as it's unneeded in TalkBack mode.

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextAccessibilityDelegate.kt
@@ -62,7 +62,6 @@ class AztecTextAccessibilityDelegate(private val aztecText: EditText) {
     private fun announceLine(lineOffset: Int) {
         if (!aztecText.isFocused || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !aztecText.isAccessibilityFocused)) {
             aztecText.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
-            aztecText.requestFocus()
         } else {
             val announcement = getTextAtLine(lineOffset).replace(Constants.IMG_STRING, mediaItemContentDescription)
             accessibilityManager.interrupt()


### PR DESCRIPTION
Fixes #926 
## Findings
The `AztecText` view was focusing on hover during accessibility mode. 

## Solution
The solution was to modify the `AztecTextAccessibilityDelegate` that was intercepting the `MotionEvent` on hover since that triggered the delegate's logic which involved requesting the focus on the `AztecText` view. 

## Testing

1. Open the example app. 
2. Enable TalkBack by long-pressing both the volume up & down key at the same time. 
3. Once it's enabled, hover over the example content of the `AztecText` view.
I modified the string content from `EXAMPLE` to `QUOTE` so testing would be easier. 
https://github.com/wordpress-mobile/AztecEditor-Android/blob/f65933fa6b597b29a8f6552e7b524c79bc165ccd/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt#L462
4. TalkBack should read out the entire content, but the view should not be focused until you double-tap it. 
5. Before TalkBack would say long-press the control as the first option but now it says tap as seen below.
6. Ensure that tapping actually causes the cursor to become visible since the view is no longer going to be focused automatically.

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/93270837-82738880-f777-11ea-9db0-f3fdefd7b92f.png" width="320"></kbd|       <kbd><img src="https://user-images.githubusercontent.com/1509205/93270835-81425b80-f777-11ea-8b51-0083fb233160.png" width="320"></kbd>

## Screenshot
Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/93271131-265d3400-f778-11ea-9d74-18a26a34a648.png" width="320"></kbd>    |       <kbd><img src="https://user-images.githubusercontent.com/1509205/93271126-23624380-f778-11ea-93a0-e3aa496d075e.png" width="320"></kbd>

## Video
Before | After 
--------|-------
 [Cursor blinking automatically](https://drive.google.com/file/d/1S-PTepDF_bXwueXfZzSyuCqCtfXA2rrL/view?usp=sharing)       | [Tap to activate cursor](https://drive.google.com/file/d/1RysRKR3exXv_dNA-McGngJGGGyL22YJH/view?usp=sharing) 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.

