### PR TITLE
Add support for highlighted background

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -55,6 +55,7 @@ import org.wordpress.aztec.spans.AztecURLSpan;
 import org.wordpress.aztec.spans.AztecUnderlineSpan;
 import org.wordpress.aztec.spans.CommentSpan;
 import org.wordpress.aztec.spans.FontSpan;
+import org.wordpress.aztec.spans.HighlightSpan;
 import org.wordpress.aztec.spans.IAztecInlineSpan;
 import org.wordpress.aztec.spans.IAztecParagraphStyle;
 import org.wordpress.aztec.spans.UnknownClickableSpan;
@@ -500,7 +501,7 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
     }
 
 
-    private static void start(SpannableStringBuilder text, AztecTextFormat textFormat, Attributes attrs) {
+    private void start(SpannableStringBuilder text, AztecTextFormat textFormat, Attributes attrs) {
         final AztecAttributes attributes = new AztecAttributes(attrs);
         IAztecInlineSpan newSpan;
 
@@ -550,6 +551,9 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
                 break;
             case FORMAT_MARK:
                 newSpan = new MarkSpan(attributes);
+                break;
+            case FORMAT_HIGHLIGHT:
+                newSpan = HighlightSpan.create(attributes, context);
                 break;
             default:
                 throw new IllegalArgumentException("Style not supported");

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -35,6 +35,7 @@ import org.wordpress.aztec.plugins.visual2html.IBlockSpanHandler
 import org.wordpress.aztec.plugins.visual2html.IHtmlPostprocessor
 import org.wordpress.aztec.plugins.visual2html.IInlineSpanHandler
 import org.wordpress.aztec.plugins.visual2html.ISpanPreprocessor
+import org.wordpress.aztec.source.CssStyleAttribute
 import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecCursorSpan
 import org.wordpress.aztec.spans.AztecHorizontalRuleSpan
@@ -423,14 +424,14 @@ class AztecParser @JvmOverloads constructor(private val alignmentRendering: Alig
                                nestable: IAztecParagraphStyle, parents: ArrayList<IAztecNestable>?, nestingLevel: Int) {
 
         if (nestable is IAztecAlignmentSpan && nestable.shouldParseAlignmentToHtml()) {
-            CssStyleFormatter.removeStyleAttribute(nestable.attributes, CssStyleFormatter.CSS_TEXT_ALIGN_ATTRIBUTE)
+            CssStyleFormatter.removeStyleAttribute(nestable.attributes, CssStyleAttribute.CSS_TEXT_ALIGN_ATTRIBUTE)
 
             nestable.align?.let {
                 val direction = TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR
                 val isRtl = direction.isRtl(text, start, end - start)
 
                 CssStyleFormatter.addStyleAttribute(nestable.attributes,
-                        CssStyleFormatter.CSS_TEXT_ALIGN_ATTRIBUTE, nestable.align!!.toCssString(isRtl))
+                        CssStyleAttribute.CSS_TEXT_ALIGN_ATTRIBUTE, nestable.align!!.toCssString(isRtl))
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -35,8 +35,8 @@ import org.wordpress.aztec.plugins.visual2html.IBlockSpanHandler
 import org.wordpress.aztec.plugins.visual2html.IHtmlPostprocessor
 import org.wordpress.aztec.plugins.visual2html.IInlineSpanHandler
 import org.wordpress.aztec.plugins.visual2html.ISpanPreprocessor
-import org.wordpress.aztec.source.CssStyleAttribute
 import org.wordpress.aztec.source.CssStyleFormatter
+import org.wordpress.aztec.source.CssStyleFormatter.Companion.CSS_TEXT_ALIGN_ATTRIBUTE
 import org.wordpress.aztec.spans.AztecCursorSpan
 import org.wordpress.aztec.spans.AztecHorizontalRuleSpan
 import org.wordpress.aztec.spans.AztecListItemSpan
@@ -424,14 +424,14 @@ class AztecParser @JvmOverloads constructor(private val alignmentRendering: Alig
                                nestable: IAztecParagraphStyle, parents: ArrayList<IAztecNestable>?, nestingLevel: Int) {
 
         if (nestable is IAztecAlignmentSpan && nestable.shouldParseAlignmentToHtml()) {
-            CssStyleFormatter.removeStyleAttribute(nestable.attributes, CssStyleAttribute.CSS_TEXT_ALIGN_ATTRIBUTE)
+            CssStyleFormatter.removeStyleAttribute(nestable.attributes, CSS_TEXT_ALIGN_ATTRIBUTE)
 
             nestable.align?.let {
                 val direction = TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR
                 val isRtl = direction.isRtl(text, start, end - start)
 
                 CssStyleFormatter.addStyleAttribute(nestable.attributes,
-                        CssStyleAttribute.CSS_TEXT_ALIGN_ATTRIBUTE, nestable.align!!.toCssString(isRtl))
+                        CSS_TEXT_ALIGN_ATTRIBUTE, nestable.align!!.toCssString(isRtl))
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -411,7 +411,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 InlineFormatter.CodeStyle(
                         styles.getColor(R.styleable.AztecText_codeBackground, 0),
                         styles.getFraction(R.styleable.AztecText_codeBackgroundAlpha, 1, 1, 0f),
-                        styles.getColor(R.styleable.AztecText_codeColor, 0)))
+                        styles.getColor(R.styleable.AztecText_codeColor, 0)),
+                InlineFormatter.HighlightStyle(styles.getResourceId(R.styleable.AztecText_highlightColor, R.color.grey_lighten_10)))
 
         blockFormatter = BlockFormatter(this,
                 BlockFormatter.ListStyle(
@@ -1146,6 +1147,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             AztecTextFormat.FORMAT_CITE,
             AztecTextFormat.FORMAT_UNDERLINE,
             AztecTextFormat.FORMAT_STRIKETHROUGH,
+            AztecTextFormat.FORMAT_HIGHLIGHT,
             AztecTextFormat.FORMAT_CODE -> inlineFormatter.toggle(textFormat)
             AztecTextFormat.FORMAT_BOLD,
             AztecTextFormat.FORMAT_STRONG -> inlineFormatter.toggleAny(ToolbarAction.BOLD.textFormats)
@@ -1182,6 +1184,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             AztecTextFormat.FORMAT_UNDERLINE,
             AztecTextFormat.FORMAT_STRIKETHROUGH,
             AztecTextFormat.FORMAT_MARK,
+            AztecTextFormat.FORMAT_HIGHLIGHT,
             AztecTextFormat.FORMAT_CODE -> return inlineFormatter.containsInlineStyle(format, selStart, selEnd)
             AztecTextFormat.FORMAT_UNORDERED_LIST,
             AztecTextFormat.FORMAT_ORDERED_LIST -> return blockFormatter.containsList(format, selStart, selEnd)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextFormat.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTextFormat.kt
@@ -36,4 +36,5 @@ enum class AztecTextFormat : ITextFormat {
     FORMAT_MONOSPACE,
     FORMAT_CODE,
     FORMAT_MARK,
+    FORMAT_HIGHLIGHT
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
@@ -7,6 +7,7 @@ import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.plugins.html2visual.ISpanPostprocessor
 import org.wordpress.aztec.plugins.visual2html.ISpanPreprocessor
+import org.wordpress.aztec.source.CssStyleAttribute
 import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecUnderlineSpan
 import org.wordpress.aztec.spans.HiddenHtmlSpan
@@ -26,8 +27,8 @@ class CssUnderlinePlugin(
 
     override fun beforeSpansProcessed(spannable: SpannableStringBuilder) {
         spannable.getSpans(0, spannable.length, AztecUnderlineSpan::class.java).filter { it.isCssStyle }.forEach {
-            if (!CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE)) {
-                CssStyleFormatter.addStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE, UNDERLINE_STYLE_VALUE)
+            if (!CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE)) {
+                CssStyleFormatter.addStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE, UNDERLINE_STYLE_VALUE)
             }
 
             val start = spannable.getSpanStart(it)
@@ -59,8 +60,8 @@ class CssUnderlinePlugin(
 
     override fun afterSpansProcessed(spannable: Spannable) {
         spannable.getSpans(0, spannable.length, HiddenHtmlSpan::class.java).forEach {
-            if (it.TAG == SPAN_TAG && CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE)) {
-                CssStyleFormatter.removeStyleAttribute(it.attributes, CssStyleFormatter.CSS_TEXT_DECORATION_ATTRIBUTE)
+            if (it.TAG == SPAN_TAG && CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE)) {
+                CssStyleFormatter.removeStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE)
                 spannable.setSpan(AztecUnderlineSpan(), spannable.getSpanStart(it), spannable.getSpanEnd(it), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
                 if (it.attributes.isEmpty()) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/CssUnderlinePlugin.kt
@@ -7,8 +7,8 @@ import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.plugins.html2visual.ISpanPostprocessor
 import org.wordpress.aztec.plugins.visual2html.ISpanPreprocessor
-import org.wordpress.aztec.source.CssStyleAttribute
 import org.wordpress.aztec.source.CssStyleFormatter
+import org.wordpress.aztec.source.CssStyleFormatter.Companion.CSS_TEXT_DECORATION_ATTRIBUTE
 import org.wordpress.aztec.spans.AztecUnderlineSpan
 import org.wordpress.aztec.spans.HiddenHtmlSpan
 import org.wordpress.aztec.spans.IAztecNestable
@@ -27,8 +27,8 @@ class CssUnderlinePlugin(
 
     override fun beforeSpansProcessed(spannable: SpannableStringBuilder) {
         spannable.getSpans(0, spannable.length, AztecUnderlineSpan::class.java).filter { it.isCssStyle }.forEach {
-            if (!CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE)) {
-                CssStyleFormatter.addStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE, UNDERLINE_STYLE_VALUE)
+            if (!CssStyleFormatter.containsStyleAttribute(it.attributes, CSS_TEXT_DECORATION_ATTRIBUTE)) {
+                CssStyleFormatter.addStyleAttribute(it.attributes, CSS_TEXT_DECORATION_ATTRIBUTE, UNDERLINE_STYLE_VALUE)
             }
 
             val start = spannable.getSpanStart(it)
@@ -60,8 +60,8 @@ class CssUnderlinePlugin(
 
     override fun afterSpansProcessed(spannable: Spannable) {
         spannable.getSpans(0, spannable.length, HiddenHtmlSpan::class.java).forEach {
-            if (it.TAG == SPAN_TAG && CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE)) {
-                CssStyleFormatter.removeStyleAttribute(it.attributes, CssStyleAttribute.CSS_TEXT_DECORATION_ATTRIBUTE)
+            if (it.TAG == SPAN_TAG && CssStyleFormatter.containsStyleAttribute(it.attributes, CSS_TEXT_DECORATION_ATTRIBUTE)) {
+                CssStyleFormatter.removeStyleAttribute(it.attributes, CSS_TEXT_DECORATION_ATTRIBUTE)
                 spannable.setSpan(AztecUnderlineSpan(), spannable.getSpanStart(it), spannable.getSpanEnd(it), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
                 if (it.attributes.isEmpty()) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -24,6 +24,10 @@ class CssStyleFormatter {
     companion object {
 
         val STYLE_ATTRIBUTE = "style"
+        val CSS_TEXT_DECORATION_ATTRIBUTE = "text-decoration"
+        val CSS_TEXT_ALIGN_ATTRIBUTE = "text-align"
+        val CSS_COLOR_ATTRIBUTE = "color"
+        val CSS_BACKGROUND_COLOR_ATTRIBUTE = "background-color"
 
         /**
          * Check the provided [attributedSpan] for the *style* attribute. If found, parse out the
@@ -48,7 +52,7 @@ class CssStyleFormatter {
 
         private fun processAlignment(blockSpan: IAztecParagraphStyle, text: Editable, start: Int, end: Int) {
             if (blockSpan is IAztecAlignmentSpan) {
-                val alignment = getStyleAttribute(blockSpan.attributes, CssStyleAttribute.CSS_TEXT_ALIGN_ATTRIBUTE)
+                val alignment = getStyleAttribute(blockSpan.attributes, CSS_TEXT_ALIGN_ATTRIBUTE)
                 if (!alignment.isBlank()) {
                     val direction = TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR
                     val isRtl = direction.isRtl(text, start, end - start)
@@ -75,7 +79,7 @@ class CssStyleFormatter {
         }
 
         private fun processColor(attributes: AztecAttributes, text: Editable, start: Int, end: Int) {
-            val colorAttrValue = getStyleAttribute(attributes, CssStyleAttribute.CSS_COLOR_ATTRIBUTE)
+            val colorAttrValue = getStyleAttribute(attributes, CSS_COLOR_ATTRIBUTE)
             if (!colorAttrValue.isBlank()) {
                 val colorInt = ColorConverter.getColorInt(colorAttrValue)
                 if (colorInt != ColorConverter.COLOR_NOT_FOUND) {
@@ -85,7 +89,7 @@ class CssStyleFormatter {
         }
 
         private fun processBackgroundColor(attributes: AztecAttributes, text: Editable, start: Int, end: Int) {
-            val colorAttrValue = getStyleAttribute(attributes, CssStyleAttribute.CSS_BACKGROUND_COLOR_ATTRIBUTE)
+            val colorAttrValue = getStyleAttribute(attributes, CSS_BACKGROUND_COLOR_ATTRIBUTE)
             if (!colorAttrValue.isBlank()) {
                 val colorInt = ColorConverter.getColorInt(colorAttrValue)
                 if (colorInt != ColorConverter.COLOR_NOT_FOUND) {
@@ -94,13 +98,13 @@ class CssStyleFormatter {
             }
         }
 
-        fun containsStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute): Boolean {
-            return attributes.hasAttribute(STYLE_ATTRIBUTE) && getMatcher(attributes, styleAttributeName.name).find()
+        fun containsStyleAttribute(attributes: AztecAttributes, styleAttributeName: String): Boolean {
+            return attributes.hasAttribute(STYLE_ATTRIBUTE) && getMatcher(attributes, styleAttributeName).find()
         }
 
-        fun removeStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute) {
+        fun removeStyleAttribute(attributes: AztecAttributes, styleAttributeName: String) {
             if (attributes.hasAttribute(STYLE_ATTRIBUTE)) {
-                val m = getMatcher(attributes, styleAttributeName.key)
+                val m = getMatcher(attributes, styleAttributeName)
                 var newStyle = m.replaceAll("")
 
                 if (newStyle.isBlank()) {
@@ -112,8 +116,8 @@ class CssStyleFormatter {
             }
         }
 
-        fun getStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute): String {
-            val m = getMatcher(attributes, styleAttributeName.key)
+        fun getStyleAttribute(attributes: AztecAttributes, styleAttributeName: String): String {
+            val m = getMatcher(attributes, styleAttributeName)
 
             var styleAttributeValue = ""
             if (m.find()) {
@@ -122,7 +126,7 @@ class CssStyleFormatter {
             return styleAttributeValue
         }
 
-        fun addStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute, styleAttributeValue: String) {
+        fun addStyleAttribute(attributes: AztecAttributes, styleAttributeName: String, styleAttributeValue: String) {
             var style = attributes.getValue(STYLE_ATTRIBUTE) ?: ""
             style = style.trim()
 
@@ -130,13 +134,13 @@ class CssStyleFormatter {
                 style += ";"
             }
 
-            style += " ${styleAttributeName.key}:$styleAttributeValue;"
+            style += " $styleAttributeName:$styleAttributeValue;"
             attributes.setValue(STYLE_ATTRIBUTE, style.trim())
         }
 
         fun mergeStyleAttributes(firstStyle: String, secondStyle: String): String {
             val firstStyles = firstStyle.trim().split(";").map { it.trim().replace(" ", "") }
-            var secondStyles = secondStyle.trim().split(";").map { it.trim().replace(" ", "") }
+              var secondStyles = secondStyle.trim().split(";").map { it.trim().replace(" ", "") }
 
             val mergedArray = firstStyles.union(secondStyles).filterNot { it.trim().isEmpty() }
 
@@ -147,11 +151,4 @@ class CssStyleFormatter {
             return style.trimEnd()
         }
     }
-}
-
-enum class CssStyleAttribute(val key: String) {
-    CSS_TEXT_DECORATION_ATTRIBUTE("text-decoration"),
-    CSS_TEXT_ALIGN_ATTRIBUTE("text-align"),
-    CSS_COLOR_ATTRIBUTE("color"),
-    CSS_BACKGROUND_COLOR_ATTRIBUTE("background-color")
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -4,6 +4,7 @@ import androidx.core.text.TextDirectionHeuristicsCompat
 import android.text.Editable
 import android.text.Layout
 import android.text.Spannable
+import android.text.style.BackgroundColorSpan
 import android.text.style.ForegroundColorSpan
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.spans.IAztecAlignmentSpan
@@ -26,6 +27,7 @@ class CssStyleFormatter {
         val CSS_TEXT_DECORATION_ATTRIBUTE = "text-decoration"
         val CSS_TEXT_ALIGN_ATTRIBUTE = "text-align"
         val CSS_COLOR_ATTRIBUTE = "color"
+        val CSS_BACKGROUND_COLOR_ATTRIBUTE = "background-color"
 
         /**
          * Check the provided [attributedSpan] for the *style* attribute. If found, parse out the
@@ -41,6 +43,7 @@ class CssStyleFormatter {
         fun applyInlineStyleAttributes(text: Editable, attributedSpan: IAztecAttributedSpan, start: Int, end: Int) {
             if (attributedSpan.attributes.hasAttribute(STYLE_ATTRIBUTE) && start != end) {
                 processColor(attributedSpan.attributes, text, start, end)
+                processBackgroundColor(attributedSpan.attributes, text, start, end)
                 if (attributedSpan is IAztecParagraphStyle) {
                     processAlignment(attributedSpan, text, start, end)
                 }
@@ -81,6 +84,16 @@ class CssStyleFormatter {
                 val colorInt = ColorConverter.getColorInt(colorAttrValue)
                 if (colorInt != ColorConverter.COLOR_NOT_FOUND) {
                     text.setSpan(ForegroundColorSpan(colorInt), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+                }
+            }
+        }
+
+        private fun processBackgroundColor(attributes: AztecAttributes, text: Editable, start: Int, end: Int) {
+            val colorAttrValue = getStyleAttribute(attributes, CSS_BACKGROUND_COLOR_ATTRIBUTE)
+            if (!colorAttrValue.isBlank()) {
+                val colorInt = ColorConverter.getColorInt(colorAttrValue)
+                if (colorInt != ColorConverter.COLOR_NOT_FOUND) {
+                    text.setSpan(BackgroundColorSpan(colorInt), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
                 }
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -140,7 +140,7 @@ class CssStyleFormatter {
 
         fun mergeStyleAttributes(firstStyle: String, secondStyle: String): String {
             val firstStyles = firstStyle.trim().split(";").map { it.trim().replace(" ", "") }
-              var secondStyles = secondStyle.trim().split(";").map { it.trim().replace(" ", "") }
+            var secondStyles = secondStyle.trim().split(";").map { it.trim().replace(" ", "") }
 
             val mergedArray = firstStyles.union(secondStyles).filterNot { it.trim().isEmpty() }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -24,10 +24,6 @@ class CssStyleFormatter {
     companion object {
 
         val STYLE_ATTRIBUTE = "style"
-        val CSS_TEXT_DECORATION_ATTRIBUTE = "text-decoration"
-        val CSS_TEXT_ALIGN_ATTRIBUTE = "text-align"
-        val CSS_COLOR_ATTRIBUTE = "color"
-        val CSS_BACKGROUND_COLOR_ATTRIBUTE = "background-color"
 
         /**
          * Check the provided [attributedSpan] for the *style* attribute. If found, parse out the
@@ -52,7 +48,7 @@ class CssStyleFormatter {
 
         private fun processAlignment(blockSpan: IAztecParagraphStyle, text: Editable, start: Int, end: Int) {
             if (blockSpan is IAztecAlignmentSpan) {
-                val alignment = getStyleAttribute(blockSpan.attributes, CSS_TEXT_ALIGN_ATTRIBUTE)
+                val alignment = getStyleAttribute(blockSpan.attributes, CssStyleAttribute.CSS_TEXT_ALIGN_ATTRIBUTE)
                 if (!alignment.isBlank()) {
                     val direction = TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR
                     val isRtl = direction.isRtl(text, start, end - start)
@@ -79,7 +75,7 @@ class CssStyleFormatter {
         }
 
         private fun processColor(attributes: AztecAttributes, text: Editable, start: Int, end: Int) {
-            val colorAttrValue = getStyleAttribute(attributes, CSS_COLOR_ATTRIBUTE)
+            val colorAttrValue = getStyleAttribute(attributes, CssStyleAttribute.CSS_COLOR_ATTRIBUTE)
             if (!colorAttrValue.isBlank()) {
                 val colorInt = ColorConverter.getColorInt(colorAttrValue)
                 if (colorInt != ColorConverter.COLOR_NOT_FOUND) {
@@ -89,7 +85,7 @@ class CssStyleFormatter {
         }
 
         private fun processBackgroundColor(attributes: AztecAttributes, text: Editable, start: Int, end: Int) {
-            val colorAttrValue = getStyleAttribute(attributes, CSS_BACKGROUND_COLOR_ATTRIBUTE)
+            val colorAttrValue = getStyleAttribute(attributes, CssStyleAttribute.CSS_BACKGROUND_COLOR_ATTRIBUTE)
             if (!colorAttrValue.isBlank()) {
                 val colorInt = ColorConverter.getColorInt(colorAttrValue)
                 if (colorInt != ColorConverter.COLOR_NOT_FOUND) {
@@ -98,13 +94,13 @@ class CssStyleFormatter {
             }
         }
 
-        fun containsStyleAttribute(attributes: AztecAttributes, styleAttributeName: String): Boolean {
-            return attributes.hasAttribute(STYLE_ATTRIBUTE) && getMatcher(attributes, styleAttributeName).find()
+        fun containsStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute): Boolean {
+            return attributes.hasAttribute(STYLE_ATTRIBUTE) && getMatcher(attributes, styleAttributeName.name).find()
         }
 
-        fun removeStyleAttribute(attributes: AztecAttributes, styleAttributeName: String) {
+        fun removeStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute) {
             if (attributes.hasAttribute(STYLE_ATTRIBUTE)) {
-                val m = getMatcher(attributes, styleAttributeName)
+                val m = getMatcher(attributes, styleAttributeName.key)
                 var newStyle = m.replaceAll("")
 
                 if (newStyle.isBlank()) {
@@ -116,8 +112,8 @@ class CssStyleFormatter {
             }
         }
 
-        fun getStyleAttribute(attributes: AztecAttributes, styleAttributeName: String): String {
-            val m = getMatcher(attributes, styleAttributeName)
+        fun getStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute): String {
+            val m = getMatcher(attributes, styleAttributeName.key)
 
             var styleAttributeValue = ""
             if (m.find()) {
@@ -126,7 +122,7 @@ class CssStyleFormatter {
             return styleAttributeValue
         }
 
-        fun addStyleAttribute(attributes: AztecAttributes, styleAttributeName: String, styleAttributeValue: String) {
+        fun addStyleAttribute(attributes: AztecAttributes, styleAttributeName: CssStyleAttribute, styleAttributeValue: String) {
             var style = attributes.getValue(STYLE_ATTRIBUTE) ?: ""
             style = style.trim()
 
@@ -134,7 +130,7 @@ class CssStyleFormatter {
                 style += ";"
             }
 
-            style += " $styleAttributeName:$styleAttributeValue;"
+            style += " ${styleAttributeName.key}:$styleAttributeValue;"
             attributes.setValue(STYLE_ATTRIBUTE, style.trim())
         }
 
@@ -151,4 +147,11 @@ class CssStyleFormatter {
             return style.trimEnd()
         }
     }
+}
+
+enum class CssStyleAttribute(val key: String) {
+    CSS_TEXT_DECORATION_ATTRIBUTE("text-decoration"),
+    CSS_TEXT_ALIGN_ATTRIBUTE("text-align"),
+    CSS_COLOR_ATTRIBUTE("color"),
+    CSS_BACKGROUND_COLOR_ATTRIBUTE("background-color")
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
@@ -10,7 +10,8 @@ import org.wordpress.aztec.formatting.InlineFormatter
 class HighlightSpan(
         override var attributes: AztecAttributes = AztecAttributes(),
         highlightStyle: InlineFormatter.HighlightStyle = InlineFormatter.HighlightStyle(R.color.grey_lighten_10),
-        context: Context) : BackgroundColorSpan(ContextCompat.getColor(context, highlightStyle.color)), IAztecInlineSpan {
+        context: Context
+) : BackgroundColorSpan(ContextCompat.getColor(context, highlightStyle.color)), IAztecInlineSpan {
 
     override var TAG = "highlight"
     companion object {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
@@ -1,0 +1,20 @@
+package org.wordpress.aztec.spans
+
+import android.content.Context
+import android.text.style.BackgroundColorSpan
+import androidx.core.content.ContextCompat
+import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.R
+import org.wordpress.aztec.formatting.InlineFormatter
+
+class HighlightSpan(
+        override var attributes: AztecAttributes = AztecAttributes(),
+        highlightStyle: InlineFormatter.HighlightStyle = InlineFormatter.HighlightStyle(R.color.grey_lighten_10),
+        context: Context) : BackgroundColorSpan(ContextCompat.getColor(context, highlightStyle.color)), IAztecInlineSpan {
+
+    override var TAG = "highlight"
+    companion object {
+        @JvmStatic
+        fun create(attributes: AztecAttributes, context: Context) = HighlightSpan(attributes = attributes, context = context)
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
@@ -37,6 +37,12 @@ enum class ToolbarAction constructor(
             ToolbarActionType.BLOCK_STYLE,
             setOf(AztecTextFormat.FORMAT_NONE),
             R.layout.format_bar_button_list),
+    HIGHLIGHT(
+            R.id.format_bar_button_highlight,
+            R.drawable.format_bar_button_highlight_selector,
+            ToolbarActionType.INLINE_STYLE,
+            setOf(AztecTextFormat.FORMAT_HIGHLIGHT),
+            R.layout.format_bar_button_highlight),
     BOLD(
             R.id.format_bar_button_bold,
             R.drawable.format_bar_button_bold_selector,

--- a/aztec/src/main/res/drawable/format_bar_button_highlight.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/toolbarIconNormalColor"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:pivotX="12"
+        android:pivotY="12"
+        android:scaleX="0.7"
+        android:scaleY="0.7">
+        <path
+            android:fillColor="@color/white"
+            android:pathData="@string/format_bar_button_highlight_path" />
+    </group>
+</vector>

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_background.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/grey_lighten_20" />
+    <corners android:radius="2dp" />
+</shape>

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_disabled.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/toolbarIconHighlightColor"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <group
+        android:pivotX="12"
+        android:pivotY="12"
+        android:scaleX="0.7"
+        android:scaleY="0.7">
+        <path
+            android:fillColor="@color/white"
+            android:pathData="@string/format_bar_button_highlight_path" />
+    </group>
+
+</vector>

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_disabled_with_background.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_disabled_with_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/format_bar_button_highlight_background"
+        android:bottom="8dp"
+        android:left="8dp"
+        android:right="8dp"
+        android:top="8dp" />
+    <item
+        android:drawable="@drawable/format_bar_button_highlight_disabled" />
+</layer-list>

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_highlighted.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/toolbarIconHighlightColor"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <group
+        android:pivotX="12"
+        android:pivotY="12"
+        android:scaleX="0.7"
+        android:scaleY="0.7">
+        <path
+            android:fillColor="@color/white"
+            android:pathData="@string/format_bar_button_highlight_path" />
+    </group>
+
+</vector>

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_highlighted_with_background.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_highlighted_with_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/format_bar_button_highlight_background"
+        android:bottom="8dp"
+        android:left="8dp"
+        android:right="8dp"
+        android:top="8dp" />
+    <item
+        android:drawable="@drawable/format_bar_button_highlight_disabled" />
+</layer-list>

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_selector.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:targetApi="lollipop">
+
+    <item android:drawable="@drawable/format_bar_button_highlight_disabled_with_background" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_highlight_highlighted_with_background" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_highlight_highlighted_with_background" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_highlight_with_background" />
+
+</animated-selector>

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_with_background.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_with_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/format_bar_button_highlight_background"
+        android:bottom="8dp"
+        android:left="8dp"
+        android:right="8dp"
+        android:top="8dp" />
+    <item
+        android:drawable="@drawable/format_bar_button_highlight" />
+</layer-list>

--- a/aztec/src/main/res/layout/format_bar_button_highlight.xml
+++ b/aztec/src/main/res/layout/format_bar_button_highlight.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.wordpress.aztec.toolbar.RippleToggleButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/format_bar_button_highlight"
+    style="@style/FormatBarButton"
+    android:layout_width="wrap_content"
+    android:layout_height="fill_parent"
+    android:contentDescription="@string/format_bar_description_highlight" />

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -13,6 +13,7 @@
         <attr name="codeBackground" format="reference|color" />
         <attr name="codeBackgroundAlpha" format="reference|fraction" />
         <attr name="codeColor" format="reference|color" />
+        <attr name="highlightColor" format="reference|color" />
         <attr name="drawableFailed" format="reference" />
         <attr name="drawableLoading" format="reference" />
         <attr name="historyEnable" format="reference|boolean" />

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <!-- FORMAT -->
     <string name="format_bar_description_heading">Heading</string>
     <string name="format_bar_description_bold">Bold</string>
+    <string name="format_bar_description_highlight">Highlight</string>
     <string name="format_bar_description_italic">Italic</string>
     <string name="format_bar_description_underline">Underline</string>
     <string name="format_bar_description_strike">Strikethrough</string>
@@ -127,5 +128,6 @@
     <string name="key_single_x">X</string>
     <string name="key_single_y">Y</string>
     <string name="key_single_z">Z</string>
+    <string name="format_bar_button_highlight_path" translatable="false">M12.9 6h-2l-4 11h1.9l1.1-3h4.2l1.1 3h1.9L12.9 6zm-2.5 6.5l1.5-4.9 1.7 4.9h-3.2z</string>
 
 </resources>


### PR DESCRIPTION
### Fix
https://github.com/wordpress-mobile/AztecEditor-Android/issues/961

This PR adds 2 features:
- `highlight` action which is a new inline style that allows the user to highlight a certain part of text with background color
- support for css `background-color` style 


### Test
1. Set the `highlightColor` attribute on `aztecText` in your layout
2. Enable the `HIGHLIGHT` toolbar action on the `AztecToolbar`
3. Run the app
4. Notice the `highlight` action visible
5. Select a text
6. Click on `highlight` 
7. Notice the text background is now of the selected color.


### Test 2
1. Set the `background-color` style in the `MainActivity` default HTML
2. Notice the color is drawn on the chosen element 


https://user-images.githubusercontent.com/1079756/155984409-4a508814-0dad-4a1d-be4b-fb2820dbbe90.mp4




### Review


Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.