### PR TITLE
Fix media removal and improve coroutine handling

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2017,6 +2017,24 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         lineBlockFormatter.insertMediaSpan(shouldAddMediaInline, span)
     }
 
+    /**
+     * Use this method to remove a media span
+     */
+    fun removeMediaSpan(span: AztecMediaSpan) {
+        history.beforeTextChanged(this@AztecText)
+        disableTextChangedListener()
+        val startIndex = editableText.getSpanStart(span)
+        val endIndex = editableText.getSpanEnd(span)
+        editableText.getSpans(startIndex, endIndex, AztecMediaClickableSpan::class.java).forEach {
+            editableText.removeSpan(it)
+        }
+        editableText.removeSpan(span)
+        editableText.delete(startIndex, endIndex)
+        onMediaDeletedListener?.onMediaDeleted(span.attributes)
+        enableTextChangedListener()
+        contentChangeWatcher.notifyContentChanged()
+    }
+
     fun insertVideo(drawable: Drawable?, attributes: Attributes) {
         lineBlockFormatter.insertVideo(shouldAddMediaInline, drawable, attributes, onVideoTappedListener, onMediaDeletedListener)
     }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -12,8 +12,8 @@ import android.view.View
 import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -39,7 +39,6 @@ import kotlin.math.min
 class PlaceholderManager(
         private val aztecText: AztecText,
         private val container: FrameLayout,
-        private val mainThreadDispatcher: CoroutineDispatcher,
         private val htmlTag: String = DEFAULT_HTML_TAG
 ) : AztecContentChangeWatcher.AztecTextChangeObserver,
         IHtmlTagHandler,
@@ -51,7 +50,7 @@ class PlaceholderManager(
     private val positionToId = mutableSetOf<Placeholder>()
     private val job = Job()
     override val coroutineContext: CoroutineContext
-        get() = mainThreadDispatcher + job
+        get() = Dispatchers.Main + job
 
     init {
         aztecText.setOnVisibilityChangeListener(this)


### PR DESCRIPTION
### Fix
The media removal is not currently added to history. That's fixed in this PR. Also the logic to remove media span is moved to the `AztecText` so that it's reusable. I've also fixed the coroutine usage and made the `PlaceholderManager` a coroutine scope.

### Test
1. Set up `PlaceholderManager` in the main activity with the `ImageWithCaptionAdapter`
2. Make the `EXAMPLE` contain a `placeholder` that you can identify
3. Add `removeItem` action to something you can control (for example the camera button)
4. In the `removeItem` identify the placeholder you want to remove
5. Run the app
6. Remove the placeholder
7. Notice it gets removed correctly

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.