### PR TITLE
Heading Span - Reset previous font metrics if the font spacing changes

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -81,6 +81,7 @@ open class AztecHeadingSpan(
 
     var previousFontMetrics: Paint.FontMetricsInt? = null
     var previousTextScale: Float = 1.0f
+    var previousSpacing: Float? = null
 
     enum class Heading constructor(internal val scale: Float, internal val tag: String) {
         H1(SCALE_H1, "h1"),
@@ -163,10 +164,11 @@ open class AztecHeadingSpan(
 
     override fun updateMeasureState(textPaint: TextPaint) {
         // when font size changes - reset cached font metrics to reapply vertical padding
-        if (previousTextScale != heading.scale) {
+        if (previousTextScale != heading.scale || previousSpacing != textPaint.fontSpacing) {
             previousFontMetrics = null
         }
         previousTextScale = heading.scale
+        previousSpacing = textPaint.fontSpacing
 
         textPaint.textSize *= heading.scale
     }


### PR DESCRIPTION
### Fix
This PR adds another check to take into account before resetting the font metrics, by checking if the font spacing changed..

### Test
Use the test instructions from this [Gutenberg PR](https://github.com/WordPress/gutenberg/pull/38205).

### Review
@antonis 

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.