### PR TITLE
Insert text when current text is empty to preserve formatting when pasting to empty edit text

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1814,9 +1814,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             disableTextChangedListener()
 
             val length = text.length
-            if (min == 0 &&
-                    (max == length || (length == 1 && text.toString() == Constants.END_OF_BUFFER_MARKER_STRING))) {
+            if (min == 0 && max == 0 && length == 1 && text.toString() == Constants.END_OF_BUFFER_MARKER_STRING) {
                 editable.insert(min, Constants.REPLACEMENT_MARKER_STRING)
+            } else if (min == 0 && max == length) {
+                setText(Constants.REPLACEMENT_MARKER_STRING)
             } else {
                 // prevent changes here from triggering the crash preventer
                 disableCrashPreventerInputFilter()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1816,7 +1816,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             val length = text.length
             if (min == 0 &&
                     (max == length || (length == 1 && text.toString() == Constants.END_OF_BUFFER_MARKER_STRING))) {
-                setText(Constants.REPLACEMENT_MARKER_STRING)
+                editable.insert(min, Constants.REPLACEMENT_MARKER_STRING)
             } else {
                 // prevent changes here from triggering the crash preventer
                 disableCrashPreventerInputFilter()

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -2,6 +2,10 @@ package org.wordpress.aztec
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.ClipData
+import android.content.Context
+import android.text.Editable
+import android.text.Spannable
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -337,5 +341,19 @@ class ClipboardTest {
         TestUtils.pasteFromClipboardAsPlainText(editText)
 
         Assert.assertEquals(LONG_TEXT_EXPECTED, editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun pasteIntoEmptyTextPreservesFormatting() {
+        editText.fromHtml("<h1></h1>")
+
+        editText.setSelection(0)
+        val clipboard = editText.context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+        clipboard.primaryClip = ClipData.newPlainText("aztec", "Heading")
+
+        TestUtils.pasteFromClipboard(editText)
+
+        Assert.assertEquals("<h1>Heading</h1>", editText.toHtml())
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.ClipData
 import android.content.Context
-import android.text.Editable
-import android.text.Spannable
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
### Fix
In this PR I'm replacing the functionality when pasting text into the empty aztec editor. Currently this triggers `setText` which removes all the formatting spans. However, I think it's a valid use case to turn on formatting and paste text and expect the pasted text to be formatted. Otherwise the functionality remains unchanged

### Test
1. Set `EXAMPLE` field in the `MainActivity` to `<h1></h1>`
2. Run the app
3. Paste text to the editor
4. Notice it gets formatted with `h1` (previously it didn't keep the formatting)

### Review
@AmandaRiu 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.