### PR TITLE
Enable media within paragraph blocks

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -188,7 +188,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
             ssb.append("\n")
             val ssbLength = ssb.length
             editableText.getSpans(position, position + ssbLength, IAztecBlockSpan::class.java).filter {
-                it !is AztecMediaSpan && it !is ParagraphSpan && editableText.getSpanStart(it) == position
+                it !is AztecMediaSpan && editableText.getSpanStart(it) == position
             }.map {
                 SpanData(it, editableText.getSpanStart(it) + ssbLength, editableText.getSpanEnd(it) + ssbLength, editableText.getSpanFlags(it))
             }.applyWithRemovedSpans {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
@@ -105,6 +105,32 @@ class ImageBlockTest {
 
     @Test
     @Throws(Exception::class)
+    fun addImageInTheLastParagraph() {
+        editText.fromHtml("<p>Line 1<br>Line 2</p>")
+
+        editText.setSelection(editText.editableText.indexOf("1"))
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("<p>Line 1<img id=\"1234\" /><br>Line 2</p>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addImageInTheParagraph() {
+        editText.fromHtml("<p>Line 1<br>Line 2</p><p>Line 3</p>")
+
+        editText.setSelection(editText.editableText.indexOf("1"))
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("<p>Line 1<img id=\"1234\" /><br>Line 2</p><p>Line 3</p>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun addHRAfterHeadline() {
         editText.fromHtml("<h1>Headline 1</h1>")
 
@@ -112,6 +138,17 @@ class ImageBlockTest {
         editText.lineBlockFormatter.applyHorizontalRule(false)
 
         Assert.assertEquals("<h1>Headline 1</h1><hr />", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addHRAfterHeadlineBeforeParagraph() {
+        editText.fromHtml("<h1>Headline 1</h1><p>Test</p>")
+
+        editText.setSelection(editText.editableText.indexOf("1"))
+        editText.lineBlockFormatter.applyHorizontalRule(false)
+
+        Assert.assertEquals("<h1>Headline 1</h1><hr /><p>Test</p>", editText.toHtml())
     }
 
     @Test


### PR DESCRIPTION
Previously we've added the option to `addMediaAfterBlocks`. This works well with almost all the blocks but it doesn't work nicely with paragraphs. We want to be able to add images within paragraphs and not only after the currently selected paragraph. This is important for paragraphs with linebreaks (where the image should be logically positioned at the linebreak, not after the paragraph). 

You can test this by setting `EXAMPLE` to 
```
<p>test<br>
<br>
test</p>
```

### Test
1. Turn on `addMediaAfterBlocks` on the visual editor
2. Run the app with the `EXAMPLE` set from the code above
3. Click between the lines
4. Add an image
5. Notice it gets added between the lines, not at the end of the document

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.