### PR TITLE
Remove xamarin.testcloud library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,5 +51,4 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestImplementation('com.xamarin.testcloud:espresso-support:1.3')
 }

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/BaseTest.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/BaseTest.kt
@@ -1,39 +1,21 @@
 package org.wordpress.aztec.demo
 
+import android.util.Log
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.runner.AndroidJUnit4
-import com.xamarin.testcloud.espresso.Factory
-import com.xamarin.testcloud.espresso.ReportHelper
-import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 abstract class BaseTest {
-
-    @Rule
-    @JvmField
-    val mReportHelper: ReportHelper = Factory.getReportHelper()
-
     @Rule
     @JvmField
     val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(android.Manifest.permission.CAMERA,
             android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
 
     companion object {
-        private lateinit var reportHelper: ReportHelper
-
         fun label(label: String) {
-            reportHelper.label(label)
+            Log.d("BaseTest", label)
         }
-    }
-
-    init {
-        BaseTest.reportHelper = mReportHelper
-    }
-
-    @Before
-    fun SetUp() {
-        reportHelper.label("Starting App")
     }
 }


### PR DESCRIPTION
This PR removes `com.xamarin.testcloud:espresso-support` which is not being used anymore. The library is not migrated to AndroidX and is blocking our progress of the "Drop Jetifier" effort.


~This is still a draft since we are waiting for confirmation from the rest of the team that this library is really unused.~

The library was added as part of POC/tool comparsion in 2017 and it hasn't been used since then.


### Test
Green CI checks should be enough.


### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.