### PR TITLE
Update wordpressUtilsVersion 1.21 -> 1.30.1 to fix AndroidX conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         robolectricVersion = '4.3.1'
         jUnitVersion = '4.12'
         jSoupVersion = '1.11.3'
-        wordpressUtilsVersion = '1.21'
+        wordpressUtilsVersion = '1.30.1'
         espressoVersion = '3.0.1'
     }
 


### PR DESCRIPTION
### Fix
This fixes #933 by resolving the dependency conflict with com.android.support 27.1.1

It also replaces #929 which seems to include unrelated changes, and which may have become stale

### Review
@jd-alexander 