### PR TITLE
Feature: Add support for the mark HTML tag

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -178,6 +178,7 @@ open class MainActivity : AppCompatActivity(),
         private val VIDEOPRESS = "[wpvideo OcobLTqC]"
         private val VIDEOPRESS_2 = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true3]"
         private val QUOTE_RTL = "<blockquote>לְצַטֵט<br>same quote but LTR</blockquote>"
+        private val MARK = "<p>Donec ipsum dolor, <mark style=\"color:#ff0000\">tempor sed</mark> bibendum <mark style=\"color:#1100ff\">vita</mark>.</p>"
 
         private val EXAMPLE =
                 IMG +
@@ -211,7 +212,8 @@ open class MainActivity : AppCompatActivity(),
                         VIDEOPRESS_2 +
                         AUDIO +
                         GUTENBERG_CODE_BLOCK +
-                        QUOTE_RTL
+                        QUOTE_RTL +
+                        MARK
 
         private val isRunningTest: Boolean by lazy {
             try {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -144,6 +144,11 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
                 handleElement(output, opening, preformatSpan)
                 return true
             }
+            MARK -> {
+                val span = createHiddenHtmlSpan(tag, AztecAttributes(attributes), nestingLevel, alignmentRendering)
+                handleElement(output, opening, span)
+                return true
+            }
             else -> {
                 if (tag.length == 2 && Character.toLowerCase(tag[0]) == 'h' && tag[1] >= '1' && tag[1] <= '6') {
                     handleElement(output, opening, createHeadingSpan(nestingLevel, tag, AztecAttributes(attributes), alignmentRendering))
@@ -245,5 +250,6 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
         private val VIDEO = "video"
         private val AUDIO = "audio"
         private val LINE = "hr"
+        private val MARK = "mark"
     }
 }


### PR DESCRIPTION
### Fix

This PR adds support for the `mark` HTML tag.

It currently supports setting the text color and there are plans to add support for background-color as well.

<kbd><img src="https://user-images.githubusercontent.com/4885740/136185821-0d9f4fd0-c32b-4518-a200-4ececb8e482f.jpg" width=200 /></kbd>

### Test
1. Open the demo app
2. Scroll down to the bottom to find the new tag
3. Expect to see the text with the colors

### Review
@0nko 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.