### PR TITLE
Issues with placeholders

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -100,6 +100,6 @@ abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override va
         onMediaDeletedListener?.onMediaDeleted(attributes)
     }
     fun beforeMediaDeleted() {
-        onMediaDeletedListener?.onMediaDeleted(attributes)
+        onMediaDeletedListener?.beforeMediaDeleted(attributes)
     }
 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.wordpress.aztec.AztecAttributes
@@ -143,7 +144,14 @@ class PlaceholderManager(
         }
         val uuid = attrs.getValue(UUID_ATTRIBUTE)
         val type = attrs.getValue(TYPE_ATTRIBUTE)
-        val textViewLayout: Layout = aztecText.layout
+        // At this point we can get to a race condition where the aztec text layout is not yet initialized.
+        // We want to wait a bit and make sure it's properly loaded.
+        var counter = 0
+        while (aztecText.layout == null && counter < 10) {
+            delay(50)
+            counter += 1
+        }
+        val textViewLayout: Layout = aztecText.layout ?: return
         val parentTextViewRect = Rect()
         val targetLineOffset = textViewLayout.getLineForOffset(targetPosition)
         textViewLayout.getLineBounds(targetLineOffset, parentTextViewRect)


### PR DESCRIPTION
### Fix
This PR fixes 2 issues. A crash that sometimes happens when you rotate your device while inserting. In that case the layout might not yet be there so I've added a delay to wait for the layout up to 500ms.

The second issue happens when deleting multiple media. The previous solution was using a list which was problematic when deleting multiple media fast. In that case There were concurrency issues and not all `onMediaDeleted` callbacks were called. 

To test change the `MainActivity` so that the `ImageWithCaption` adapter is set up. This means add this: 
```
private lateinit var placeholderManager: PlaceholderManager
override fun onCreate(savedInstanceState: Bundle?) {
        ...
        placeholderManager = PlaceholderManager(visualEditor, findViewById(R.id.container_frame_layout))
        placeholderManager.registerAdapter(ImageWithCaptionAdapter())
        ...
        Aztec.with(...)
                .addOnMediaDeletedListener(placeholderManager)
                .addPlugin(placeholderManager)
}
    override fun onDestroy() {
        super.onDestroy()
        placeholderManager.onDestroy()
        ...
        }
```

and change the `EXAMPLE` to something like this: 
```
"""
<h1>Test</h1>
<placeholder type="image_with_caption" src="https://file-examples.com/storage/fe91f87fd962e70179469a5/2017/10/file_example_JPG_100kB.jpg" caption="image1" />
<placeholder type="image_with_caption" src="https://file-examples.com/storage/fe91f87fd962e70179469a5/2017/10/file_example_JPG_100kB.jpg" caption="image2" />
<placeholder type="image_with_caption" src="https://file-examples.com/storage/fe91f87fd962e70179469a5/2017/10/file_example_JPG_100kB.jpg" caption="image3" />
<placeholder type="image_with_caption" src="https://file-examples.com/storage/fe91f87fd962e70179469a5/2017/10/file_example_JPG_100kB.jpg" caption="image4" />
                        """.trimIndent()
```

### Test
1. Run the app with the changes described above
2. Place the cursor after all the images
3. Press "Backspace" multiple times fast
4. Notice all the images are correctly deleted

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.