### PR TITLE
Use org.wordpress:utils:1.30 to avoid com.android.support 27.1.1 conflict

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.aztec"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -517,11 +517,11 @@ open class MainActivity : AppCompatActivity(),
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
+    override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
         if (mediaUploadDialog != null && mediaUploadDialog!!.isShowing) {
-            outState?.putBoolean("isMediaUploadDialogVisible", true)
+            outState.putBoolean("isMediaUploadDialogVisible", true)
         }
     }
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecStyleBoldSpan
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(16, 21, 25))
+@Config(sdk = intArrayOf(18, 21, 25))
 class CssStyleAttributeTest : AndroidTestCase() {
 
     private val EMPTY_STYLE_HTML = "<b>bold</b>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
@@ -29,7 +29,7 @@ import org.wordpress.aztec.spans.IAztecAttributedSpan
  * Also tests invalid html style attribute color properties.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(16, 21, 25))
+@Config(sdk = intArrayOf(18, 21, 25))
 class HtmlAttributeStyleColorTest : AndroidTestCase() {
 
     private val HTML_BOLD_STYLE_COLOR = "<b style=\"color:blue;\">Blue</b>"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         gradlePluginVersion = '3.3.1'
-        kotlinVersion = '1.3.11'
+        kotlinVersion = '1.3.50'
         kotlinCoroutinesVersion = '1.1.0'
         supportLibVersion = '27.1.1'
         tagSoupVersion = '1.2.1'
@@ -10,7 +10,7 @@ buildscript {
         robolectricVersion = '4.3.1'
         jUnitVersion = '4.12'
         jSoupVersion = '1.11.3'
-        wordpressUtilsVersion = '1.21'
+        wordpressUtilsVersion = '1.30.1'
         espressoVersion = '3.0.1'
     }
 

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionName "1.0"
     }


### PR DESCRIPTION
Update org.wordpress:utils to version 1.30.1 to avoid com.android.support 27.1.1 conflict

Need to update minSdkVersion to 18 because merging manifest failed due to org.wordpress:utils  with minSdkVersion in 18