### PR TITLE
Enable exclusive blocks in AztecText.kt

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -435,7 +435,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         getPreformatBackgroundAlpha(styles),
                         styles.getColor(R.styleable.AztecText_preformatColor, 0),
                         verticalParagraphMargin),
-                alignmentRendering
+                alignmentRendering,
+                BlockFormatter.ExclusiveBlockStyles(styles.getBoolean(R.styleable.AztecText_exclusiveBlocks, false))
         )
 
         linkFormatter = LinkFormatter(this, LinkFormatter.LinkStyle(styles.getColor(

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -116,7 +116,7 @@ class BlockFormatter(editor: AztecText,
 
     fun togglePreformat() {
         if (!containsPreformat()) {
-                if (containsOtherHeadings(AztecTextFormat.FORMAT_PREFORMAT)) {
+                if (containsOtherHeadings(AztecTextFormat.FORMAT_PREFORMAT) && !exclusiveBlockStyles.enabled) {
                     switchHeadingToPreformat()
                 } else {
                     applyBlockStyle(AztecTextFormat.FORMAT_PREFORMAT)
@@ -135,7 +135,7 @@ class BlockFormatter(editor: AztecText,
             AztecTextFormat.FORMAT_HEADING_5,
             AztecTextFormat.FORMAT_HEADING_6 -> {
                 if (!containsHeadingOnly(textFormat)) {
-                    if (containsPreformat()) {
+                    if (containsPreformat() && !exclusiveBlockStyles.enabled) {
                         switchPreformatToHeading(textFormat)
                     } else if (containsOtherHeadings(textFormat)) {
                         switchHeaderType(textFormat)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -46,12 +46,14 @@ class BlockFormatter(editor: AztecText,
                      private val quoteStyle: QuoteStyle,
                      private val headerStyle: HeaderStyle,
                      private val preformatStyle: PreformatStyle,
-                     private val alignmentRendering: AlignmentRendering
+                     private val alignmentRendering: AlignmentRendering,
+                     private val exclusiveBlockStyles: ExclusiveBlockStyles
 ) : AztecFormatter(editor) {
     data class ListStyle(val indicatorColor: Int, val indicatorMargin: Int, val indicatorPadding: Int, val indicatorWidth: Int, val verticalPadding: Int)
     data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteBackgroundAlpha: Float, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
     data class PreformatStyle(val preformatBackground: Int, val preformatBackgroundAlpha: Float, val preformatColor: Int, val verticalPadding: Int)
     data class HeaderStyle(val verticalPadding: Int)
+    data class ExclusiveBlockStyles(val enabled: Boolean = false)
 
     fun toggleOrderedList() {
         if (!containsList(AztecTextFormat.FORMAT_ORDERED_LIST, 0)) {
@@ -210,6 +212,78 @@ class BlockFormatter(editor: AztecText,
         }
 
         return changed
+    }
+
+    /**
+     * This method makes sure only one block style is ever applied to part of the text. The following block styles are
+     * made exclusive if the option is enabled:
+     * - all the lists
+     * - all the headings
+     * - quote
+     * - preformat
+     */
+    private fun removeBlockStylesFromSelectedLine(appliedClass: IAztecBlockSpan) {
+        // We only want to remove the previous block styles if this option is enabled
+        if (!exclusiveBlockStyles.enabled) {
+            return
+        }
+        val selectionStart = editor.selectionStart
+
+        // try to remove block styling when pressing backspace at the beginning of the text
+        editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java).forEach {
+            // We want to remove any list item span that's being converted to another block
+            if (it is AztecListItemSpan) {
+                editableText.removeSpan(it)
+                return@forEach
+            }
+            // Only these supported blocks will be split/removed on block change
+            val format = when (it) {
+                is AztecHeadingSpan -> it.textFormat
+                is AztecOrderedListSpan -> AztecTextFormat.FORMAT_ORDERED_LIST
+                is AztecUnorderedListSpan -> AztecTextFormat.FORMAT_UNORDERED_LIST
+                is AztecTaskListSpan -> AztecTextFormat.FORMAT_TASK_LIST
+                is AztecListItemSpan -> AztecTextFormat.FORMAT_UNORDERED_LIST
+                is AztecQuoteSpan -> AztecTextFormat.FORMAT_QUOTE
+                is AztecPreformatSpan -> AztecTextFormat.FORMAT_PREFORMAT
+                else -> return@forEach
+            }
+            // We do not want to handle cases where the applied style is already existing on a span
+            if (it.javaClass == appliedClass.javaClass) {
+                return@forEach
+            }
+            val spanStart = editableText.getSpanStart(it)
+            val spanEnd = editableText.getSpanEnd(it)
+            val spanFlags = editableText.getSpanFlags(it)
+            val nextLineLength = "\n".length
+            // Defines end of a line in a block
+            val lineEnd = editableText.indexOf("\n", selectionEnd) + nextLineLength
+            // Defines start of a line in a block
+            val lineStart = if (lineEnd == selectionStart + nextLineLength) {
+                editableText.lastIndexOf("\n", selectionStart - 1)
+            } else {
+                editableText.lastIndexOf("\n", selectionStart)
+            } + nextLineLength
+            val spanStartsBeforeLineStart = spanStart < lineStart
+            val spanEndsAfterLineEnd = spanEnd > lineEnd
+            if (spanStartsBeforeLineStart && spanEndsAfterLineEnd) {
+                // The line is fully inside of the span so we want to split span in two around the selected line
+                val copy = makeBlock(format, it.nestingLevel, it.attributes).first()
+                editableText.removeSpan(it)
+                editableText.setSpan(it, spanStart, lineStart, spanFlags)
+                editableText.setSpan(copy, lineEnd, spanEnd, spanFlags)
+            } else if (!spanStartsBeforeLineStart && spanEndsAfterLineEnd) {
+                // If the selected line is at the beginning of a span, move the span start to the end of the line
+                editableText.removeSpan(it)
+                editableText.setSpan(it, lineEnd, spanEnd, spanFlags)
+            } else if (spanStartsBeforeLineStart && !spanEndsAfterLineEnd) {
+                // If the selected line is at the end of a span, move the span end to the start of the line
+                editableText.removeSpan(it)
+                editableText.setSpan(it, spanStart, lineStart, spanFlags)
+            } else {
+                // In this case the line fully covers the span so we just want to remove the span
+                editableText.removeSpan(it)
+            }
+        }
     }
 
     fun removeBlockStyle(textFormat: ITextFormat) {
@@ -568,6 +642,7 @@ class BlockFormatter(editor: AztecText,
         val boundsOfSelectedText = getBoundsOfText(editableText, start, end)
         val nestingLevel = IAztecNestable.getNestingLevelAt(editableText, start) + 1
         val spanToApply = makeBlockSpan(blockElementType, nestingLevel)
+        removeBlockStylesFromSelectedLine(spanToApply)
 
         if (start != end) {
             // we want to push line blocks as deep as possible, because they can't contain other block elements (e.g. headings)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -236,17 +236,12 @@ class BlockFormatter(editor: AztecText,
                 editableText.removeSpan(it)
                 return@forEach
             }
-            // Only these supported blocks will be split/removed on block change
-            val format = when (it) {
-                is AztecHeadingSpan -> it.textFormat
-                is AztecOrderedListSpan -> AztecTextFormat.FORMAT_ORDERED_LIST
-                is AztecUnorderedListSpan -> AztecTextFormat.FORMAT_UNORDERED_LIST
-                is AztecTaskListSpan -> AztecTextFormat.FORMAT_TASK_LIST
-                is AztecListItemSpan -> AztecTextFormat.FORMAT_UNORDERED_LIST
-                is AztecQuoteSpan -> AztecTextFormat.FORMAT_QUOTE
-                is AztecPreformatSpan -> AztecTextFormat.FORMAT_PREFORMAT
-                else -> return@forEach
+            // We don't mind the paragraph blocks which wrap everything
+            if (it is ParagraphSpan) {
+                return@forEach
             }
+            // Only these supported blocks will be split/removed on block change
+            val format = it.textFormat ?: return@forEach
             // We do not want to handle cases where the applied style is already existing on a span
             if (it.javaClass == appliedClass.javaClass) {
                 return@forEach

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -256,13 +256,15 @@ class BlockFormatter(editor: AztecText,
             val spanFlags = editableText.getSpanFlags(it)
             val nextLineLength = "\n".length
             // Defines end of a line in a block
-            val lineEnd = editableText.indexOf("\n", selectionEnd) + nextLineLength
+            val previousLineBreak = editableText.indexOf("\n", selectionEnd)
+            val lineEnd = if (previousLineBreak > -1) { previousLineBreak + nextLineLength } else spanEnd
             // Defines start of a line in a block
-            val lineStart = if (lineEnd == selectionStart + nextLineLength) {
+            val nextLineBreak = if (lineEnd == selectionStart + nextLineLength) {
                 editableText.lastIndexOf("\n", selectionStart - 1)
             } else {
                 editableText.lastIndexOf("\n", selectionStart)
-            } + nextLineLength
+            }
+            val lineStart = if (nextLineBreak > -1) { nextLineBreak + nextLineLength } else spanStart
             val spanStartsBeforeLineStart = spanStart < lineStart
             val spanEndsAfterLineEnd = spanEnd > lineEnd
             if (spanStartsBeforeLineStart && spanEndsAfterLineEnd) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -71,7 +71,7 @@ open class AztecHeadingSpan(
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 
-    var textFormat: ITextFormat = AztecTextFormat.FORMAT_HEADING_1
+    override var textFormat: ITextFormat = AztecTextFormat.FORMAT_HEADING_1
         set(value) {
             field = value
             heading = textFormatToHeading(value)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
@@ -3,6 +3,8 @@ package org.wordpress.aztec.spans
 import android.text.Layout
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 import java.lang.StringBuilder
 
 fun createListItemSpan(nestingLevel: Int,
@@ -67,6 +69,7 @@ open class AztecListItemSpan(
             }
 
         }
+    override val textFormat: ITextFormat? = null
 
     override val TAG = "li"
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
@@ -3,7 +3,6 @@ package org.wordpress.aztec.spans
 import android.text.Layout
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
-import org.wordpress.aztec.AztecTextFormat
 import org.wordpress.aztec.ITextFormat
 import java.lang.StringBuilder
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -23,6 +23,8 @@ import android.text.Layout
 import android.text.Spanned
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.formatting.BlockFormatter
 
 fun createOrderedListSpan(
@@ -125,4 +127,6 @@ open class AztecOrderedListSpan(
         p.color = oldColor
         p.style = style
     }
+
+    override val textFormat: ITextFormat = AztecTextFormat.FORMAT_ORDERED_LIST
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -12,6 +12,8 @@ import android.text.style.LineHeightSpan
 import android.text.style.TypefaceSpan
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.formatting.BlockFormatter
 
 fun createPreformatSpan(
@@ -19,7 +21,7 @@ fun createPreformatSpan(
         alignmentRendering: AlignmentRendering,
         attributes: AztecAttributes = AztecAttributes(),
         preformatStyle: BlockFormatter.PreformatStyle = BlockFormatter.PreformatStyle(0, 0f, 0, 0)
-) : AztecPreformatSpan =
+): AztecPreformatSpan =
         when (alignmentRendering) {
             AlignmentRendering.SPAN_LEVEL -> AztecPreformatSpanAligned(nestingLevel, attributes, preformatStyle)
             AlignmentRendering.VIEW_LEVEL -> AztecPreformatSpan(nestingLevel, attributes, preformatStyle)
@@ -44,12 +46,11 @@ open class AztecPreformatSpan(
         override var nestingLevel: Int,
         override var attributes: AztecAttributes,
         open var preformatStyle: BlockFormatter.PreformatStyle
-    ) : IAztecBlockSpan,
+) : IAztecBlockSpan,
         LeadingMarginSpan,
         LineBackgroundSpan,
         LineHeightSpan,
-        TypefaceSpan("monospace")
-    {
+        TypefaceSpan("monospace") {
     override val TAG: String = "pre"
 
     override var endBeforeBleed: Int = -1
@@ -105,4 +106,6 @@ open class AztecPreformatSpan(
     override fun getLeadingMargin(first: Boolean): Int {
         return MARGIN
     }
+
+    override val textFormat: ITextFormat = AztecTextFormat.FORMAT_PREFORMAT
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -35,6 +35,8 @@ import android.text.style.UpdateLayout
 import androidx.collection.ArrayMap
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.formatting.BlockFormatter
 import java.util.Locale
 
@@ -67,12 +69,11 @@ open class AztecQuoteSpan(
         override var nestingLevel: Int,
         override var attributes: AztecAttributes,
         var quoteStyle: BlockFormatter.QuoteStyle
-    ) : QuoteSpan(),
+) : QuoteSpan(),
         LineBackgroundSpan,
         IAztecBlockSpan,
         LineHeightSpan,
-        UpdateLayout
-    {
+        UpdateLayout {
 
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
@@ -197,4 +198,5 @@ open class AztecQuoteSpan(
         return textDirectionHeuristic.isRtl(text, start, end - start)
     }
 
+    override val textFormat: ITextFormat = AztecTextFormat.FORMAT_QUOTE
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
@@ -25,6 +25,8 @@ import android.text.Layout
 import android.text.Spanned
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.R
 import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.setTaskList
@@ -134,4 +136,6 @@ open class AztecTaskListSpan(
         }
         return sortedSpans.getOrNull(lineIndex - 1)?.attributes?.getValue("checked") == "true"
     }
+
+    override val textFormat: ITextFormat = AztecTextFormat.FORMAT_TASK_LIST
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
@@ -129,6 +129,9 @@ open class AztecTaskListSpan(
     private fun isChecked(text: CharSequence, lineIndex: Int): Boolean {
         val spanStart = (text as Spanned).getSpanStart(this)
         val spanEnd = text.getSpanEnd(this)
-        return text.getSpans(spanStart, spanEnd, AztecListItemSpan::class.java).getOrNull(lineIndex - 1)?.attributes?.getValue("checked") == "true"
+        val sortedSpans = text.getSpans(spanStart, spanEnd, AztecListItemSpan::class.java).sortedBy {
+            text.getSpanStart(it)
+        }
+        return sortedSpans.getOrNull(lineIndex - 1)?.attributes?.getValue("checked") == "true"
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -23,6 +23,8 @@ import android.text.Layout
 import android.text.Spanned
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.formatting.BlockFormatter
 
 fun createUnorderedListSpan(
@@ -93,4 +95,6 @@ open class AztecUnorderedListSpan(
         p.color = oldColor
         p.style = style
     }
+
+    override val textFormat: ITextFormat = AztecTextFormat.FORMAT_UNORDERED_LIST
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlBlockSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HiddenHtmlBlockSpan.kt
@@ -3,6 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.Layout
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.ITextFormat
 
 fun createHiddenHtmlBlockSpan(tag: String,
                               alignmentRendering: AlignmentRendering,
@@ -34,4 +35,5 @@ open class HiddenHtmlBlockSpan(tag: String,
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
     override val TAG: String = tag
+    override val textFormat: ITextFormat? = null
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecBlockSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecBlockSpan.kt
@@ -1,3 +1,11 @@
 package org.wordpress.aztec.spans
 
-interface IAztecBlockSpan : IAztecParagraphStyle, IAztecSurroundedWithNewlines, IParagraphFlagged
+import org.wordpress.aztec.ITextFormat
+
+interface IAztecBlockSpan : IAztecParagraphStyle, IAztecSurroundedWithNewlines, IParagraphFlagged {
+    /**
+     * Marks the text format associated with the block span. This field is not mandatory as some block styles don't
+     * have text formats.
+     */
+    val textFormat: ITextFormat?
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
@@ -3,10 +3,12 @@ package org.wordpress.aztec.spans
 import android.text.Layout
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 
 fun createParagraphSpan(nestingLevel: Int,
                         alignmentRendering: AlignmentRendering,
-                        attributes: AztecAttributes = AztecAttributes()) : IAztecBlockSpan =
+                        attributes: AztecAttributes = AztecAttributes()): IAztecBlockSpan =
         when (alignmentRendering) {
             AlignmentRendering.SPAN_LEVEL -> ParagraphSpanAligned(nestingLevel, attributes, null)
             AlignmentRendering.VIEW_LEVEL -> ParagraphSpan(nestingLevel, attributes)
@@ -14,7 +16,7 @@ fun createParagraphSpan(nestingLevel: Int,
 
 fun createParagraphSpan(nestingLevel: Int,
                         align: Layout.Alignment?,
-                        attributes: AztecAttributes = AztecAttributes()) : IAztecBlockSpan =
+                        attributes: AztecAttributes = AztecAttributes()): IAztecBlockSpan =
         ParagraphSpanAligned(nestingLevel, attributes, align)
 
 /**
@@ -33,6 +35,7 @@ open class ParagraphSpan(
 
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
+    override val textFormat: ITextFormat = AztecTextFormat.FORMAT_PARAGRAPH
 }
 
 class ParagraphSpanAligned(

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -33,6 +33,7 @@
         <attr name="quoteWidth" format="reference|dimension" />
         <attr name="textColor" format="reference|color" />
         <attr name="textColorHint" format="reference|color" />
+        <attr name="exclusiveBlocks" format="reference|boolean" />
     </declare-styleable>
 
     <declare-styleable name="AztecToolbar">

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
@@ -1,6 +1,8 @@
 package org.wordpress.aztec.plugins.wpcomments.spans
 
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.spans.IAztecBlockSpan
 
 class GutenbergCommentSpan(
@@ -18,4 +20,6 @@ class GutenbergCommentSpan(
         set(value) {
             _endTag = value
         }
+
+    override val textFormat: ITextFormat? = null
 }

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergCommentSpan.kt
@@ -1,7 +1,6 @@
 package org.wordpress.aztec.plugins.wpcomments.spans
 
 import org.wordpress.aztec.AztecAttributes
-import org.wordpress.aztec.AztecTextFormat
 import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.spans.IAztecBlockSpan
 

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/spans/CaptionShortcodeSpan.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/spans/CaptionShortcodeSpan.kt
@@ -7,7 +7,9 @@ import android.text.style.StyleSpan
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.AztecTextFormat
 import org.wordpress.aztec.Constants
+import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.spans.IAztecAlignmentSpan
 import org.wordpress.aztec.spans.IAztecBlockSpan
 import org.wordpress.aztec.util.SpanWrapper
@@ -115,4 +117,6 @@ open class CaptionShortcodeSpan(
         }
         return end
     }
+
+    override val textFormat: ITextFormat? = null
 }

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/spans/CaptionShortcodeSpan.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/spans/CaptionShortcodeSpan.kt
@@ -7,7 +7,6 @@ import android.text.style.StyleSpan
 import org.wordpress.aztec.AlignmentRendering
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
-import org.wordpress.aztec.AztecTextFormat
 import org.wordpress.aztec.Constants
 import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.spans.IAztecAlignmentSpan


### PR DESCRIPTION
### Fix
https://github.com/wordpress-mobile/AztecEditor-Android/issues/969

In this PR I've added an optional setting which when set makes block styles exclusive. 

### Before test
Make sure you enable all the block styles in the MainActivity by calling:
```
        toolbar.setToolbarItems(ToolbarItems.BasicLayout(
                ToolbarAction.HEADING, ToolbarAction.LIST, ToolbarAction.QUOTE, ToolbarAction.PREFORMAT
        ))
```
Make sure you set this style on `AztecTextStyle`
```
<item name="exclusiveBlocks">true</item>
```

### Test a
1. Click on a heading
2. Select "Preformat" style
3. Notice that the heading style is removed and the preformat is applied
4. Select "heading" style
5. Notice the heading style is reapplied

### Test 2
1. Click on a list item (try first, last and an item in the middle)
2. Select "Heading" style
3. Notice that the item is removed from the list and the style is applied

### Test 3
1. Test various combinations of block styles

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.