### PR TITLE
Add flag to control whether applying Aztec styles to HTML

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1305,7 +1305,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 
-        if(useAztecStyleHTML) {
+        if (useAztecStyleHTML) {
             switchToAztecStyle(builder, 0, builder.length)
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -251,6 +251,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     private var isHandlingBackspaceEvent = false
 
     var commentsVisible = resources.getBoolean(R.bool.comments_visible)
+    var useAztecStyleHTML = resources.getBoolean(R.bool.use_aztec_style_html)
 
     var isInCalypsoMode = true
     var isInGutenbergMode: Boolean = false
@@ -1304,7 +1305,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 
-        switchToAztecStyle(builder, 0, builder.length)
+        if(useAztecStyleHTML) {
+            switchToAztecStyle(builder, 0, builder.length)
+        }
+
         disableTextChangedListener()
 
         builder.getSpans(0, builder.length, AztecDynamicImageSpan::class.java).forEach {

--- a/aztec/src/main/res/values/bools.xml
+++ b/aztec/src/main/res/values/bools.xml
@@ -5,5 +5,6 @@
     <bool name="history_enable">true</bool>
     <bool name="comments_visible">true</bool>
     <bool name="link_underline">true</bool>
+    <bool name="use_aztec_style_html">true</bool>
 
 </resources>


### PR DESCRIPTION
This PR introduces a new resource bool (`use_aztec_style_html`) as a flag to control whether, when parsing HTML, it should apply Aztec styles ([reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/5d983f84e74d0d6db4297e846ef010a3d5146612/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1481-L1532)). This change shouldn't produce regressions as the flag by default is set to `true`, which is the default behavior.

Related to https://github.com/wordpress-mobile/gutenberg-mobile/issues/3136.

### Test
#### Verify that no regressions are introduced
1. Open the demo app.
2. Observe that the content is properly rendered with expected styles.

### Review
[TBD]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.