### PR TITLE
[Gutenberg] Account for the end of buffer marker

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -632,8 +632,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         val emptyEditTextBackspaceDetector = InputFilter { source, start, end, dest, dstart, dend ->
             if (selectionStart == 0 && selectionEnd == 0
-                    && end == 0 && start == 0
+                    && end == 1 && start == 0
                     && dstart == 0 && dend == 0
+                    && isCleanStringEmpty(source)
                     && !isHandlingBackspaceEvent) {
                 isHandlingBackspaceEvent = true
 
@@ -652,6 +653,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         } else {
             filters = arrayOf(emptyEditTextBackspaceDetector)
         }
+    }
+
+    private fun isCleanStringEmpty(text: CharSequence): Boolean {
+        return (text.count() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)
     }
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -656,7 +656,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     private fun isCleanStringEmpty(text: CharSequence): Boolean {
-        if( isInGutenbergMode ) {
+        if ( isInGutenbergMode ) {
             return (text.count() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)
         } else {
             return text.count() == 0

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -632,7 +632,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         val emptyEditTextBackspaceDetector = InputFilter { source, start, end, dest, dstart, dend ->
             if (selectionStart == 0 && selectionEnd == 0
-                    && end == 1 && start == 0
+                    && start == 0
                     && dstart == 0 && dend == 0
                     && isCleanStringEmpty(source)
                     && !isHandlingBackspaceEvent) {
@@ -656,7 +656,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     private fun isCleanStringEmpty(text: CharSequence): Boolean {
-        return (text.count() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)
+        if( isInGutenbergMode ) {
+            return (text.count() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)
+        } else {
+            return text.count() == 0
+        }
     }
 
     private fun handleBackspaceAndEnter(event: KeyEvent): Boolean {


### PR DESCRIPTION
### Fix
https://github.com/wordpress-mobile/gutenberg-mobile/issues/1663
https://github.com/wordpress-mobile/gutenberg-mobile/issues/1524

When deleting text in the Heading block the end of buffer marker prevents the `handleBackspaceAndEnter` event from firing resulting in weird behavior like the placeholder not showing up. This also affects formatting updates.

To resolve this I now account for that character in `emptyEditTextBackspaceDetector` check these changes will allow the

### Heading block
1. Open the Gutenberg Editor 
1. Create a Heading block containing some text
1. Press backspace until all of the text has been deleted
*Expect* to see the placeholder text return after the last character is deleted

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/3384451/93357281-1db73d00-f80e-11ea-94d2-efd4aa5399d9.gif"/>
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/3384451/93357188-0710e600-f80e-11ea-87bb-51f1640b5878.gif"/>
</details>

### Paragraph block
1. Open the Gutenberg Editor 
1. Create a Paragraph block containing some text
1. Select the full text and apply some styling like bold
1. Press backspace until all of the text has been deleted
**Expect** to see the placeholder text return after the last character is deleted
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/3384451/93357841-c4034280-f80e-11ea-913c-520c7bd4a7d6.gif"/>
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/3384451/93357565-74247b80-f80e-11ea-9caf-52e6890f0332.gif"/>
</details>

### Review
@khaykov I think you were the last one to work in this area if you have time to review if not just let me know and I can ask someone working on Gutenberg to review. 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.