### PR TITLE
Add option to set placeholder size based on the item shown

### DIFF
--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
@@ -15,14 +15,14 @@ class AztecPlaceholderSpan(
         attributes: AztecAttributes = AztecAttributes(),
         onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
         editor: AztecText? = null,
-        private val adapter: PlaceholderManager.PlaceholderAdapter) :
+        private val adapter: PlaceholderManager.PlaceholderAdapter,
+        override val TAG: String) :
         AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
-    override val TAG: String = "placeholder"
     override fun onClick() {
 
     }
 
     override fun getMaxWidth(editorWidth: Int): Int {
-        return adapter.getWidth(editorWidth)
+        return adapter.calculateWidth(attributes, editorWidth)
     }
 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
@@ -8,17 +8,19 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import com.bumptech.glide.Glide
 import org.wordpress.aztec.AztecAttributes
-import org.wordpress.aztec.placeholders.PlaceholderManager.PlaceholderAdapter.PlaceholderSize
+import org.wordpress.aztec.placeholders.PlaceholderManager.PlaceholderAdapter.Proportion
 
 /**
  * A sample adapter which creates a custom layout over the placeholder. Treat this as an example of what can be done.
  * This adapter creates an image with a caption under it
  */
 class ImageWithCaptionAdapter(
-        override val placeholderSize: PlaceholderSize = PlaceholderSize(height = PlaceholderSize.Proportion.Ratio(0.5f)),
         override val type: String = "image_with_caption"
 ) : PlaceholderManager.PlaceholderAdapter {
     private val media = mutableMapOf<String, ImageWithCaptionObject>()
+    override fun getHeight(attrs: AztecAttributes): Proportion {
+        return Proportion.Ratio(0.5f)
+    }
     override fun createView(context: Context, placeholderUuid: String, attrs: AztecAttributes): View {
         val imageWithCaptionObject = media[placeholderUuid] ?: ImageWithCaptionObject(placeholderUuid, attrs.getValue(SRC_ATTRIBUTE), View.generateViewId()).apply {
             media[placeholderUuid] = this


### PR DESCRIPTION
### Fix
This PR adds an option to the placeholder sizing where you can define placeholder size based on the item (and the AztecAttributes). This is good for things like images and videos which might not always be in landscape/portrait and showing them differently might result in a non-perfect experience 

### Test
1. Set up `MainActivity` with the placeholder manager and the `ImageWithCaptionAdapter`. The steps are:
  - Create `PlaceholderManager` in the `onCreate` method in `MainActivity` passing in the `visualEditor`
  - Call `placeholderManager.registerAdapter(ImageWithCaptionAdapter())` to register the `ImageWithCaptionAdapter`
  - Call `aztec.addPlugin(placeholderManager)` 
  -  Call `aztec.addOnMediaDeletedListener(placeholderManager)`
2. Modify the `getWidth` and `getHeight` methods in order to change them based on the item shown. For example:
  - Set `EXAMPLE` to ```<placeholder type=\"image_with_caption\" src=\"https://file-examples.com/storage/febc474733629f43d9f078c/2017/10/file_example_JPG_100kB.jpg\" caption=\"1\"><br><placeholder type=\"image_with_caption\" src=\"https://file-examples.com/storage/febc474733629f43d9f078c/2017/10/file_example_JPG_100kB.jpg\" caption=\"2\">```
  - Modify `getHeight` method in `ImageWithCaptionAdapter` so that it returns different value based on the `caption` attribute`
3. Run the app
4. Notice the images are drawn differently

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.