### PR TITLE
Stop using custom getLineForOffset

### DIFF
--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation aztecProjectDependency
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     testImplementation "junit:junit:$jUnitVersion"
 }
 

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
@@ -2,6 +2,7 @@ package org.wordpress.aztec.placeholders
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import kotlinx.coroutines.runBlocking
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecMediaSpan
@@ -23,6 +24,6 @@ class AztecPlaceholderSpan(
     }
 
     override fun getMaxWidth(editorWidth: Int): Int {
-        return adapter.calculateWidth(attributes, editorWidth)
+        return runBlocking { adapter.calculateWidth(attributes, editorWidth) }
     }
 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
@@ -18,7 +18,7 @@ class ImageWithCaptionAdapter(
         override val type: String = "image_with_caption"
 ) : PlaceholderManager.PlaceholderAdapter {
     private val media = mutableMapOf<String, ImageWithCaptionObject>()
-    override fun getHeight(attrs: AztecAttributes): Proportion {
+    suspend override fun getHeight(attrs: AztecAttributes): Proportion {
         return Proportion.Ratio(0.5f)
     }
 

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
@@ -21,10 +21,12 @@ class ImageWithCaptionAdapter(
     override fun getHeight(attrs: AztecAttributes): Proportion {
         return Proportion.Ratio(0.5f)
     }
-    override suspend fun createView(context: Context, placeholderUuid: String, attrs: AztecAttributes): View {
-        val imageWithCaptionObject = media[placeholderUuid] ?: ImageWithCaptionObject(placeholderUuid, attrs.getValue(SRC_ATTRIBUTE), View.generateViewId()).apply {
-            media[placeholderUuid] = this
-        }
+
+    suspend override fun createView(context: Context, placeholderUuid: String, attrs: AztecAttributes): View {
+        val imageWithCaptionObject = media[placeholderUuid]
+                ?: ImageWithCaptionObject(placeholderUuid, attrs.getValue(SRC_ATTRIBUTE), View.generateViewId()).apply {
+                    media[placeholderUuid] = this
+                }
         val captionLayoutId = View.generateViewId()
         val imageLayoutId = imageWithCaptionObject.layoutId
         val linearLayout = LinearLayout(context)
@@ -61,7 +63,7 @@ class ImageWithCaptionAdapter(
         return linearLayout
     }
 
-    override suspend fun onViewCreated(view: View, placeholderUuid: String) {
+    suspend override fun onViewCreated(view: View, placeholderUuid: String) {
         val image = media[placeholderUuid]!!
         val imageView = view.findViewById<ImageView>(image.layoutId)
         Glide.with(view).load(image.src).into(imageView)

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
@@ -21,7 +21,7 @@ class ImageWithCaptionAdapter(
     override fun getHeight(attrs: AztecAttributes): Proportion {
         return Proportion.Ratio(0.5f)
     }
-    override fun createView(context: Context, placeholderUuid: String, attrs: AztecAttributes): View {
+    override suspend fun createView(context: Context, placeholderUuid: String, attrs: AztecAttributes): View {
         val imageWithCaptionObject = media[placeholderUuid] ?: ImageWithCaptionObject(placeholderUuid, attrs.getValue(SRC_ATTRIBUTE), View.generateViewId()).apply {
             media[placeholderUuid] = this
         }
@@ -61,7 +61,7 @@ class ImageWithCaptionAdapter(
         return linearLayout
     }
 
-    override fun onViewCreated(view: View, placeholderUuid: String) {
+    override suspend fun onViewCreated(view: View, placeholderUuid: String) {
         val image = media[placeholderUuid]!!
         val imageView = view.findViewById<ImageView>(image.layoutId)
         Glide.with(view).load(image.src).into(imageView)
@@ -79,7 +79,7 @@ class ImageWithCaptionAdapter(
         private const val CAPTION_ATTRIBUTE = "caption"
         private const val SRC_ATTRIBUTE = "src"
 
-        fun insertImageWithCaption(placeholderManager: PlaceholderManager, src: String, caption: String) {
+        suspend fun insertImageWithCaption(placeholderManager: PlaceholderManager, src: String, caption: String) {
             placeholderManager.insertItem(ADAPTER_TYPE, SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to caption)
         }
     }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -135,7 +135,7 @@ class PlaceholderManager(
         val type = attrs.getValue(TYPE_ATTRIBUTE)
         val textViewLayout: Layout = aztecText.layout
         val parentTextViewRect = Rect()
-        val targetLineOffset = getLineForOffset(targetPosition)
+        val targetLineOffset = textViewLayout.getLineForOffset(targetPosition)
         if (currentPosition != null) {
             if (targetLineOffset != 0 && currentPosition == targetPosition) {
                 return
@@ -175,19 +175,6 @@ class PlaceholderManager(
             container.addView(box)
             adapter.onViewCreated(box, uuid)
         }
-    }
-
-    private fun getLineForOffset(offset: Int): Int {
-        var counter = 0
-        var index = 0
-        for (line in aztecText.text.split("\n")) {
-            counter += line.length + 1
-            if (counter > offset) {
-                break
-            }
-            index += 1
-        }
-        return index
     }
 
     private fun validateAttributes(attributes: AztecAttributes): Boolean {


### PR DESCRIPTION
### Fix
There is an issue where there is a multiline text element before a placeholder. The custom method that was calculating line for offset doesn't take that into account. I've replaced it with the default `getLineForOffset` and it seems to work well now.

In addition to this I've also made some of the functions in the `PlaceholderManager` suspended to improve performance and allow async computation

### Test
1. Enable placeholders and add a multiline text followed by a placeholder to the `Example` field
2. Run the app
3. Notice the placeholder is drawn correctly

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.