### PR TITLE
Add method to remove placeholder programatically

### DIFF
--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -77,6 +77,26 @@ class PlaceholderManager(
         insertContentOverSpanWithId(attrs.getValue(UUID_ATTRIBUTE), null)
     }
 
+    /**
+     * Call this method to remove a placeholder from both the AztecText and the overlaying layer programatically.
+     * @param predicate determines whether a span should be removed
+     */
+    fun removeItem(predicate: (AztecAttributes) -> Boolean) {
+        aztecText.editableText.getSpans(0, aztecText.length(), AztecPlaceholderSpan::class.java).filter {
+            predicate(it.attributes)
+        }.forEach { placeholderSpan ->
+            val startIndex = aztecText.editableText.getSpanStart(placeholderSpan)
+            val endIndex = aztecText.editableText.getSpanEnd(placeholderSpan)
+            aztecText.editableText.getSpans(startIndex, endIndex, AztecMediaClickableSpan::class.java).forEach {
+                aztecText.editableText.removeSpan(it)
+            }
+            aztecText.editableText.removeSpan(placeholderSpan)
+            aztecText.editableText.delete(startIndex, endIndex)
+            onMediaDeleted(placeholderSpan.attributes)
+        }
+        aztecText.refreshText(false)
+    }
+
     private fun buildPlaceholderDrawable(adapter: PlaceholderAdapter, attrs: AztecAttributes): Drawable {
         val drawable = ContextCompat.getDrawable(aztecText.context, android.R.color.transparent)!!
         updateDrawableBounds(adapter, attrs, drawable)


### PR DESCRIPTION
### Fix
This PR introduces a method to remove a placeholder from the AztecText programatically. 
- It locates the placeholder span based on predicate
- It removes the placeholder span
- it removes the wrapping media clickable span
- it removes the magic whitespace char that represents the span
- it refreshes the edit text


### Test
1. Initialize `PlaceholderManager` in the `MainActivity.onCreate` method
2. Set `aztec.addOnMediaDeletedListener(placeholderManager)` 
3. Set `aztec.addPlugin(placeholderManager)`
4. Register adapter `placeholderManager.registerAdapter(ImageWithCaptionAdapter())`
5. Set `EXAMPLE` to `"<placeholder type=\"image_with_caption\" src=\"https://file-examples.com/storage/febc474733629f43d9f078c/2017/10/file_example_JPG_100kB.jpg\" caption=\"1\"><br><placeholder type=\"image_with_caption\" src=\"https://file-examples.com/storage/febc474733629f43d9f078c/2017/10/file_example_JPG_100kB.jpg\" caption=\"2\">"`
6. Run the app
7. Call the `removeItem` to remove a placeholder based on a predicate, for example I've tested it by adding the following call to the gallery button click: 

```
placeholderManager.removeItem {
                    it.getValue("caption") == "1"
                }
```

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.