### PR TITLE
Expand quote and preformat styling options

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -449,6 +449,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 quoteStyle = BlockFormatter.QuoteStyle(
                         styles.getColor(R.styleable.AztecText_quoteBackground, 0),
                         styles.getColor(R.styleable.AztecText_quoteColor, 0),
+                        styles.getColor(R.styleable.AztecText_quoteTextColor,
+                                ContextCompat.getColor(context, R.color.text)),
                         styles.getFraction(R.styleable.AztecText_quoteBackgroundAlpha, 1, 1, 0f),
                         styles.getDimensionPixelSize(R.styleable.AztecText_quoteMargin, 0),
                         styles.getDimensionPixelSize(R.styleable.AztecText_quotePadding, 0),
@@ -484,7 +486,13 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         styles.getColor(R.styleable.AztecText_preformatBackground, 0),
                         getPreformatBackgroundAlpha(styles),
                         styles.getColor(R.styleable.AztecText_preformatColor, 0),
-                        verticalParagraphPadding),
+                        verticalParagraphPadding,
+                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatLeadingMargin,
+                                resources.getDimensionPixelSize(R.dimen.preformat_leading_margin)),
+                        styles.getColor(R.styleable.AztecText_preformatBorderColor, 0),
+                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderRadius, 0),
+                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderThickness, 0),
+                ),
                 alignmentRendering = alignmentRendering,
                 exclusiveBlockStyles = BlockFormatter.ExclusiveBlockStyles(styles.getBoolean(R.styleable.AztecText_exclusiveBlocks, false), verticalParagraphPadding),
                 paragraphStyle = BlockFormatter.ParagraphStyle(verticalParagraphMargin)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -491,7 +491,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                                 resources.getDimensionPixelSize(R.dimen.preformat_leading_margin)),
                         styles.getColor(R.styleable.AztecText_preformatBorderColor, 0),
                         styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderRadius, 0),
-                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderThickness, 0)
+                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderThickness, 0),
+                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatTextSize, textSize.toInt())
                 ),
                 alignmentRendering = alignmentRendering,
                 exclusiveBlockStyles = BlockFormatter.ExclusiveBlockStyles(styles.getBoolean(R.styleable.AztecText_exclusiveBlocks, false), verticalParagraphPadding),

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -455,7 +455,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         styles.getDimensionPixelSize(R.styleable.AztecText_quoteMargin, 0),
                         styles.getDimensionPixelSize(R.styleable.AztecText_quotePadding, 0),
                         styles.getDimensionPixelSize(R.styleable.AztecText_quoteWidth, 0),
-                        verticalParagraphPadding),
+                        styles.getDimensionPixelSize(R.styleable.AztecText_quoteVerticalPadding, verticalParagraphPadding)),
                 headerStyle = BlockFormatter.HeaderStyles(verticalHeadingMargin, mapOf(
                         AztecHeadingSpan.Heading.H1 to BlockFormatter.HeaderStyles.HeadingStyle(
                                 styles.getDimensionPixelSize(R.styleable.AztecText_headingOneFontSize, 0),
@@ -486,7 +486,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         styles.getColor(R.styleable.AztecText_preformatBackground, 0),
                         getPreformatBackgroundAlpha(styles),
                         styles.getColor(R.styleable.AztecText_preformatColor, 0),
-                        verticalParagraphPadding,
+                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatVerticalPadding, verticalParagraphPadding),
                         styles.getDimensionPixelSize(R.styleable.AztecText_preformatLeadingMargin,
                                 resources.getDimensionPixelSize(R.dimen.preformat_leading_margin)),
                         styles.getColor(R.styleable.AztecText_preformatBorderColor, 0),

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -491,7 +491,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                                 resources.getDimensionPixelSize(R.dimen.preformat_leading_margin)),
                         styles.getColor(R.styleable.AztecText_preformatBorderColor, 0),
                         styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderRadius, 0),
-                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderThickness, 0),
+                        styles.getDimensionPixelSize(R.styleable.AztecText_preformatBorderThickness, 0)
                 ),
                 alignmentRendering = alignmentRendering,
                 exclusiveBlockStyles = BlockFormatter.ExclusiveBlockStyles(styles.getBoolean(R.styleable.AztecText_exclusiveBlocks, false), verticalParagraphPadding),

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -61,7 +61,7 @@ class BlockFormatter(editor: AztecText,
     }
 
     data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteTextColor: Int, val quoteBackgroundAlpha: Float, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
-    data class PreformatStyle(val preformatBackground: Int, val preformatBackgroundAlpha: Float, val preformatColor: Int, val verticalPadding: Int, val leadingMargin: Int, val preformatBorderColor: Int, val preformatBorderRadius: Int, val preformatBorderThickness: Int )
+    data class PreformatStyle(val preformatBackground: Int, val preformatBackgroundAlpha: Float, val preformatColor: Int, val verticalPadding: Int, val leadingMargin: Int, val preformatBorderColor: Int, val preformatBorderRadius: Int, val preformatBorderThickness: Int, val preformatTextSize: Int)
     data class HeaderStyles(val verticalPadding: Int, val styles: Map<AztecHeadingSpan.Heading, HeadingStyle>) {
         data class HeadingStyle(val fontSize: Int, val fontColor: Int)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -60,8 +60,8 @@ class BlockFormatter(editor: AztecText,
         }
     }
 
-    data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteBackgroundAlpha: Float, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
-    data class PreformatStyle(val preformatBackground: Int, val preformatBackgroundAlpha: Float, val preformatColor: Int, val verticalPadding: Int)
+    data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteTextColor: Int, val quoteBackgroundAlpha: Float, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
+    data class PreformatStyle(val preformatBackground: Int, val preformatBackgroundAlpha: Float, val preformatColor: Int, val verticalPadding: Int, val leadingMargin: Int, val preformatBorderColor: Int, val preformatBorderRadius: Int, val preformatBorderThickness: Int )
     data class HeaderStyles(val verticalPadding: Int, val styles: Map<AztecHeadingSpan.Heading, HeadingStyle>) {
         data class HeadingStyle(val fontSize: Int, val fontColor: Int)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -58,11 +58,12 @@ open class AztecPreformatSpan(
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 
-    var originalAscent: Int = 0
-    var originalTop: Int = 0
-    var originalDescent: Int = 0
-    var originalBottom: Int = 0
+    private var originalAscent: Int = 0
+    private var originalTop: Int = 0
+    private var originalDescent: Int = 0
+    private var originalBottom: Int = 0
 
+    // this method adds extra padding to the top and bottom lines of the text while removing it from middle lines
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int,
                               fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -58,20 +58,48 @@ open class AztecPreformatSpan(
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
 
+    var originalAscent: Int = 0
+    var originalTop: Int = 0
+    var originalDescent: Int = 0
+    var originalBottom: Int = 0
+
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int,
                               fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
+        val isFirstLine = start <= spanStart
+        val isLastLine = spanEnd <= end
 
-        if (start == spanStart || start < spanStart) {
+        if (isFirstLine) {
+            originalAscent = fm.ascent
+            originalTop = fm.top
+            originalDescent = fm.descent
+            originalBottom = fm.bottom
+
             fm.ascent -= preformatStyle.verticalPadding
             fm.top -= preformatStyle.verticalPadding
-        }
 
-        if (end == spanEnd || spanEnd < end) {
+            if(!isLastLine){
+                fm.descent = originalDescent
+                fm.bottom = originalBottom
+            }
+        }
+        if (isLastLine) {
             fm.descent += preformatStyle.verticalPadding
             fm.bottom += preformatStyle.verticalPadding
+
+            if(!isFirstLine){
+                fm.ascent = originalAscent
+                fm.top = originalTop
+            }
+        }
+
+        if (!isFirstLine && !isLastLine) {
+            fm.ascent = originalAscent
+            fm.top = originalTop
+            fm.descent = originalDescent
+            fm.bottom = originalBottom
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -8,7 +8,6 @@ import android.graphics.Path
 import android.text.Layout
 import android.text.Spanned
 import android.text.TextPaint
-import android.text.style.AbsoluteSizeSpan
 import android.text.style.LeadingMarginSpan
 import android.text.style.LineBackgroundSpan
 import android.text.style.LineHeightSpan

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -97,12 +97,14 @@ open class AztecPreformatSpan(
 
     override fun drawBackground(canvas: Canvas, paint: Paint, left: Int, right: Int, top: Int, baseline: Int,
                                 bottom: Int, text: CharSequence?, start: Int, end: Int, lnum: Int) {
-
         val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
-        val alpha: Int = (preformatStyle.preformatBackgroundAlpha * 255).toInt()
+        val isFirstLine = spanStart == start
+        val isLastLine = spanEnd == end
 
+        val alpha: Int = (preformatStyle.preformatBackgroundAlpha * 255).toInt()
         fillPaint.color = Color.argb(
                 alpha,
                 Color.red(preformatStyle.preformatBackground),
@@ -115,10 +117,6 @@ open class AztecPreformatSpan(
 
         strokePaint.color = preformatStyle.preformatBorderColor
         strokePaint.strokeWidth = preformatStyle.preformatBorderThickness.toFloat()
-
-        val isFirstLine = top == 0
-
-        val isLastLine = spanEnd == end
 
         val fillPath = Path().apply {
             if (isFirstLine) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -84,8 +84,6 @@ open class AztecPreformatSpan(
         strokeCap = Paint.Cap.ROUND
     }
 
-
-
     override fun drawBackground(canvas: Canvas, paint: Paint, left: Int, right: Int, top: Int, baseline: Int,
                                 bottom: Int, text: CharSequence?, start: Int, end: Int, lnum: Int) {
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -7,6 +7,8 @@ import android.graphics.Paint
 import android.graphics.Path
 import android.text.Layout
 import android.text.Spanned
+import android.text.TextPaint
+import android.text.style.AbsoluteSizeSpan
 import android.text.style.LeadingMarginSpan
 import android.text.style.LineBackgroundSpan
 import android.text.style.LineHeightSpan
@@ -21,7 +23,7 @@ fun createPreformatSpan(
         nestingLevel: Int,
         alignmentRendering: AlignmentRendering,
         attributes: AztecAttributes = AztecAttributes(),
-        preformatStyle: BlockFormatter.PreformatStyle = BlockFormatter.PreformatStyle(0, 0f, 0, 0, 0, 0, 0, 0)
+        preformatStyle: BlockFormatter.PreformatStyle = BlockFormatter.PreformatStyle(0, 0f, 0, 0, 0, 0, 0, 0, 0)
 ): AztecPreformatSpan =
         when (alignmentRendering) {
             AlignmentRendering.SPAN_LEVEL -> AztecPreformatSpanAligned(nestingLevel, attributes, preformatStyle)
@@ -72,6 +74,16 @@ open class AztecPreformatSpan(
             fm.descent += preformatStyle.verticalPadding
             fm.bottom += preformatStyle.verticalPadding
         }
+    }
+
+    override fun updateDrawState(ds: TextPaint) {
+        super.updateDrawState(ds)
+        ds.textSize = preformatStyle.preformatTextSize.toFloat()
+    }
+
+    override fun updateMeasureState(paint: TextPaint) {
+        super.updateMeasureState(paint)
+        paint.textSize = preformatStyle.preformatTextSize.toFloat()
     }
 
     private val strokePaint = Paint().apply {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -80,7 +80,7 @@ open class AztecPreformatSpan(
             fm.ascent -= preformatStyle.verticalPadding
             fm.top -= preformatStyle.verticalPadding
 
-            if(!isLastLine){
+            if (!isLastLine) {
                 fm.descent = originalDescent
                 fm.bottom = originalBottom
             }
@@ -89,7 +89,7 @@ open class AztecPreformatSpan(
             fm.descent += preformatStyle.verticalPadding
             fm.bottom += preformatStyle.verticalPadding
 
-            if(!isFirstLine){
+            if (!isFirstLine) {
                 fm.ascent = originalAscent
                 fm.top = originalTop
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -28,9 +28,12 @@ import androidx.core.view.ViewCompat
 import android.text.Editable
 import android.text.Layout
 import android.text.Spanned
+import android.text.TextPaint
+import android.text.style.CharacterStyle
+import android.text.style.LeadingMarginSpan
 import android.text.style.LineBackgroundSpan
 import android.text.style.LineHeightSpan
-import android.text.style.QuoteSpan
+import android.text.style.UpdateAppearance
 import android.text.style.UpdateLayout
 import androidx.collection.ArrayMap
 import org.wordpress.aztec.AlignmentRendering
@@ -44,7 +47,7 @@ fun createAztecQuoteSpan(
         nestingLevel: Int,
         attributes: AztecAttributes = AztecAttributes(),
         alignmentRendering: AlignmentRendering,
-        quoteStyle: BlockFormatter.QuoteStyle = BlockFormatter.QuoteStyle(0, 0, 0f, 0, 0, 0, 0)
+        quoteStyle: BlockFormatter.QuoteStyle = BlockFormatter.QuoteStyle(0, 0, 0, 0f, 0, 0, 0, 0)
 ) = when (alignmentRendering) {
     AlignmentRendering.SPAN_LEVEL -> AztecQuoteSpanAligned(nestingLevel, attributes, quoteStyle, null)
     AlignmentRendering.VIEW_LEVEL -> AztecQuoteSpan(nestingLevel, attributes, quoteStyle)
@@ -69,11 +72,12 @@ open class AztecQuoteSpan(
         override var nestingLevel: Int,
         override var attributes: AztecAttributes,
         var quoteStyle: BlockFormatter.QuoteStyle
-) : QuoteSpan(),
+) : CharacterStyle(), LeadingMarginSpan,
         LineBackgroundSpan,
         IAztecBlockSpan,
         LineHeightSpan,
-        UpdateLayout {
+        UpdateLayout,
+        UpdateAppearance {
 
     override var endBeforeBleed: Int = -1
     override var startBeforeCollapse: Int = -1
@@ -199,4 +203,8 @@ open class AztecQuoteSpan(
     }
 
     override val textFormat: ITextFormat = AztecTextFormat.FORMAT_QUOTE
+
+    override fun updateDrawState(tp: TextPaint?) {
+        tp?.color = quoteStyle.quoteTextColor
+    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -88,18 +88,48 @@ open class AztecQuoteSpan(
 
     override val TAG: String = "blockquote"
 
-    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
+    var originalAscent: Int = 0
+    var originalTop: Int = 0
+    var originalDescent: Int = 0
+    var originalBottom: Int = 0
+
+    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int,
+                              fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
+        val isFirstLine = start <= spanStart
+        val isLastLine = spanEnd <= end
 
-        if (start == spanStart || start < spanStart) {
+        if (isFirstLine) {
+            originalAscent = fm.ascent
+            originalTop = fm.top
+            originalDescent = fm.descent
+            originalBottom = fm.bottom
+
             fm.ascent -= quoteStyle.verticalPadding
             fm.top -= quoteStyle.verticalPadding
+
+            if(!isLastLine){
+                fm.descent = originalDescent
+                fm.bottom = originalBottom
+            }
         }
-        if (end == spanEnd || spanEnd < end) {
+        if (isLastLine) {
             fm.descent += quoteStyle.verticalPadding
             fm.bottom += quoteStyle.verticalPadding
+
+            if(!isFirstLine){
+                fm.ascent = originalAscent
+                fm.top = originalTop
+            }
+        }
+
+        if (!isFirstLine && !isLastLine) {
+            fm.ascent = originalAscent
+            fm.top = originalTop
+            fm.descent = originalDescent
+            fm.bottom = originalBottom
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -110,7 +110,7 @@ open class AztecQuoteSpan(
             fm.ascent -= quoteStyle.verticalPadding
             fm.top -= quoteStyle.verticalPadding
 
-            if(!isLastLine){
+            if (!isLastLine) {
                 fm.descent = originalDescent
                 fm.bottom = originalBottom
             }
@@ -119,7 +119,7 @@ open class AztecQuoteSpan(
             fm.descent += quoteStyle.verticalPadding
             fm.bottom += quoteStyle.verticalPadding
 
-            if(!isFirstLine){
+            if (!isFirstLine) {
                 fm.ascent = originalAscent
                 fm.top = originalTop
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -88,11 +88,12 @@ open class AztecQuoteSpan(
 
     override val TAG: String = "blockquote"
 
-    var originalAscent: Int = 0
-    var originalTop: Int = 0
-    var originalDescent: Int = 0
-    var originalBottom: Int = 0
+    private var originalAscent: Int = 0
+    private var originalTop: Int = 0
+    private var originalDescent: Int = 0
+    private var originalBottom: Int = 0
 
+    // this method adds extra padding to the top and bottom lines of the text while removing it from middle lines
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int,
                               fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -32,6 +32,7 @@
         <attr name="preformatBorderThickness" format="reference|dimension" />
         <attr name="preformatLeadingMargin" format="reference|dimension" />
         <attr name="preformatTextSize" format="reference|dimension" />
+        <attr name="preformatVerticalPadding" format="reference|dimension" />
         <attr name="quoteBackground" format="reference|color" />
         <attr name="quoteBackgroundAlpha" format="reference|fraction" />
         <attr name="quoteColor" format="reference|color" />
@@ -39,6 +40,7 @@
         <attr name="quoteMargin" format="reference|dimension" />
         <attr name="quotePadding" format="reference|dimension" />
         <attr name="quoteWidth" format="reference|dimension" />
+        <attr name="quoteVerticalPadding" format="reference|dimension" />
         <attr name="textColor" format="reference|color" />
         <attr name="textColorHint" format="reference|color" />
         <attr name="exclusiveBlocks" format="reference|boolean" />

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -31,6 +31,7 @@
         <attr name="preformatBorderRadius" format="reference|dimension" />
         <attr name="preformatBorderThickness" format="reference|dimension" />
         <attr name="preformatLeadingMargin" format="reference|dimension" />
+        <attr name="preformatTextSize" format="reference|dimension" />
         <attr name="quoteBackground" format="reference|color" />
         <attr name="quoteBackgroundAlpha" format="reference|fraction" />
         <attr name="quoteColor" format="reference|color" />

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -27,9 +27,14 @@
         <attr name="preformatBackground" format="reference|color" />
         <attr name="preformatBackgroundAlpha" format="reference|fraction" />
         <attr name="preformatColor" format="reference|color" />
+        <attr name="preformatBorderColor" format="reference|color" />
+        <attr name="preformatBorderRadius" format="reference|dimension" />
+        <attr name="preformatBorderThickness" format="reference|dimension" />
+        <attr name="preformatLeadingMargin" format="reference|dimension" />
         <attr name="quoteBackground" format="reference|color" />
         <attr name="quoteBackgroundAlpha" format="reference|fraction" />
         <attr name="quoteColor" format="reference|color" />
+        <attr name="quoteTextColor" format="reference|color" />
         <attr name="quoteMargin" format="reference|dimension" />
         <attr name="quotePadding" format="reference|dimension" />
         <attr name="quoteWidth" format="reference|dimension" />

--- a/aztec/src/main/res/values/dimens.xml
+++ b/aztec/src/main/res/values/dimens.xml
@@ -46,6 +46,7 @@
     <dimen name="margin_extra_large">16dp</dimen>
 
     <dimen name="preformat_leading_margin">8dp</dimen>
+    <dimen name="preformat_text_size">16sp</dimen>
 
     <dimen name="text_dialog">14sp</dimen>
 

--- a/aztec/src/main/res/values/dimens.xml
+++ b/aztec/src/main/res/values/dimens.xml
@@ -45,6 +45,8 @@
     <dimen name="margin_large">12dp</dimen>
     <dimen name="margin_extra_large">16dp</dimen>
 
+    <dimen name="preformat_leading_margin">8dp</dimen>
+
     <dimen name="text_dialog">14sp</dimen>
 
 </resources>

--- a/aztec/src/main/res/values/dimens.xml
+++ b/aztec/src/main/res/values/dimens.xml
@@ -47,6 +47,7 @@
 
     <dimen name="preformat_leading_margin">8dp</dimen>
     <dimen name="preformat_text_size">16sp</dimen>
+    <dimen name="preformat_vertical_padding">12dp</dimen>
 
     <dimen name="text_dialog">14sp</dimen>
 

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -46,6 +46,7 @@
         <item name="preformatBorderThickness">1dp</item>
         <item name="preformatLeadingMargin">@dimen/preformat_leading_margin</item>
         <item name="preformatTextSize">@dimen/preformat_text_size</item>
+        <item name="preformatVerticalPadding">@dimen/preformat_vertical_padding</item>
         <!-- Quote -->
         <item name="quoteBackground">@color/blue_wordpress</item>
         <item name="quoteBackgroundAlpha">75%</item>
@@ -54,6 +55,7 @@
         <item name="quoteMargin">@dimen/quote_margin</item>
         <item name="quotePadding">@dimen/quote_padding</item>
         <item name="quoteWidth">@dimen/quote_width</item>
+        <item name="quoteVerticalPadding">@dimen/block_vertical_padding</item>
         <!-- General Text -->
         <item name="textColor">@android:color/white</item>
         <item name="textColorHint">@android:color/darker_gray</item>

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -25,30 +25,42 @@
     </style>
 
     <style name="AztecTextStyle">
-        <item name="android:textCursorDrawable">?attr/textColor</item>
-        <item name="backgroundColor">@android:color/transparent</item>
+        <!-- Unordered list -->
         <item name="bulletColor">@color/blue_medium</item>
         <item name="bulletMargin">@dimen/bullet_margin</item>
         <item name="bulletPadding">@dimen/bullet_padding</item>
         <item name="bulletWidth">@dimen/bullet_width</item>
+        <!-- Code -->
         <item name="codeBackground">@color/code_background</item>
         <item name="codeBackgroundAlpha">75%</item>
         <item name="codeColor">@color/code</item>
-        <item name="lineSpacingExtra">@dimen/spacing_extra</item>
-        <item name="lineSpacingMultiplier">@dimen/spacing_multiplier</item>
+        <!-- Link -->
         <item name="linkColor">@color/blue_wordpress</item>
         <item name="linkUnderline">false</item>
+        <!-- Preformatted -->
         <item name="preformatBackground">@color/code_background</item>
         <item name="preformatBackgroundAlpha">75%</item>
         <item name="preformatColor">@color/white</item>
+        <item name="preformatBorderColor">#1AFFFFFF</item>
+        <item name="preformatBorderRadius">2dp</item>
+        <item name="preformatBorderThickness">1dp</item>
+        <item name="preformatLeadingMargin">@dimen/preformat_leading_margin</item>
+        <!-- Quote -->
         <item name="quoteBackground">@color/blue_wordpress</item>
         <item name="quoteBackgroundAlpha">75%</item>
         <item name="quoteColor">@color/blue_medium</item>
+        <item name="quoteTextColor">@android:color/white</item>
         <item name="quoteMargin">@dimen/quote_margin</item>
         <item name="quotePadding">@dimen/quote_padding</item>
         <item name="quoteWidth">@dimen/quote_width</item>
+        <!-- General Text -->
         <item name="textColor">@android:color/white</item>
         <item name="textColorHint">@android:color/darker_gray</item>
+        <!-- Other -->
+        <item name="lineSpacingExtra">@dimen/spacing_extra</item>
+        <item name="lineSpacingMultiplier">@dimen/spacing_multiplier</item>
+        <item name="android:textCursorDrawable">?attr/textColor</item>
+        <item name="backgroundColor">@android:color/transparent</item>
     </style>
 
     <style name="AztecToolbarStyle">

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -45,6 +45,7 @@
         <item name="preformatBorderRadius">2dp</item>
         <item name="preformatBorderThickness">1dp</item>
         <item name="preformatLeadingMargin">@dimen/preformat_leading_margin</item>
+        <item name="preformatTextSize">@dimen/preformat_text_size</item>
         <!-- Quote -->
         <item name="quoteBackground">@color/blue_wordpress</item>
         <item name="quoteBackgroundAlpha">75%</item>

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -41,7 +41,7 @@
         <item name="preformatBackground">@color/code_background</item>
         <item name="preformatBackgroundAlpha">75%</item>
         <item name="preformatColor">@color/white</item>
-        <item name="preformatBorderColor">#1AFFFFFF</item>
+        <item name="preformatBorderColor">@android:color/darker_gray</item>
         <item name="preformatBorderRadius">2dp</item>
         <item name="preformatBorderThickness">1dp</item>
         <item name="preformatLeadingMargin">@dimen/preformat_leading_margin</item>


### PR DESCRIPTION
This PR adds:
- Text color and vertical padding option to Quote span.
- Border thickness, border color, corner radius, vertical padding and text size options to Preformat span.


Details of changes:
- `AztecQuoteSpan` span was extending `QuoteSpan` but was not utilizing anything Quote specific from the superclass. We already doing all the work ourself utilizing `LeadingMarginSpan` and `LineBackgroundSpan`. Because of this I switched from extending `QuoteSpan` with `CharacterStyle` to affect the text color.

- `AztecPreformatSpan` - added bunch of styling options, and changed how we draw background - from simple rect drawing to path drawing. This was necessary since path drawing provides extra flexibility that allows us to draw border and fill depending on which line in the block is being rendered (top, middle or bottom). 

- Removed content of `drawLeadingMargin` from `AztecPreformatSpan` since it did nothing useful.

- For both spans - fixed the issue where vertical padding was inconsistently applied to wrapping and new lines within same block (see quote screenshot)

| Before | After |
| ------------- | ------------- |
|  ![Screenshot_1664493510](https://user-images.githubusercontent.com/728822/193159024-d8e8a52d-37d5-40ee-9a20-88548d6d6849.png)  | ![Screenshot_1664493591](https://user-images.githubusercontent.com/728822/193159040-7545685d-1bdb-420c-80cc-7924ab13f385.png) |





### Test
1. Modify `quoteTextColor` in `styles.xml` and make sure the value is used to render text of the Quote.
2. Modify `preformatBorderColor`, `preformatBorderRadius`, `preformatBorderThickness`, `preformat_leading_margin` and  `preformatTextSize` and confirm that style of preformed code changes accordingly.
