### PR TITLE
Update Kotlin to 1.6.10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation project(':wordpress-shortcodes')
     implementation project(':media-placeholders')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -48,8 +48,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
-
     implementation "org.ccil.cowan.tagsoup:tagsoup:$tagSoupVersion"
     implementation "org.jsoup:jsoup:$jSoupVersion"
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecNestable.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecNestable.kt
@@ -12,7 +12,7 @@ interface IAztecNestable {
         fun getNestingLevelAt(spanned: Spanned, index: Int, nextIndex: Int = index): Int {
             return spanned.getSpans(index, nextIndex, IAztecNestable::class.java)
                     .filter { spanned.getSpanEnd(it) != index || index == 0 || spanned[index - 1] != Constants.NEWLINE }
-                    .maxBy { it.nestingLevel }?.nestingLevel ?: 0
+                    .maxByOrNull { it.nestingLevel }?.nestingLevel ?: 0
         }
 
         fun getMinNestingLevelAt(spanned: Spanned, index: Int, nextIndex: Int = index): Int {
@@ -21,7 +21,7 @@ interface IAztecNestable {
                     .filter { spanned.getSpanStart(it) <= index && spanned.getSpanEnd(it) >= nextIndex &&
                             (spanned.getSpanStart(it) != index || spanned.getSpanEnd(it) != nextIndex) }
                     .filter { index != nextIndex || spanned.getSpanStart(it) != index && spanned.getSpanEnd(it) != index }
-                    .minBy { it.nestingLevel }?.nestingLevel ?: 0
+                    .minByOrNull { it.nestingLevel }?.nestingLevel ?: 0
         }
 
         fun pushDeeper(spannable: Spannable, start: Int, end: Int, fromLevel: Int = 0, pushBy: Int = 1): List<SpanWrapper<IAztecNestable>> {

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
     tagSoupVersion = '1.2.1'
     glideVersion = '4.10.0'
     picassoVersion = '2.5.2'
-    robolectricVersion = '4.4'
+    robolectricVersion = '4.9'
     jUnitVersion = '4.12'
     jSoupVersion = '1.11.3'
     wordpressUtilsVersion = 'trunk-1ed207c03d2242b6fc3d74f9e388e9163cbc82a6'

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -24,8 +24,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
-
     implementation aztecProjectDependency
     implementation "com.github.bumptech.glide:glide:$glideVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx1536m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 android.enableJetifier=false
 android.useAndroidX=true
 

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -23,8 +23,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
-
     implementation aztecProjectDependency
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.4.20'
+    gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
 
     plugins {

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -35,8 +35,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
-
     implementation aztecProjectDependency
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -34,8 +34,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
-
     implementation aztecProjectDependency
 
     implementation 'androidx.appcompat:appcompat:1.0.0'


### PR DESCRIPTION
This PR upgrades Kotlin to `1.6.10`.

FYI: This is primarily done to unblock development with JDK17.

-----

It also includes the following:

- [Remove max perm size option gradle jvmargs from gradle properties.](https://github.com/wordpress-mobile/AztecEditor-Android/commit/ba86630a6c7ccdd0ee4e0258c796969c8fa1466e) This is done because otherwise the Gradle daemon fails to start for JDK17.
- [Update robolectric to 4.9.](https://github.com/wordpress-mobile/AztecEditor-Android/commit/310d583c619c8ed48c1486ce9f165c7b553445d4) This is done because otherwise Unit Tests are failing to run.
- [Remove unnecessary kotlin stdlib dependency from all modules.](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1015/commits/47a77e856f7df95fc41f24d8ac8e0999967c6b14) This is a clean-up commit.

-----

### Test
1. Smoke test the app.
2. Test for build time increases (local & CI).

-----

### Review

@planarvoid and @danilo04 as you were also involved in #982.

-----

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.