### PR TITLE
Clear references in AztecExceptionHandler.kt

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -6,8 +6,10 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.aztec.exceptions.DynamicLayoutGetBlockIndexOutOfBoundsException
 import org.wordpress.aztec.util.AztecLog
 import java.lang.Thread.UncaughtExceptionHandler
+import java.lang.ref.WeakReference
 
-class AztecExceptionHandler(private var logHelper: ExceptionHandlerHelper?, private var visualEditor: AztecText?) : UncaughtExceptionHandler {
+class AztecExceptionHandler(private var logHelper: WeakReference<ExceptionHandlerHelper>, private var visualEditor: WeakReference<AztecText>) : UncaughtExceptionHandler {
+    constructor(logHelper: ExceptionHandlerHelper, visualEditor: AztecText): this(WeakReference(logHelper), WeakReference(visualEditor))
 
     interface ExceptionHandlerHelper {
         fun shouldLog(ex: Throwable) : Boolean
@@ -25,7 +27,7 @@ class AztecExceptionHandler(private var logHelper: ExceptionHandlerHelper?, priv
         // Check if we should log the content or not
         var shouldLog = true
         try {
-            shouldLog = logHelper?.shouldLog(ex) ?: true
+            shouldLog = logHelper.get()?.shouldLog(ex) ?: true
         } catch (e: Throwable) {
             AppLog.w(AppLog.T.EDITOR, "There was an exception in the Logger Helper. Set the logging to true")
         }
@@ -34,12 +36,12 @@ class AztecExceptionHandler(private var logHelper: ExceptionHandlerHelper?, priv
             // Try to report the HTML code of the content, the spans details, but do not report exceptions that can occur logging the content
             try {
                 AppLog.e(AppLog.T.EDITOR, "HTML content of Aztec Editor before the crash:")
-                AppLog.e(AppLog.T.EDITOR, visualEditor?.toPlainHtml(false) ?: "Editor was cleared")
+                AppLog.e(AppLog.T.EDITOR, visualEditor.get()?.toPlainHtml(false) ?: "Editor was cleared")
             } catch (e: Throwable) {
                 AppLog.e(AppLog.T.EDITOR, "Oops! There was an error logging the HTML code.")
             }
             try {
-                visualEditor?.let {
+                visualEditor.get()?.let {
                     AztecLog.logContentDetails(it)
                 }
             } catch (e: Throwable) {
@@ -60,7 +62,7 @@ class AztecExceptionHandler(private var logHelper: ExceptionHandlerHelper?, priv
                 detected = true
             }
             if (detected) {
-                visualEditor?.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
+                visualEditor.get()?.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
             }
         }
 
@@ -68,8 +70,8 @@ class AztecExceptionHandler(private var logHelper: ExceptionHandlerHelper?, priv
     }
 
     fun restoreDefaultHandler() {
-        visualEditor = null
-        logHelper = null
+        visualEditor.clear()
+        logHelper.clear()
         Thread.setDefaultUncaughtExceptionHandler(rootHandler)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -125,6 +125,7 @@ import org.wordpress.aztec.watchers.event.text.BeforeTextChangedEventData
 import org.wordpress.aztec.watchers.event.text.OnTextChangedEventData
 import org.wordpress.aztec.watchers.event.text.TextWatcherEvent
 import org.xml.sax.Attributes
+import java.lang.ref.WeakReference
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.Arrays
@@ -1390,7 +1391,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         disableTextChangedListener()
 
         builder.getSpans(0, builder.length, AztecDynamicImageSpan::class.java).forEach {
-            it.textView = this
+            it.textView = WeakReference(this)
         }
 
         val cursorPosition = consumeCursorPosition(builder)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -7,9 +7,10 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.text.style.DynamicDrawableSpan
 import org.wordpress.aztec.AztecText
+import java.lang.ref.WeakReference
 
 abstract class AztecDynamicImageSpan(val context: Context, protected var imageDrawable: Drawable?) : DynamicDrawableSpan() {
-    var textView: AztecText? = null
+    var textView: WeakReference<AztecText>? = null
     var aspectRatio: Double = 1.0
 
     private var measuring = false
@@ -88,11 +89,11 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
     }
 
     fun adjustBounds(start: Int): Rect {
-        if (textView == null || textView?.widthMeasureSpec == 0) {
+        if (textView == null || textView?.get()?.widthMeasureSpec == 0) {
             return Rect(imageDrawable?.bounds ?: Rect(0, 0, 0, 0))
         }
 
-        val layout = textView?.layout
+        val layout = textView?.get()?.layout
 
         if (measuring || layout == null) {
             // if we're in pre-layout phase, just return an empty rect
@@ -143,7 +144,7 @@ abstract class AztecDynamicImageSpan(val context: Context, protected var imageDr
 
         if (imageDrawable != null) {
             var transY = top
-            if (mVerticalAlignment == DynamicDrawableSpan.ALIGN_BASELINE) {
+            if (mVerticalAlignment == ALIGN_BASELINE) {
                 transY -= paint.fontMetricsInt.descent
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
@@ -4,12 +4,13 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
+import java.lang.ref.WeakReference
 
 class AztecHorizontalRuleSpan(context: Context, drawable: Drawable, override var nestingLevel: Int,
                               override var attributes: AztecAttributes = AztecAttributes(), editor: AztecText? = null) :
         AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan, IAztecSpan {
     init {
-        textView = editor
+        textView = WeakReference(editor)
     }
 
     override val TAG: String = "hr"

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable
 import android.view.Gravity
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
+import java.lang.ref.WeakReference
 import java.util.ArrayList
 
 abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
@@ -18,7 +19,7 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
     private val overlays: ArrayList<Pair<Drawable?, Int>> = ArrayList()
 
     init {
-        textView = editor
+        textView = editor?.let { WeakReference(editor) }
     }
 
     fun setOverlay(index: Int, newDrawable: Drawable?, gravity: Int) {

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
@@ -8,6 +8,7 @@ import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecMediaSpan
 import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
 import org.wordpress.aztec.spans.IAztecSpan
+import java.lang.ref.WeakReference
 
 class AztecPlaceholderSpan(
         context: Context,
@@ -16,7 +17,7 @@ class AztecPlaceholderSpan(
         attributes: AztecAttributes = AztecAttributes(),
         onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
         editor: AztecText? = null,
-        private val adapter: PlaceholderManager.PlaceholderAdapter,
+        private val adapter: WeakReference<PlaceholderManager.PlaceholderAdapter>,
         override val TAG: String) :
         AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
     override fun onClick() {
@@ -24,6 +25,6 @@ class AztecPlaceholderSpan(
     }
 
     override fun getMaxWidth(editorWidth: Int): Int {
-        return runBlocking { adapter.calculateWidth(attributes, editorWidth) }
+        return runBlocking { adapter.get()?.calculateWidth(attributes, editorWidth) ?: editorWidth }
     }
 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -25,6 +25,7 @@ import org.wordpress.aztec.Html
 import org.wordpress.aztec.plugins.html2visual.IHtmlTagHandler
 import org.wordpress.aztec.spans.AztecMediaClickableSpan
 import org.xml.sax.Attributes
+import java.lang.ref.WeakReference
 import java.util.UUID
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.min
@@ -90,7 +91,7 @@ class PlaceholderManager(
         val attrs = getAttributesForMedia(type, attributes)
         val drawable = buildPlaceholderDrawable(adapter, attrs)
         aztecText.insertMediaSpan(AztecPlaceholderSpan(aztecText.context, drawable, 0, attrs,
-                this, aztecText, adapter, TAG = htmlTag))
+                this, aztecText, WeakReference(adapter), TAG = htmlTag))
         insertContentOverSpanWithId(attrs.getValue(UUID_ATTRIBUTE))
     }
 
@@ -260,7 +261,7 @@ class PlaceholderManager(
                     nestingLevel = nestingLevel,
                     attributes = aztecAttributes,
                     onMediaDeletedListener = this,
-                    adapter = adapter,
+                    adapter = WeakReference(adapter),
                     TAG = htmlTag
             )
             val clickableSpan = AztecMediaClickableSpan(span)

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergInlineCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergInlineCommentSpan.kt
@@ -5,11 +5,12 @@ import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecDynamicImageSpan
 import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
+import java.lang.ref.WeakReference
 
 class GutenbergInlineCommentSpan @JvmOverloads constructor(val commentText: String, context: Context, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
         AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan {
 
     init {
-        textView = editor
+        textView = WeakReference(editor)
     }
 }

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/WordPressCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/WordPressCommentSpan.kt
@@ -5,12 +5,13 @@ import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecDynamicImageSpan
 import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
+import java.lang.ref.WeakReference
 
 class WordPressCommentSpan @JvmOverloads constructor(val commentText: String, context: Context, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
         AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan {
 
     init {
-        textView = editor
+        textView = WeakReference(editor)
     }
 
     companion object {

--- a/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
+++ b/wordpress-shortcodes/src/main/java/org/wordpress/aztec/plugins/shortcodes/extensions/CaptionExtensions.kt
@@ -59,9 +59,9 @@ fun AztecText.hasImageCaption(attributePredicate: AztecText.AttributePredicate):
 }
 
 fun AztecImageSpan.getCaption(): String {
-    textView?.text?.let {
-        val wrapper = SpanWrapper(textView!!.text, this)
-        textView!!.text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.let {
+    textView?.get()?.text?.let { editable ->
+        val wrapper = SpanWrapper(editable, this)
+        editable.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.let {
             return it.caption
         }
     }
@@ -69,9 +69,9 @@ fun AztecImageSpan.getCaption(): String {
 }
 
 fun AztecImageSpan.getCaptionAttributes(): AztecAttributes {
-    textView?.text?.let {
-        val wrapper = SpanWrapper(textView!!.text, this)
-        textView!!.text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.let {
+    textView?.get()?.text?.let { editable ->
+        val wrapper = SpanWrapper(editable, this)
+        editable.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.let {
             return it.attributes
         }
     }
@@ -80,17 +80,17 @@ fun AztecImageSpan.getCaptionAttributes(): AztecAttributes {
 
 @JvmOverloads
 fun AztecImageSpan.setCaption(value: String, attrs: AztecAttributes? = null) {
-    textView?.text?.let {
-        val wrapper = SpanWrapper(textView!!.text, this)
+    textView?.get()?.text?.let { editable ->
+        val wrapper = SpanWrapper(editable, this)
 
-        var captionSpan = textView?.text?.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java)?.firstOrNull()
+        var captionSpan = editable.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java)?.firstOrNull()
         if (captionSpan == null) {
             captionSpan = createCaptionShortcodeSpan(
                     AztecAttributes(),
                     CaptionShortcodePlugin.HTML_TAG,
-                    IAztecNestable.getNestingLevelAt(textView!!.text, wrapper.start),
-                    textView!!)
-            textView!!.text.setSpan(captionSpan, wrapper.start, wrapper.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    IAztecNestable.getNestingLevelAt(editable, wrapper.start),
+                    textView?.get()!!)
+            editable.setSpan(captionSpan, wrapper.start, wrapper.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
 
         captionSpan.caption = value
@@ -114,8 +114,8 @@ fun AztecImageSpan.setCaption(value: String, attrs: AztecAttributes? = null) {
 }
 
 fun AztecImageSpan.removeCaption() {
-    textView?.text?.let {
-        val wrapper = SpanWrapper(textView!!.text, this)
-        textView!!.text.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.remove()
+    textView?.get()?.text?.let { editable ->
+        val wrapper = SpanWrapper(editable, this)
+        editable.getSpans(wrapper.start, wrapper.end, CaptionShortcodeSpan::class.java).firstOrNull()?.remove()
     }
 }


### PR DESCRIPTION
### Fix
`AztecExceptionHandler` is leaking `AztecText`. In this PR I'm replacing the references with `WeakReference` so that the reference to the `AztecText` is not held by the exception handler longer than necessary


### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.