### PR TITLE
Fix issue when adding image when no blocks are present

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -182,7 +182,6 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
             }
         } else {
             ssb.append("\n")
-
             val ssbLength = ssb.length
             editableText.getSpans(position, position + ssbLength, IAztecBlockSpan::class.java).filter {
                 it !is AztecMediaSpan && editableText.getSpanStart(it) == position
@@ -238,6 +237,12 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
             if (spanEnd > position) {
                 position = spanEnd
             }
+        }
+        if (position <= 0 && selectionEnd != 0) {
+            position = editableText.indexOf("\n", selectionEnd)
+        }
+        if (position <= 0 && selectionEnd != 0) {
+            position = editableText.length
         }
         return position
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -231,6 +231,9 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
     }
 
     private fun getEndOfBlock(): Int {
+        if (selectionStart == 0 && selectionEnd == 0) {
+            return 0
+        }
         var position = 0
         editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java).forEach {
             val spanEnd = editableText.getSpanEnd(it)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -239,10 +239,8 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
             }
         }
         if (position <= 0 && selectionEnd != 0) {
-            position = editableText.indexOf("\n", selectionEnd)
-        }
-        if (position <= 0 && selectionEnd != 0) {
-            position = editableText.length
+            // If the text contains "\n" return that as the position, else set the position to the end of the text
+            position = editableText.indexOf("\n", selectionEnd).takeIf { it >= 0 } ?: editableText.length
         }
         return position
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
@@ -137,4 +137,30 @@ class ImageBlockTest {
 
         Assert.assertEquals("<h1>Headline 1</h1><hr /><h2>Headline 2</h2>", editText.toHtml())
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun addImageAtTheEndWhenNoBlocksPresent() {
+        editText.fromHtml("Test 1<br>test 2<br>test 3")
+
+        editText.setSelection(editText.editableText.indexOf("3"))
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("Test 1<br>test 2<br>test 3<img id=\"1234\" />", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addImageInTheMiddleWhenNoBlocksPresent() {
+        editText.fromHtml("Test 1<br>test 2<br>test 3")
+
+        editText.setSelection(editText.editableText.indexOf("2"))
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("Test 1<br>test 2<img id=\"1234\" /><br>test 3", editText.toHtml())
+    }
 }


### PR DESCRIPTION
### Fix
There is an issue that when there are no blocks in the selection and the user wants to add an image. In that case the selection is set to 0 and the image is added to the beginning of the editor. 

I've added unit tests to cover this functionality as well

### Test
1. Turn on `aztec.visualEditor.addMediaAfterBlocks()` in the `MainActivity`
2. Set `EXAMPLE` to something like `<h1>Test 1</h1>\nBody`
3. Run the app
4. Click at the end of `Body`
5. Add an image
6. Check it gets added after the `Body` and not at the beginning of the editor

### Review
@AmandaRiu 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.