### PR TITLE
Preserve link, code span instances when styling

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1481,22 +1481,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     private fun switchToAztecStyle(editable: Editable, start: Int, end: Int) {
         editable.getSpans(start, end, IAztecBlockSpan::class.java).forEach { blockFormatter.setBlockStyle(it) }
         editable.getSpans(start, end, EndOfParagraphMarker::class.java).forEach { it.verticalPadding = verticalParagraphMargin }
-
-        val urlSpans = editable.getSpans(start, end, AztecURLSpan::class.java)
-        for (span in urlSpans) {
-            val spanStart = editable.getSpanStart(span)
-            val spanEnd = editable.getSpanEnd(span)
-            editable.removeSpan(span)
-            editable.setSpan(linkFormatter.makeUrlSpan(span.url, span.attributes), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-
-        val codeSpans = editable.getSpans(start, end, AztecCodeSpan::class.java)
-        codeSpans.forEach {
-            val spanStart = editable.getSpanStart(it)
-            val spanEnd = editable.getSpanEnd(it)
-            editable.removeSpan(it)
-            editable.setSpan(inlineFormatter.makeInlineSpan(it.javaClass, it.attributes), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
+        editable.getSpans(start, end, AztecURLSpan::class.java).forEach { it.linkStyle = linkFormatter.linkStyle }
+        editable.getSpans(start, end, AztecCodeSpan::class.java).forEach { it.codeStyle = inlineFormatter.codeStyle }
 
         val imageSpans = editable.getSpans(start, end, AztecImageSpan::class.java)
         imageSpans.forEach {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -27,14 +27,10 @@ import org.wordpress.aztec.formatting.InlineFormatter
 class AztecCodeSpan(override var attributes: AztecAttributes = AztecAttributes()) : MetricAffectingSpan(), IAztecInlineSpan {
     override val TAG = "code"
 
-    private var codeBackground: Int = 0
-    private var codeBackgroundAlpha: Float = 0.0f
-    private var codeColor: Int = 0
+    var codeStyle = InlineFormatter.CodeStyle(0, 0.0f, 0)
 
     constructor(codeStyle: InlineFormatter.CodeStyle, attributes: AztecAttributes = AztecAttributes()) : this(attributes) {
-        this.codeBackground = codeStyle.codeBackground
-        this.codeBackgroundAlpha = codeStyle.codeBackgroundAlpha
-        this.codeColor = codeStyle.codeColor
+        this.codeStyle = codeStyle;
     }
 
     override fun updateDrawState(tp: TextPaint?) {
@@ -46,9 +42,13 @@ class AztecCodeSpan(override var attributes: AztecAttributes = AztecAttributes()
     }
 
     private fun configureTextPaint(tp: TextPaint?) {
-        val alpha: Int = (codeBackgroundAlpha * 255).toInt()
+        val alpha: Int = (codeStyle.codeBackgroundAlpha * 255).toInt()
         tp?.typeface = Typeface.MONOSPACE
-        tp?.bgColor = Color.argb(alpha, Color.red(codeBackground), Color.green(codeBackground), Color.blue(codeBackground))
-        tp?.color = codeColor
+        tp?.bgColor = Color.argb(
+                alpha,
+                Color.red(codeStyle.codeBackground),
+                Color.green(codeStyle.codeBackground),
+                Color.blue(codeStyle.codeBackground))
+        tp?.color = codeStyle.codeColor
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -30,7 +30,7 @@ class AztecCodeSpan(override var attributes: AztecAttributes = AztecAttributes()
     var codeStyle = InlineFormatter.CodeStyle(0, 0.0f, 0)
 
     constructor(codeStyle: InlineFormatter.CodeStyle, attributes: AztecAttributes = AztecAttributes()) : this(attributes) {
-        this.codeStyle = codeStyle;
+        this.codeStyle = codeStyle
     }
 
     override fun updateDrawState(tp: TextPaint?) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -25,8 +25,7 @@ import org.wordpress.aztec.formatting.LinkFormatter
 class AztecURLSpan : URLSpan, IAztecInlineSpan {
     override val TAG = "a"
 
-    private var linkColor = 0
-    private var linkUnderline = true
+    var linkStyle = LinkFormatter.LinkStyle(0, true)
 
     override var attributes: AztecAttributes = AztecAttributes()
 
@@ -39,12 +38,11 @@ class AztecURLSpan : URLSpan, IAztecInlineSpan {
     }
 
     constructor(url: String, linkStyle: LinkFormatter.LinkStyle, attributes: AztecAttributes = AztecAttributes()) : this(url, attributes) {
-        this.linkColor = linkStyle.linkColor
-        this.linkUnderline = linkStyle.linkUnderline
+        this.linkStyle = linkStyle
     }
 
     override fun updateDrawState(ds: TextPaint) {
-        ds.color = if (linkColor != 0) linkColor else ds.linkColor
-        ds.isUnderlineText = linkUnderline
+        ds.color = if (linkStyle.linkColor != 0) linkStyle.linkColor else ds.linkColor
+        ds.isUnderlineText = linkStyle.linkUnderline
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/InlineElementsTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/InlineElementsTest.kt
@@ -1,0 +1,50 @@
+package org.wordpress.aztec
+
+import android.app.Activity
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.aztec.spans.AztecCodeSpan
+import org.wordpress.aztec.spans.AztecStyleStrongSpan
+import org.wordpress.aztec.spans.AztecURLSpan
+import org.wordpress.aztec.spans.IAztecInlineSpan
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = intArrayOf(23))
+class InlineElementsTest {
+
+    lateinit var editText: AztecText
+
+    /**
+     * Initialize variables.
+     */
+    @Before
+    fun init() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+        editText = AztecText(activity)
+        editText.setCalypsoMode(false)
+        activity.setContentView(editText)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun preserveLinkTagOrder() {
+        editText.fromHtml("<p>This is a <a href=\"http://wordpress.com\"><strong>link</strong></a></p>")
+        val spans = editText.text.getSpans(0, editText.length(), IAztecInlineSpan::class.java)
+        Assert.assertTrue(spans[0] is AztecURLSpan)
+        Assert.assertTrue(spans[1] is AztecStyleStrongSpan)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun preserveCodeTagOrder() {
+        editText.fromHtml("<p>This is a <code><strong>some code</strong></code></p>")
+        val spans = editText.text.getSpans(0, editText.length(), IAztecInlineSpan::class.java)
+        Assert.assertTrue(spans[0] is AztecCodeSpan)
+        Assert.assertTrue(spans[1] is AztecStyleStrongSpan)
+    }
+}


### PR DESCRIPTION
### Fix

PR to preserve the span and tag order for `link` and `code` tags. Although HTML doesn't dictate that the inline element order is of importance, there's no good reason for Aztec to alter the order when parsing.

In this PR, the code that applies style to the `a` and `code` spans is refactored to be able to set the style on the span without replace the span itself in the spannable.

This PR is an alternative approach of https://github.com/wordpress-mobile/AztecEditor-Android/pull/944.

### Test
1. In `MainActivity.kt` use the following html as value to the [EXAMPLE val](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt#L183): `<p>This is a <a href="http://wordpress.com"><strong>link</strong></a></p>`
2. Compile and run the demo app
3. Switch to html mode and notice that the markup is the same as the one in `EXAMPLE`
4. Switch back to visual mode
5. Type a new character in the beginning of the line
6. Switch to html mode again
7. Notice that the `strong` is still nested inside the `a`

The above steps fail without the changes in this PR.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.