### PR TITLE
Prevent update selected styles when text changes on Gutenberg mode

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1048,7 +1048,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         onSelectionChangedListener?.onSelectionChanged(selStart, selEnd)
-        setSelectedStyles(getAppliedStyles(selStart, selEnd))
+        // Gutenberg controls the selected styles so we need to prevent Aztec to modify them
+        if (!isInGutenbergMode) {
+            setSelectedStyles(getAppliedStyles(selStart, selEnd))
+        }
 
         isLeadingStyleRemoved = false
     }


### PR DESCRIPTION
**Related to Gutenberg PR: https://github.com/WordPress/gutenberg/pull/37676**

Gutenberg already controls the selected styles, so we need to prevent Aztec from modifying them when the text changes.

### Test
This change shouldn't affect the current behavior of the selected styles hence, we should just verify that Aztec works as expected regarding the selected styles when modifying text.

### Review
@guarani 
@antonis 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.