### PR TITLE
Use adapter height when drawing a placeholder

### DIFF
--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -160,7 +160,6 @@ class PlaceholderManager(
         aztecText.getLocationOnScreen(parentTextViewLocation)
         val parentTextViewTopAndBottomOffset = aztecText.scrollY + aztecText.compoundPaddingTop
 
-
         val adapter = adapters[type]!!
         val height = adapter.calculateHeight(attrs, parentTextViewRect.right - parentTextViewRect.left - 20)
         parentTextViewRect.top += parentTextViewTopAndBottomOffset

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -161,7 +161,8 @@ class PlaceholderManager(
         val parentTextViewTopAndBottomOffset = aztecText.scrollY + aztecText.compoundPaddingTop
 
         val adapter = adapters[type]!!
-        val height = adapter.calculateHeight(attrs, parentTextViewRect.right - parentTextViewRect.left - 20)
+        val windowWidth = parentTextViewRect.right - parentTextViewRect.left - 20
+        val height = adapter.calculateHeight(attrs, windowWidth)
         parentTextViewRect.top += parentTextViewTopAndBottomOffset
         parentTextViewRect.bottom = parentTextViewRect.top + height
 
@@ -175,14 +176,14 @@ class PlaceholderManager(
             box = adapter.createView(container.context, uuid, attrs)
         }
         val params = FrameLayout.LayoutParams(
-                adapter.calculateWidth(attrs, parentTextViewRect.right - parentTextViewRect.left - 20),
-                height
+                adapter.calculateWidth(attrs, windowWidth) - 20,
+                height - 20
         )
         val padding = 10
         params.setMargins(
                 parentTextViewRect.left + padding + aztecText.paddingStart,
                 parentTextViewRect.top + padding,
-                parentTextViewRect.right - padding - aztecText.paddingEnd,
+                0,
                 0
         )
         box.layoutParams = params

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -160,8 +160,11 @@ class PlaceholderManager(
         aztecText.getLocationOnScreen(parentTextViewLocation)
         val parentTextViewTopAndBottomOffset = aztecText.scrollY + aztecText.compoundPaddingTop
 
+
+        val adapter = adapters[type]!!
+        val height = adapter.calculateHeight(attrs, parentTextViewRect.right - parentTextViewRect.left - 20)
         parentTextViewRect.top += parentTextViewTopAndBottomOffset
-        parentTextViewRect.bottom += parentTextViewTopAndBottomOffset
+        parentTextViewRect.bottom = parentTextViewRect.top + height
 
         positionToId.removeAll {
             it.uuid == uuid
@@ -169,13 +172,12 @@ class PlaceholderManager(
 
         var box = container.findViewWithTag<View>(uuid)
         val exists = box != null
-        val adapter = adapters[type]!!
         if (!exists) {
             box = adapter.createView(container.context, uuid, attrs)
         }
         val params = FrameLayout.LayoutParams(
                 adapter.calculateWidth(attrs, parentTextViewRect.right - parentTextViewRect.left - 20),
-                parentTextViewRect.bottom - parentTextViewRect.top - 20
+                height
         )
         val padding = 10
         params.setMargins(


### PR DESCRIPTION
### Fix
This PR fixes an issue when the placeholder size was different (by a little bit) than what was defined in the adapter. This was mostly visible on smaller placeholders. I think only the last placeholder of the document was affected. 

In addition it fixes the width so that the cursor doesn't overlap the placeholder

### Test (it's better to test this with the PR where it's used)
1. Setup placeholders
2. Add 2 placeholders to the `EXAMPLE` 
3. Add logging of actual height to the code
4. Check the height is fixed

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.