### PR TITLE
Updates: target sdk version to 31

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize|stateHidden"
             android:theme="@style/MainActivityTheme" >
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -60,9 +60,9 @@ dependencies {
 
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation 'androidx.test:core:1.4.0'
 
-    androidTestImplementation 'androidx.test:core:1.2.0'
+    androidTestImplementation 'androidx.test:core:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0', {

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ ext {
     jSoupVersion = '1.11.3'
     wordpressUtilsVersion = 'trunk-1ed207c03d2242b6fc3d74f9e388e9163cbc82a6'
     espressoVersion = '3.0.1'
-    commonTargetSdkVersion = 30
+    commonTargetSdkVersion = 31
     commonMinSdkVersion = 21
 
     aztecProjectDependency = project.hasProperty("aztecVersion") ? "org.wordpress:aztec:${project.getProperty("aztecVersion")}" : project(":aztec")


### PR DESCRIPTION
Closes #1003 

This PR updates the `targetSDKversion` to 31 for the Android 12 migration

Test Instructions
- Install the app from the Parent https://github.com/wordpress-mobile/WordPress-Android/pull/17153
- Make sure the functionalities provided by the library work as expected


[x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.