### PR TITLE
Added task list as a potential button that you can add to toolbar.

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
@@ -55,6 +55,12 @@ enum class ToolbarAction constructor(
             ToolbarActionType.BLOCK_STYLE,
             setOf(AztecTextFormat.FORMAT_ORDERED_LIST),
             R.layout.format_bar_button_list_ordered),
+    TASK_LIST(
+            R.id.format_bar_button_list_task,
+            R.drawable.format_bar_button_tasklist_selector,
+            ToolbarActionType.BLOCK_STYLE,
+            setOf(AztecTextFormat.FORMAT_TASK_LIST),
+            R.layout.format_bar_button_list_task),
     INDENT(
             R.id.format_bar_button_indent,
             R.drawable.format_bar_button_indent_selector,

--- a/aztec/src/main/res/drawable/format_bar_button_tasklist.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_tasklist.xml
@@ -3,10 +3,8 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/toolbarIconNormalColor"
     android:viewportWidth="24"
     android:viewportHeight="24">
-
 
     <group
         android:pivotX="12"
@@ -14,7 +12,7 @@
         android:scaleX="0.6"
         android:scaleY="0.6">
         <path
-            android:fillColor="@color/white"
+            android:fillColor="?attr/toolbarIconNormalColor"
             android:pathData="M7.57622 11.4801L12.5762 5.48014L11.4239 4.51987L6.94966 9.88895L4.53039 7.46968L3.46973 8.53034L6.46973 11.5303L7.05046 12.1111L7.57622 11.4801ZM20.0001 16H4.00006V14.5H20.0001V16ZM13.0001 20H4.00006V18.5H13.0001V20Z" />
     </group>
 

--- a/aztec/src/main/res/drawable/format_bar_button_tasklist_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_tasklist_disabled.xml
@@ -3,7 +3,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/toolbarIconDisabledColor"
     android:viewportWidth="24"
     android:viewportHeight="24">
 
@@ -14,7 +13,7 @@
         android:scaleX="0.6"
         android:scaleY="0.6">
         <path
-            android:fillColor="@color/white"
+            android:fillColor="?attr/toolbarIconDisabledColor"
             android:pathData="M7.57622 11.4801L12.5762 5.48014L11.4239 4.51987L6.94966 9.88895L4.53039 7.46968L3.46973 8.53034L6.46973 11.5303L7.05046 12.1111L7.57622 11.4801ZM20.0001 16H4.00006V14.5H20.0001V16ZM13.0001 20H4.00006V18.5H13.0001V20Z" />
     </group>
 

--- a/aztec/src/main/res/drawable/format_bar_button_tasklist_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_tasklist_highlighted.xml
@@ -3,7 +3,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/toolbarIconHighlightColor"
     android:viewportWidth="24"
     android:viewportHeight="24">
 
@@ -13,7 +12,7 @@
         android:scaleX="0.6"
         android:scaleY="0.6">
         <path
-            android:fillColor="@color/white"
+            android:fillColor="?attr/toolbarIconHighlightColor"
             android:pathData="M7.57622 11.4801L12.5762 5.48014L11.4239 4.51987L6.94966 9.88895L4.53039 7.46968L3.46973 8.53034L6.46973 11.5303L7.05046 12.1111L7.57622 11.4801ZM20.0001 16H4.00006V14.5H20.0001V16ZM13.0001 20H4.00006V18.5H13.0001V20Z" />
     </group>
 

--- a/aztec/src/main/res/drawable/format_bar_button_tasklist_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_tasklist_selector.xml
@@ -5,7 +5,7 @@
     tools:targetApi="lollipop">
 
     <item android:drawable="@drawable/format_bar_button_tasklist_disabled" android:state_enabled="false" />
-    <item android:drawable="@drawable/format_bar_button_tasklist_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_tasklist_highlighted" android:state_checked="true" />
     <item android:drawable="@drawable/format_bar_button_tasklist" />
 
 </animated-selector>

--- a/aztec/src/main/res/layout/format_bar_button_list_task.xml
+++ b/aztec/src/main/res/layout/format_bar_button_list_task.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.wordpress.aztec.toolbar.RippleToggleButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/format_bar_button_list_task"
+    style="@style/FormatBarButton"
+    android:layout_width="wrap_content"
+    android:layout_height="fill_parent"
+    android:contentDescription="@string/item_format_task_list" />


### PR DESCRIPTION
This PR adds a task list as an option for toolbar.

To test the button, add `ToolbarAction.TASK_LIST` into basic toolbar list [here](https://github.com/wordpress-mobile/AztecEditor-Android/blob/trunk/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarItems.kt#L54).

Make sure it works same as other lists and the button correctly highlights, and shows hint on long press.

[![Image from Gyazo](https://i.gyazo.com/33a5035ac3320f0ea3d4edf5755d06c4.png)](https://gyazo.com/33a5035ac3320f0ea3d4edf5755d06c4)

### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.