### PR TITLE
Add Mark inline formatting

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -59,6 +59,7 @@ import org.wordpress.aztec.spans.IAztecInlineSpan;
 import org.wordpress.aztec.spans.IAztecParagraphStyle;
 import org.wordpress.aztec.spans.UnknownClickableSpan;
 import org.wordpress.aztec.spans.UnknownHtmlSpan;
+import org.wordpress.aztec.spans.MarkSpan;
 import org.wordpress.aztec.util.CleaningUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -355,6 +356,8 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
         } else if (tag.equalsIgnoreCase("code")) {
             insideCodeTag = true;
             start(spannableStringBuilder, AztecTextFormat.FORMAT_CODE, attributes);
+        } else if (tag.equalsIgnoreCase("mark")) {
+            start(spannableStringBuilder, AztecTextFormat.FORMAT_MARK, attributes);
         } else if (!UnknownHtmlSpan.Companion.getKNOWN_TAGS().contains(tag.toLowerCase())) {
             // Initialize a new "Unknown" node
             if (contentHandlerLevel == 0) {
@@ -448,6 +451,8 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
         } else if (tag.equalsIgnoreCase("code")) {
             insideCodeTag = false;
             end(spannableStringBuilder, AztecTextFormat.FORMAT_CODE);
+        } else if (tag.equalsIgnoreCase("mark")) {
+            end(spannableStringBuilder, AztecTextFormat.FORMAT_MARK);
         }
     }
 
@@ -543,6 +548,9 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
             case FORMAT_CODE:
                 newSpan = new AztecCodeSpan(attributes);
                 break;
+            case FORMAT_MARK:
+                newSpan = new MarkSpan(attributes);
+                break;
             default:
                 throw new IllegalArgumentException("Style not supported");
         }
@@ -596,6 +604,9 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
                 break;
             case FORMAT_CODE:
                 span = (AztecCodeSpan) getLast(text, AztecCodeSpan.class);
+                break;
+            case FORMAT_MARK:
+                span = (MarkSpan) getLast(text, MarkSpan.class);
                 break;
             default:
                 throw new IllegalArgumentException("Style not supported");

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -144,11 +144,6 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
                 handleElement(output, opening, preformatSpan)
                 return true
             }
-            MARK -> {
-                val span = createHiddenHtmlSpan(tag, AztecAttributes(attributes), nestingLevel, alignmentRendering)
-                handleElement(output, opening, span)
-                return true
-            }
             else -> {
                 if (tag.length == 2 && Character.toLowerCase(tag[0]) == 'h' && tag[1] >= '1' && tag[1] <= '6') {
                     handleElement(output, opening, createHeadingSpan(nestingLevel, tag, AztecAttributes(attributes), alignmentRendering))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1178,6 +1178,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             AztecTextFormat.FORMAT_CITE,
             AztecTextFormat.FORMAT_UNDERLINE,
             AztecTextFormat.FORMAT_STRIKETHROUGH,
+            AztecTextFormat.FORMAT_MARK,
             AztecTextFormat.FORMAT_CODE -> return inlineFormatter.containsInlineStyle(format, selStart, selEnd)
             AztecTextFormat.FORMAT_UNORDERED_LIST,
             AztecTextFormat.FORMAT_ORDERED_LIST -> return blockFormatter.containsList(format, selStart, selEnd)
@@ -1633,6 +1634,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_STRIKETHROUGH, start, end)
         inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_UNDERLINE, start, end)
         inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_CODE, start, end)
+        inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_MARK, start, end)
     }
 
     fun removeBlockStylesFromRange(start: Int, end: Int, ignoreLineBounds: Boolean = false) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextFormat.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextFormat.kt
@@ -35,4 +35,5 @@ enum class AztecTextFormat : ITextFormat {
     FORMAT_FONT,
     FORMAT_MONOSPACE,
     FORMAT_CODE,
+    FORMAT_MARK,
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
@@ -1,0 +1,12 @@
+package org.wordpress.aztec.spans
+
+import android.text.TextPaint
+import android.text.style.CharacterStyle
+import org.wordpress.aztec.AztecAttributes
+
+class MarkSpan(override var attributes: AztecAttributes = AztecAttributes()) : CharacterStyle(), IAztecInlineSpan {
+    override var TAG = "mark"
+
+    override fun updateDrawState(tp: TextPaint?) {
+    }
+}


### PR DESCRIPTION
This PR is a follow-up of https://github.com/wordpress-mobile/AztecEditor-Android/pull/939 to wrap up adding `Mark` formatting support.

To test this feature, use the iOS build from this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15504) that uses this feature.

### Fix

Adds Mark formatting capabilities.

### Test
For test cases, you can check the description of this [PR](https://github.com/WordPress/gutenberg/pull/36028).

### Review
@antonis 

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.