### PR TITLE
Feature/add styling options to task list

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -59,6 +59,8 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
+import org.wordpress.aztec.toolbar.ToolbarAction
+import org.wordpress.aztec.toolbar.ToolbarItems
 import org.wordpress.aztec.util.AztecLog
 import org.xml.sax.Attributes
 import java.io.File
@@ -90,6 +92,10 @@ open class MainActivity : AppCompatActivity(),
         private val UNDERLINE = "<u style=\"color:lime\">Underline</u><br>"
         private val STRIKETHROUGH = "<s style=\"color:#ff666666\" class=\"test\">Strikethrough</s><br>" // <s> or <strike> or <del>
         private val ORDERED = "<ol style=\"color:green\"><li>Ordered</li><li>should have color</li></ol>"
+        private val TASK_LIST = "<ul type=\"task-list\">\n" +
+                " <li><input type=\"checkbox\" class=\"task-list-item-checkbox\">Unchecked</li>\n" +
+                " <li><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked>Checked</li>\n" +
+                "</ul>"
         private val ORDERED_WITH_START = "<h4>Start in 10 List:</h4>" +
                 "<ol start=\"10\">\n" +
                 "    <li>Ten</li>\n" +
@@ -186,6 +192,7 @@ open class MainActivity : AppCompatActivity(),
                         ITALIC +
                         UNDERLINE +
                         STRIKETHROUGH +
+                        TASK_LIST +
                         ORDERED +
                         ORDERED_WITH_START +
                         ORDERED_REVERSED +

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -59,8 +59,6 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
-import org.wordpress.aztec.toolbar.ToolbarAction
-import org.wordpress.aztec.toolbar.ToolbarItems
 import org.wordpress.aztec.util.AztecLog
 import org.xml.sax.Attributes
 import java.io.File

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -447,7 +447,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 styles.getDimensionPixelSize(R.styleable.AztecText_bulletWidth, 0),
                 verticalParagraphPadding)
 
-         listItemStyle = BlockFormatter.ListItemStyle(
+        listItemStyle = BlockFormatter.ListItemStyle(
                 styles.getBoolean(R.styleable.AztecText_taskListStrikethroughChecked, false),
                 styles.getColor(R.styleable.AztecText_taskListCheckedTextColor, 0))
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -313,6 +313,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     var lastPressedXCoord: Int = 0
     var lastPressedYCoord: Int = 0
 
+    private lateinit var listItemStyle: BlockFormatter.ListItemStyle
+
     interface OnSelectionChangedListener {
         fun onSelectionChanged(selStart: Int, selEnd: Int)
     }
@@ -444,8 +446,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 styles.getDimensionPixelSize(R.styleable.AztecText_bulletPadding, 0),
                 styles.getDimensionPixelSize(R.styleable.AztecText_bulletWidth, 0),
                 verticalParagraphPadding)
+
+         listItemStyle = BlockFormatter.ListItemStyle(
+                styles.getBoolean(R.styleable.AztecText_taskListStrikethroughChecked, false),
+                styles.getColor(R.styleable.AztecText_taskListCheckedTextColor, 0))
+
         blockFormatter = BlockFormatter(editor = this,
                 listStyle = listStyle,
+                listItemStyle = listItemStyle,
                 quoteStyle = BlockFormatter.QuoteStyle(
                         styles.getColor(R.styleable.AztecText_quoteBackground, 0),
                         styles.getColor(R.styleable.AztecText_quoteColor, 0),
@@ -771,7 +779,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         BlockElementWatcher(this)
                 .add(HeadingHandler(alignmentRendering))
                 .add(ListHandler())
-                .add(ListItemHandler(alignmentRendering))
+                .add(ListItemHandler(alignmentRendering, listItemStyle))
                 .add(QuoteHandler())
                 .add(PreformatHandler())
                 .install(this)
@@ -1582,6 +1590,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         editable.getSpans(start, end, EndOfParagraphMarker::class.java).forEach { it.verticalPadding = verticalParagraphPadding }
         editable.getSpans(start, end, AztecURLSpan::class.java).forEach { it.linkStyle = linkFormatter.linkStyle }
         editable.getSpans(start, end, AztecCodeSpan::class.java).forEach { it.codeStyle = inlineFormatter.codeStyle }
+        editable.getSpans(start, end, AztecListItemSpan::class.java).forEach { it.listItemStyle = listItemStyle }
 
         val imageSpans = editable.getSpans(start, end, AztecImageSpan::class.java)
         imageSpans.forEach {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -44,6 +44,7 @@ import kotlin.reflect.KClass
 
 class BlockFormatter(editor: AztecText,
                      private val listStyle: ListStyle,
+                     private val listItemStyle: ListItemStyle,
                      private val quoteStyle: QuoteStyle,
                      private val headerStyle: HeaderStyles,
                      private val preformatStyle: PreformatStyle,
@@ -59,6 +60,8 @@ class BlockFormatter(editor: AztecText,
             return indicatorMargin + 2 * indicatorWidth + indicatorPadding
         }
     }
+
+    data class ListItemStyle(val strikeThroughCheckedItems: Boolean, val checkedItemsTextColor: Int)
 
     data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteBackgroundAlpha: Float, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
     data class PreformatStyle(val preformatBackground: Int, val preformatBackgroundAlpha: Float, val preformatColor: Int, val verticalPadding: Int)
@@ -452,7 +455,7 @@ class BlockFormatter(editor: AztecText,
         return when (textFormat) {
             AztecTextFormat.FORMAT_ORDERED_LIST -> listOf(createOrderedListSpan(nestingLevel, alignmentRendering, attrs, listStyle), createListItemSpan(nestingLevel + 1, alignmentRendering))
             AztecTextFormat.FORMAT_UNORDERED_LIST -> listOf(createUnorderedListSpan(nestingLevel, alignmentRendering, attrs, listStyle), createListItemSpan(nestingLevel + 1, alignmentRendering))
-            AztecTextFormat.FORMAT_TASK_LIST -> listOf(createTaskListSpan(nestingLevel, alignmentRendering, attrs, editor.context, listStyle), createListItemSpan(nestingLevel + 1, alignmentRendering))
+            AztecTextFormat.FORMAT_TASK_LIST -> listOf(createTaskListSpan(nestingLevel, alignmentRendering, attrs, editor.context, listStyle), createListItemSpan(nestingLevel + 1, alignmentRendering, listItemStyle = listItemStyle))
             AztecTextFormat.FORMAT_QUOTE -> listOf(createAztecQuoteSpan(nestingLevel, attrs, alignmentRendering, quoteStyle))
             AztecTextFormat.FORMAT_HEADING_1,
             AztecTextFormat.FORMAT_HEADING_2,
@@ -500,7 +503,7 @@ class BlockFormatter(editor: AztecText,
             typeIsAssignableTo(AztecOrderedListSpan::class) -> createOrderedListSpan(nestingLevel, alignmentRendering, attrs, listStyle)
             typeIsAssignableTo(AztecUnorderedListSpan::class) -> createUnorderedListSpan(nestingLevel, alignmentRendering, attrs, listStyle)
             typeIsAssignableTo(AztecTaskListSpan::class) -> createTaskListSpan(nestingLevel, alignmentRendering, attrs, editor.context, listStyle)
-            typeIsAssignableTo(AztecListItemSpan::class) -> createListItemSpan(nestingLevel, alignmentRendering, attrs)
+            typeIsAssignableTo(AztecListItemSpan::class) -> createListItemSpan(nestingLevel, alignmentRendering, attrs, listItemStyle)
             typeIsAssignableTo(AztecQuoteSpan::class) -> createAztecQuoteSpan(nestingLevel, attrs, alignmentRendering, quoteStyle)
             typeIsAssignableTo(AztecHeadingSpan::class) -> createHeadingSpan(nestingLevel, textFormat, attrs, alignmentRendering, headerStyle)
             typeIsAssignableTo(AztecPreformatSpan::class) -> createPreformatSpan(nestingLevel, alignmentRendering, attrs, preformatStyle)
@@ -812,7 +815,7 @@ class BlockFormatter(editor: AztecText,
         BlockHandler.set(editableText, listSpan, start, end)
         // special case for styling single empty lines
         if (end - start == 1 && (editableText[end - 1] == '\n' || editableText[end - 1] == Constants.END_OF_BUFFER_MARKER)) {
-            ListItemHandler.newListItem(editableText, start, end, listSpan.nestingLevel + 1, alignmentRendering)
+            ListItemHandler.newListItem(editableText, start, end, listSpan.nestingLevel + 1, alignmentRendering, listItemStyle)
         } else {
             val listEnd = if (end == editableText.length) end else end - 1
             val listContent = editableText.substring(start, listEnd)
@@ -831,7 +834,7 @@ class BlockFormatter(editor: AztecText,
                         start + lineStart,
                         start + lineEnd,
                         listSpan.nestingLevel + 1,
-                        alignmentRendering)
+                        alignmentRendering, listItemStyle)
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/ListItemHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/ListItemHandler.kt
@@ -2,6 +2,7 @@ package org.wordpress.aztec.handlers
 
 import android.text.Spannable
 import org.wordpress.aztec.AlignmentRendering
+import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.spans.AztecListItemSpan
 import org.wordpress.aztec.spans.AztecListItemSpan.Companion.CHECKED
 import org.wordpress.aztec.spans.AztecTaskListSpan
@@ -10,12 +11,13 @@ import org.wordpress.aztec.spans.createListItemSpan
 import org.wordpress.aztec.watchers.TextDeleter
 
 class ListItemHandler(
-        val alignmentRendering: AlignmentRendering
+        val alignmentRendering: AlignmentRendering,
+        val listItemStyle: BlockFormatter.ListItemStyle
 ) : BlockHandler<AztecListItemSpan>(AztecListItemSpan::class.java) {
 
     override fun handleNewlineAtStartOfBlock() {
         // newline added at start of bullet so, add a new bullet
-        newListItem(text, newlineIndex, newlineIndex + 1, block.span.nestingLevel, alignmentRendering)
+        newListItem(text, newlineIndex, newlineIndex + 1, block.span.nestingLevel, alignmentRendering, listItemStyle)
 
         // push current bullet forward
         block.start = newlineIndex + 1
@@ -58,7 +60,7 @@ class ListItemHandler(
             newListItemStart = newlineIndex
         }
 
-        newListItem(text, newListItemStart, block.end, block.span.nestingLevel, alignmentRendering)
+        newListItem(text, newListItemStart, block.end, block.span.nestingLevel, alignmentRendering, listItemStyle)
         block.end = newListItemStart
     }
 
@@ -69,7 +71,7 @@ class ListItemHandler(
         }
 
         // attach a new bullet around the end-of-text marker
-        newListItem(text, markerIndex, markerIndex + 1, block.span.nestingLevel, alignmentRendering)
+        newListItem(text, markerIndex, markerIndex + 1, block.span.nestingLevel, alignmentRendering, listItemStyle)
 
         // the current list item has bled over to the marker so, let's adjust its range to just before the marker.
         //  There's a newline there hopefully :)
@@ -82,10 +84,11 @@ class ListItemHandler(
                 start: Int,
                 end: Int,
                 nestingLevel: Int,
-                alignmentRendering: AlignmentRendering
+                alignmentRendering: AlignmentRendering,
+                listItemStyle: BlockFormatter.ListItemStyle
         ) {
             val isInTaskList = !text.getSpans(start, end, AztecTaskListSpan::class.java).isNullOrEmpty()
-            set(text, createListItemSpan(nestingLevel, alignmentRendering).apply {
+            set(text, createListItemSpan(nestingLevel, alignmentRendering, listItemStyle = listItemStyle).apply {
                 if (isInTaskList) {
                     this.attributes.setValue(CHECKED, "false")
                 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListItemSpan.kt
@@ -12,12 +12,10 @@ import java.lang.StringBuilder
 fun createListItemSpan(nestingLevel: Int,
                        alignmentRendering: AlignmentRendering,
                        attributes: AztecAttributes = AztecAttributes(),
-                       listItemStyle: BlockFormatter.ListItemStyle = BlockFormatter.ListItemStyle(
-                               false, 0)): IAztecBlockSpan =
-        when (alignmentRendering) {
-            AlignmentRendering.SPAN_LEVEL -> AztecListItemSpanAligned(nestingLevel, attributes, null, listItemStyle)
-            AlignmentRendering.VIEW_LEVEL -> AztecListItemSpan(nestingLevel, attributes, listItemStyle)
-        }
+                       listItemStyle: BlockFormatter.ListItemStyle = BlockFormatter.ListItemStyle(false, 0)): IAztecBlockSpan = when (alignmentRendering) {
+    AlignmentRendering.SPAN_LEVEL -> AztecListItemSpanAligned(nestingLevel, attributes, null, listItemStyle)
+    AlignmentRendering.VIEW_LEVEL -> AztecListItemSpan(nestingLevel, attributes, listItemStyle)
+}
 
 /**
  * We need to have two classes for handling alignment at either the Span-level (ListItemSpanAligned)

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -48,6 +48,8 @@
         <attr name="headingFourFontColor" format="reference|color" />
         <attr name="headingFiveFontColor" format="reference|color" />
         <attr name="headingSixFontColor" format="reference|color" />
+        <attr name="taskListStrikethroughChecked" format="reference|boolean" />
+        <attr name="taskListCheckedTextColor" format="reference|color" />
     </declare-styleable>
 
     <declare-styleable name="AztecToolbar">

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -49,6 +49,8 @@
         <item name="quoteWidth">@dimen/quote_width</item>
         <item name="textColor">@android:color/white</item>
         <item name="textColorHint">@android:color/darker_gray</item>
+        <item name="taskListCheckedTextColor">@android:color/darker_gray</item>
+        <item name="taskListStrikethroughChecked">true</item>
     </style>
 
     <style name="AztecToolbarStyle">


### PR DESCRIPTION
This PR adds option to specify checked task list item color and if it should use strikethrough.

I tried couple of approaches, but the easiest one was to add styling to the `AztecListItemSpan`. This requires wiring the styling data to a lot of places, but it also opens up potential for styling list items for other purposes.

### Test
You can add the task list button to the toolbar by pasting following code somewhere [here](https://github.com/wordpress-mobile/AztecEditor-Android/blob/trunk/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt#L394):

```
toolbar.setToolbarItems(ToolbarItems.BasicLayout(
        ToolbarAction.TASK_LIST
))
toolbar.enableTaskList()
```

[![Image from Gyazo](https://i.gyazo.com/45effa99808119eab242a5bc4844858e.gif)](https://gyazo.com/45effa99808119eab242a5bc4844858e)


1. Confirm that task list in HTML rendered from example has a task list, it works as expected and selected items use grey strikethrough text.
1. Confirm that task list added from toolbar works as expected and selected items use grey strikethrough text.


Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.