### PR TITLE
Drop jetifier

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.aztec"
-        minSdkVersion 16
+        minSdkVersion commonMinSdkVersion
         targetSdkVersion commonTargetSdkVersion
         versionCode 1
         versionName "1.0"

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -519,7 +519,7 @@ open class MainActivity : AppCompatActivity(),
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
+    override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
         if (mediaUploadDialog != null && mediaUploadDialog!!.isShowing) {

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion commonMinSdkVersion
         targetSdkVersion commonTargetSdkVersion
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
@@ -9,10 +9,10 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnLongClickListener
 import android.widget.Toast
-import android.widget.ToggleButton
+import androidx.appcompat.widget.AppCompatToggleButton
 import org.wordpress.aztec.R
 
-class RippleToggleButton : ToggleButton, OnLongClickListener {
+class RippleToggleButton : AppCompatToggleButton, OnLongClickListener {
     private var mHalfWidth: Float = 0.toFloat()
     private var mAnimationIsRunning = false
     private var mTimer = 0

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecStyleBoldSpan
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(16, 21, 25))
+@Config(sdk = intArrayOf(21, 25, 30))
 class CssStyleAttributeTest : AndroidTestCase() {
 
     private val EMPTY_STYLE_HTML = "<b>bold</b>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecStyleBoldSpan
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(21, 25, 30))
+@Config(sdk = intArrayOf(21, 25))
 class CssStyleAttributeTest : AndroidTestCase() {
 
     private val EMPTY_STYLE_HTML = "<b>bold</b>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
@@ -29,7 +29,7 @@ import org.wordpress.aztec.spans.IAztecAttributedSpan
  * Also tests invalid html style attribute color properties.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(16, 21, 25))
+@Config(sdk = intArrayOf(21, 25, 29))
 class HtmlAttributeStyleColorTest : AndroidTestCase() {
 
     private val HTML_BOLD_STYLE_COLOR = "<b style=\"color:blue;\">Blue</b>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
@@ -29,7 +29,7 @@ import org.wordpress.aztec.spans.IAztecAttributedSpan
  * Also tests invalid html style attribute color properties.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(21, 25, 29))
+@Config(sdk = intArrayOf(21, 25))
 class HtmlAttributeStyleColorTest : AndroidTestCase() {
 
     private val HTML_BOLD_STYLE_COLOR = "<b style=\"color:blue;\">Blue</b>"

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ subprojects {
 ext {
     gradlePluginVersion = '3.3.1'
     kotlinCoroutinesVersion = '1.1.0'
-    supportLibVersion = '27.1.1'
     tagSoupVersion = '1.2.1'
     glideVersion = '4.10.0'
     picassoVersion = '2.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ ext {
     wordpressUtilsVersion = 'trunk-1ed207c03d2242b6fc3d74f9e388e9163cbc82a6'
     espressoVersion = '3.0.1'
     commonTargetSdkVersion = 30
+    commonMinSdkVersion = 21
 
     aztecProjectDependency = project.hasProperty("aztecVersion") ? "org.wordpress:aztec:${project.getProperty("aztecVersion")}" : project(":aztec")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     robolectricVersion = '4.4'
     jUnitVersion = '4.12'
     jSoupVersion = '1.11.3'
-    wordpressUtilsVersion = '1.21'
+    wordpressUtilsVersion = 'trunk-1ed207c03d2242b6fc3d74f9e388e9163cbc82a6'
     espressoVersion = '3.0.1'
     commonTargetSdkVersion = 30
 

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion commonMinSdkVersion
         targetSdkVersion commonTargetSdkVersion
         versionCode 1
         versionName "1.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 org.gradle.jvmargs=-Xmx1536m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-android.enableJetifier=true
+android.enableJetifier=false
 android.useAndroidX=true
 
 

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion commonMinSdkVersion
         targetSdkVersion commonTargetSdkVersion
         versionCode 1
         versionName "1.0"

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion commonMinSdkVersion
         targetSdkVersion commonTargetSdkVersion
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion commonMinSdkVersion
         targetSdkVersion commonTargetSdkVersion
         versionName "1.0"
     }


### PR DESCRIPTION
Make sure https://github.com/wordpress-mobile/AztecEditor-Android/pull/947 is merged first -> update the target branch to `develop` unless GitHub does it automatically.

This PR is part of [the effort to drop Jetifier from WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/15675). Aztec directly doesn't rely on the android support library, however, it is dependant on utils version which is not migrated to AndroidX. This PR is technically not necessary to unblock the PR in WPAndroid as gradle can resolve the utils version conflict and use the newer version in WPAndroid. However, since we are using composite builds and having inconsistent versions could bite us, I opted for updating it everywhere for consistency.


Changes
- Bumps utils version to a version which is migrated to AndroidX
- Bumps minSdkVersion from 16 to 21 => WordPress Utils requires version 18. However, since we never test any of the changes on Android < 21 I decided to bump the version to 21.
- Disables jetifier

To test
Make sure to disable Jetifier in your local gradle.properties  => Smoke test the example app

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.