### PR TITLE
Add UrlPastePlugin.kt to handle pasted links

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -46,7 +46,6 @@ import org.wordpress.aztec.glideloader.GlideImageLoader
 import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader
 import org.wordpress.aztec.plugins.CssUnderlinePlugin
 import org.wordpress.aztec.plugins.IMediaToolbarButton
-import org.wordpress.aztec.plugins.UrlPastePlugin
 import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin
 import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin
 import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin
@@ -450,7 +449,6 @@ open class MainActivity : AppCompatActivity(),
                 .addPlugin(HiddenGutenbergPlugin(visualEditor))
                 .addPlugin(galleryButton)
                 .addPlugin(cameraButton)
-                .addPlugin(UrlPastePlugin())
 
         // initialize the plugins, text & HTML
         if (!isRunningTest) {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -46,6 +46,7 @@ import org.wordpress.aztec.glideloader.GlideImageLoader
 import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader
 import org.wordpress.aztec.plugins.CssUnderlinePlugin
 import org.wordpress.aztec.plugins.IMediaToolbarButton
+import org.wordpress.aztec.plugins.UrlPastePlugin
 import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin
 import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin
 import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin
@@ -449,6 +450,7 @@ open class MainActivity : AppCompatActivity(),
                 .addPlugin(HiddenGutenbergPlugin(visualEditor))
                 .addPlugin(galleryButton)
                 .addPlugin(cameraButton)
+                .addPlugin(UrlPastePlugin())
 
         // initialize the plugins, text & HTML
         if (!isRunningTest) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -74,6 +74,7 @@ import org.wordpress.aztec.handlers.ListItemHandler
 import org.wordpress.aztec.handlers.PreformatHandler
 import org.wordpress.aztec.handlers.QuoteHandler
 import org.wordpress.aztec.plugins.IAztecPlugin
+import org.wordpress.aztec.plugins.ITextPastePlugin
 import org.wordpress.aztec.plugins.IToolbarButton
 import org.wordpress.aztec.source.Format
 import org.wordpress.aztec.source.SourceViewEditText
@@ -1845,11 +1846,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             disableTextChangedListener()
 
             val length = text.length
+            var selectedText: String? = null
             if (min == 0 && max == 0 && length == 1 && text.toString() == Constants.END_OF_BUFFER_MARKER_STRING) {
                 editable.insert(min, Constants.REPLACEMENT_MARKER_STRING)
             } else if (min == 0 && max == length) {
                 setText(Constants.REPLACEMENT_MARKER_STRING)
             } else {
+                selectedText = editable.substring(min, max)
                 // prevent changes here from triggering the crash preventer
                 disableCrashPreventerInputFilter()
                 editable.delete(min, max)
@@ -1875,7 +1878,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 else clip.getItemAt(0).coerceToHtmlText(AztecParser(alignmentRendering, plugins))
 
                 val oldHtml = toPlainHtml().replace("<aztec_cursor>", "")
-                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, textToPaste + "<" + AztecCursorSpan.AZTEC_CURSOR_TAG + ">")
+                val pastedHtmlText = plugins.filterIsInstance<ITextPastePlugin>().fold(textToPaste) { acc, plugin ->
+                    if (selectedText.isNullOrEmpty()) {
+                        plugin.toHtml(acc)
+                    } else {
+                        plugin.toHtml(selectedText, acc)
+                    }
+                }
+                val newHtml = oldHtml.replace(Constants.REPLACEMENT_MARKER_STRING, pastedHtmlText + "<" + AztecCursorSpan.AZTEC_CURSOR_TAG + ">")
 
                 fromHtml(newHtml, false)
                 inlineFormatter.joinStyleSpans(0, length())

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/ITextPastePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/ITextPastePlugin.kt
@@ -1,0 +1,31 @@
+package org.wordpress.aztec.plugins
+
+/**
+ * Use this plugin in order to override the default text paste behaviour. An example is overriding the paste so that
+ * you can handle pasted URLs as links over the selected text.
+ */
+interface ITextPastePlugin: IAztecPlugin {
+    /**
+     * This method is called when the cursor is placed into the editor, no text is selected and the user pastes text
+     * into the editor. This method should return HTML (plain text is OK if you don't apply any changes to the pasted
+     * text).
+     * @param pastedText pasted text
+     * @return html of the result
+     */
+    fun toHtml(pastedText: String): String {
+        return pastedText
+    }
+
+    /**
+     * This method is called when some text is selected in the editor and the user pastes text. The default behaviour
+     * is to replace the selected text with the pasted text but it can be changed in this method. This method should
+     * return HTML (plain text is OK if you don't apply any changes to the pasted text).
+     * @param selectedText currently selected text
+     * @param pastedText text pasted over selected text
+     * @return html of the result
+     */
+    fun toHtml(selectedText: String, pastedText: String): String {
+        return pastedText
+    }
+}
+

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/ITextPastePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/ITextPastePlugin.kt
@@ -4,7 +4,7 @@ package org.wordpress.aztec.plugins
  * Use this plugin in order to override the default text paste behaviour. An example is overriding the paste so that
  * you can handle pasted URLs as links over the selected text.
  */
-interface ITextPastePlugin: IAztecPlugin {
+interface ITextPastePlugin : IAztecPlugin {
     /**
      * This method is called when the cursor is placed into the editor, no text is selected and the user pastes text
      * into the editor. This method should return HTML (plain text is OK if you don't apply any changes to the pasted

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/UrlPastePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/UrlPastePlugin.kt
@@ -1,0 +1,31 @@
+package org.wordpress.aztec.plugins
+
+import android.util.Patterns
+
+/**
+ * This plugin overrides the paste logic of URLs in the AztecText. The purpose is to make sure inserted links are
+ * treated as HTML links.
+ */
+class UrlPastePlugin : ITextPastePlugin {
+    /**
+     * If the pasted text is a link, make sure it's wrapped with the `a` tag so that it's rendered as a link.
+     */
+    override fun toHtml(pastedText: String): String {
+        return if (Patterns.WEB_URL.matcher(pastedText).matches()) {
+            "<a href=\"$pastedText\">$pastedText</a>"
+        } else {
+            pastedText
+        }
+    }
+    /**
+     * If the pasted text is a link, make sure the selected text is wrapped with `a` tag and not removed.
+     */
+    override fun toHtml(selectedText: String, pastedText: String): String {
+        return if (Patterns.WEB_URL.matcher(pastedText).matches()) {
+            "<a href=\"$pastedText\">$selectedText</a>"
+        } else {
+            pastedText
+        }
+    }
+}
+

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/UrlPastePlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/UrlPastePlugin.kt
@@ -17,6 +17,7 @@ class UrlPastePlugin : ITextPastePlugin {
             pastedText
         }
     }
+
     /**
      * If the pasted text is a link, make sure the selected text is wrapped with `a` tag and not removed.
      */


### PR DESCRIPTION
In this PR I'm adding a plugin option to handle pasted text. This could be useful to override the default behaviour of handling any links. I'm also adding `UrlPastePlugin` which makes sure that when you paste an URL over selected text, it makes the whole thing into a link instead of replacing the selected text with a link.

Before you start make sure you add the following code to `aztec` in your `MainActivity` 
```
aztec.addPlugin(UrlPastePlugin())
```

### Test
1. Run the app
2. Copy link from your browser
3. Long press within the text
4. Paste content of your clipboard
5. Notice the pasted text is a link
6. Click on the link
7. Notice it's recognized by the toolbar as a link

### Test
1. Run the app
2. Copy link from your browser
3. Select a word in the text
4. Long press on it
5. Paste content of your clipboard
6. Notice the previously selected text is now a link
7. Click on the link
8. Notice it's recognized by the toolbar as a link 

### Test
1. Run the app
2. Copy something that's not a link
3. Long press within the text
4. Paste content of your clipboard
5. Notice the pasted text is not a link

### Test
1. Run the app
2. Copy something that's not a link
3. Select a word in the text
4. Long press on it
5. Paste content of your clipboard
5. Notice the selected text is replaced by the pasted text and is not a link

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.