### PR TITLE
Keep tab character when cleaning-up html.

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -57,7 +57,7 @@ object Format {
             val doc = Jsoup.parseBodyFragment(htmlWithoutSourceFormatting.replace("\n", "")).outputSettings(Document.OutputSettings().prettyPrint(false))
             return doc.body().html()
         } else {
-            return if (isGutenbergMode) { html } else { replaceAll(html, "\\s*<(/?($block)(.*?))>\\s*", "<$1>") }
+            return if (isGutenbergMode) { html } else { replaceAll(html, "\\s*<(/?($block)(.*?))>[ \\r\\n\\f]*", "<$1>") }
         }
     }
 


### PR DESCRIPTION
### Fix


### Test
1. [STEP_1]
2. [STEP_2]
3. [STEP_3]

### Review
@[USER_NAME]

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.