### PR TITLE
Updated span removal logic when using exclusiveBlocks

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -245,8 +245,19 @@ class BlockFormatter(editor: AztecText,
         }
         val selectionStart = editor.selectionStart
 
+        var newSelStart = if (selectionStart > selectionEnd) selectionEnd else selectionStart
+        var newSelEnd = selectionEnd
+
+        if (newSelStart == 0 && newSelEnd == 0) {
+            newSelEnd++
+        } else if (newSelStart == newSelEnd && editableText.length > selectionStart && editableText[selectionStart - 1] == Constants.NEWLINE) {
+            newSelEnd++
+        } else if (newSelStart > 0 && !editor.isTextSelected()) {
+            newSelStart--
+        }
+
         // try to remove block styling when pressing backspace at the beginning of the text
-        editableText.getSpans(selectionStart, selectionEnd, IAztecBlockSpan::class.java).forEach {
+        editableText.getSpans(newSelStart, newSelEnd, IAztecBlockSpan::class.java).forEach {
             // We want to remove any list item span that's being converted to another block
             if (it is AztecListItemSpan) {
                 editableText.removeSpan(it)
@@ -267,15 +278,15 @@ class BlockFormatter(editor: AztecText,
             val spanFlags = editableText.getSpanFlags(it)
             val nextLineLength = "\n".length
             // Defines end of a line in a block
-            val previousLineBreak = editableText.indexOf("\n", selectionEnd)
+            val previousLineBreak = editableText.indexOf("\n", newSelEnd)
             val lineEnd = if (previousLineBreak > -1) {
                 previousLineBreak + nextLineLength
             } else spanEnd
             // Defines start of a line in a block
-            val nextLineBreak = if (lineEnd == selectionStart + nextLineLength) {
-                editableText.lastIndexOf("\n", selectionStart - 1)
+            val nextLineBreak = if (lineEnd == newSelStart + nextLineLength) {
+                editableText.lastIndexOf("\n", newSelStart - 1)
             } else {
-                editableText.lastIndexOf("\n", selectionStart)
+                editableText.lastIndexOf("\n", newSelStart)
             }
             val lineStart = if (nextLineBreak > -1) {
                 nextLineBreak + nextLineLength


### PR DESCRIPTION
This PR fixes issue with adding new block spans right next to the existing ones, when `exclusiveBlocks` is set to `true`.

To test this PR and the original issue you need to add `aztec:exclusiveBlocks="true"` to `AztecText` [layout](https://github.com/wordpress-mobile/AztecEditor-Android/blob/trunk/app/src/main/res/layout/activity_main.xml#L28).

When `exclusiveBlocks` is set to `true` the block are replaced when other block style is applied to them (normal behavior is to allow multiple block style to be applied).

Issue was caused because the range we used to detect spans we should remove included the span on the line before the cursor. I used the range logic from the toolbar highlight code, which I believe is more accurate.

Steps to reproduce original issue:

1. Create a list with one element in it.
2. Press enter to add a second element element, and press enter again to remove it a start a new line.
3. Add a quote.
4. Notice that the list styling has disappeared.

[![Image from Gyazo](https://i.gyazo.com/1931a4f46ff0decf0c688fe5aba59525.gif)](https://gyazo.com/1931a4f46ff0decf0c688fe5aba59525)

### Test
1. Create a list with one element in it.
2. Press enter to add a second element element, and press enter again to remove it a start a new line.
3. Add a quote.
4. Notice that the quote is added correctly and list style remains.

This behavior affects block styles, like Lists, Quotes and Headings.
Try testing it in various ways - applying block styles in the middle of multiline block element, at the beginning and at the end.
