### PR TITLE
Updates publish-to-s3 plugin to 0.7.0 and publishes '-sources.jar'

### DIFF
--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -83,13 +83,9 @@ project.afterEvaluate {
 
                 groupId "org.wordpress"
                 artifactId "aztec"
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress"
-    mavenPublishArtifactId "aztec"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.application" apply false
     id "org.jetbrains.kotlin.android" apply false
+    id "com.automattic.android.publish-to-s3" apply false
 }
 
 allprojects {

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -38,13 +38,9 @@ project.afterEvaluate {
 
                 groupId "org.wordpress.aztec"
                 artifactId "glide-loader"
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress.aztec"
-    mavenPublishArtifactId "glide-loader"
 }

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -41,13 +41,9 @@ project.afterEvaluate {
 
                 groupId "org.wordpress.aztec"
                 artifactId "picasso-loader"
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress.aztec"
-    mavenPublishArtifactId "picasso-loader"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
         id "com.android.library" version gradle.ext.agpVersion
         id "com.android.application" version gradle.ext.agpVersion
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
-        id "com.automattic.android.publish-to-s3" version "0.6.1"
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
         maven {

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -55,13 +55,9 @@ project.afterEvaluate {
 
                 groupId "org.wordpress.aztec"
                 artifactId "wordpress-comments"
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress.aztec"
-    mavenPublishArtifactId "wordpress-comments"
 }

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -52,13 +52,9 @@ project.afterEvaluate {
 
                 groupId "org.wordpress.aztec"
                 artifactId "wordpress-shortcodes"
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress.aztec"
-    mavenPublishArtifactId "wordpress-shortcodes"
 }


### PR DESCRIPTION
This PR updates `publish-to-s3` Gradle plugin to `0.7.0` and uses the newly introduced `androidSourcesJar` task to upload the `-sources.jar` file so it can be used by developers to access the source code from their IDEs. More details can be found in: https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/29

**To test:**
* https://github.com/wordpress-mobile/WordPress-Android/pull/15492 can be used to test the same changes applied to [WordPress-Utils-Android](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/95) & [WordPress-FluxC-Android](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2160) projects.

Once this PR is merged, I'll create a tag and update https://github.com/WordPress/gutenberg/pull/36034 to include this change, so it'll be tested as part of that PR as well.