### PR TITLE
Avoid creating loading drawables when there are no images/videos to load

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1370,6 +1370,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private fun loadImages() {
         val spans = this.text.getSpans(0, text.length, AztecImageSpan::class.java)
+
+        // Avoid the work of getting placeholder drawable if there are no images. This becomes a big
+        // on screens that have many AztecText views
+        if (spans.isEmpty()) {
+            return
+        }
+
         val loadingDrawable = getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
 
         // Make sure to keep a reference to the maxWidth, otherwise in the Callbacks there is
@@ -1404,6 +1411,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private fun loadVideos() {
         val spans = this.text.getSpans(0, text.length, AztecVideoSpan::class.java)
+
+        // Avoid the work of getting placeholder drawable if there are no videos. This becomes a big
+        // on screens that have many AztecText views
+        if (spans.isEmpty()) {
+            return
+        }
+
         val loadingDrawable = getPlaceholderDrawableFromResID(context, drawableLoading, maxImagesWidth)
         val videoListenerRef = this.onVideoInfoRequestedListener
 


### PR DESCRIPTION
Improves performance by only creating the placeholder drawables for images and videos when there are images or videos, instead of doing it every time we call `fromHtml`. This makes a big difference in performance when there are a lot of `AztecText` views on the screen at once (i.e., in [Gutenberg-Mobile](https://github.com/wordpress-mobile/gutenberg-mobile)).

Before this change, scrolling from the top to the bottom of a Gutenberg post containing 500 paragraph blocks could cause the device to allocate and deallocate over a gigabyte of data to create VectorDrawables and Bitmaps for image and video placeholders for every block. After this change, there is no memory allocated or deallocated for that purpose when there are no image or video spans in the HTML passed to Aztec.

Please read [the PR description in the WPAndroid repo](https://github.com/wordpress-mobile/WordPress-Android/pull/16490) for more information.

### Test
1. Verify that the Aztec demo app still works fine
2. Verify that Gutenberg still works fine via the tests described in the WPAndroid PR

Make sure strings will be translated:

- [X] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.