### PR TITLE
Update README for publishing changes to S3 Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.5.4')
+    api "org.wordpress:aztec:v1.5.4"
 }
 ```
 
@@ -113,9 +113,9 @@ or have fun with the latest snapshot at their own risk:
 
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:trunk-{commit_sha1}')
+    api "org.wordpress:aztec:trunk-{commit_sha1}"
     // As an example, for '3f004c8c8cd4b53ab9748f42f373cf00a30e9d86' commit sha1, this would look like:
-    // api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:trunk-3f004c8c8cd4b53ab9748f42f373cf00a30e9d86')
+    // api "org.wordpress:aztec:trunk-3f004c8c8cd4b53ab9748f42f373cf00a30e9d86"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,15 +97,14 @@ $ ./gradlew cAT
 
 ## Integrating Aztec in your project
 
-You can import Aztec into your project using Jitpack:
 ```gradle
 repositories {
-    maven { url "https://jitpack.io" }
+    maven { url "https://a8c-libs.s3.amazonaws.com/android" }
 }
 ```
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.44')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.5.4')
 }
 ```
 
@@ -114,7 +113,9 @@ or have fun with the latest snapshot at their own risk:
 
 ```gradle
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:develop-SNAPSHOT')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:trunk-{commit_sha1}')
+    // As an example, for '3f004c8c8cd4b53ab9748f42f373cf00a30e9d86' commit sha1, this would look like:
+    // api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:trunk-3f004c8c8cd4b53ab9748f42f373cf00a30e9d86')
 }
 ```
 


### PR DESCRIPTION
In https://github.com/wordpress-mobile/AztecEditor-Android/pull/941, we switched publishing the artifacts from Jitpack to our S3 Maven. This PR updates the integration instructions in `README` to reflect this change.