### PR TITLE
[Compile Warnings As Errors] Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/BaseTest.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/BaseTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.aztec.demo
 
 import android.util.Log

--- a/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
+++ b/app/src/androidTest/kotlin/org/wordpress/aztec/demo/tests/GutenbergCompatTests.kt
@@ -328,7 +328,7 @@ class GutenbergCompatTests : BaseTest() {
         val editorPage = EditorPage()
         val audioShortcodePlugin = AudioShortcodePlugin()
         val aztecText = mActivityIntentsTestRule.activity.findViewById<AztecText>(R.id.aztec)
-        aztecText.plugins?.add(audioShortcodePlugin)
+        aztecText.plugins.add(audioShortcodePlugin)
 
         // let's test the plugin works as expected, i.e. it preserves the Gutenberg block structure
         editorPage

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -525,7 +525,7 @@ open class MainActivity : AppCompatActivity(),
         super.onSaveInstanceState(outState)
 
         if (mediaUploadDialog != null && mediaUploadDialog!!.isShowing) {
-            outState?.putBoolean("isMediaUploadDialogVisible", true)
+            outState.putBoolean("isMediaUploadDialogVisible", true)
         }
     }
 

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -253,15 +253,13 @@ open class MainActivity : AppCompatActivity(),
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (resultCode == Activity.RESULT_OK) {
-            var bitmap: Bitmap
-
             when (requestCode) {
                 REQUEST_MEDIA_CAMERA_PHOTO -> {
                     // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
                     //  to correctly set the input density to 160 ourselves.
                     val options = BitmapFactory.Options()
                     options.inDensity = DisplayMetrics.DENSITY_DEFAULT
-                    bitmap = BitmapFactory.decodeFile(mediaPath, options)
+                    val bitmap = BitmapFactory.decodeFile(mediaPath, options)
                     insertImageAndSimulateUpload(bitmap, mediaPath)
                 }
                 REQUEST_MEDIA_PHOTO -> {
@@ -271,7 +269,7 @@ open class MainActivity : AppCompatActivity(),
                     //  to correctly set the input density to 160 ourselves.
                     val options = BitmapFactory.Options()
                     options.inDensity = DisplayMetrics.DENSITY_DEFAULT
-                    bitmap = BitmapFactory.decodeStream(stream, null, options)
+                    val bitmap = BitmapFactory.decodeStream(stream, null, options)
 
                     insertImageAndSimulateUpload(bitmap, mediaPath)
                 }
@@ -287,7 +285,7 @@ open class MainActivity : AppCompatActivity(),
 
                         override fun onThumbnailLoaded(drawable: Drawable?) {
                             val conf = Bitmap.Config.ARGB_8888 // see other conf types
-                            bitmap = Bitmap.createBitmap(drawable!!.intrinsicWidth, drawable.intrinsicHeight, conf)
+                            val bitmap = Bitmap.createBitmap(drawable!!.intrinsicWidth, drawable.intrinsicHeight, conf)
                             val canvas = Canvas(bitmap)
                             drawable.setBounds(0, 0, canvas.width, canvas.height)
                             drawable.draw(canvas)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -53,6 +53,7 @@ import org.wordpress.aztec.spans.createTaskListSpan
 import org.wordpress.aztec.spans.createUnorderedListSpan
 import org.wordpress.aztec.util.getLast
 import org.xml.sax.Attributes
+import java.util.Locale
 
 class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = ArrayList(), private val alignmentRendering: AlignmentRendering
 ) : Html.TagHandler {
@@ -75,7 +76,7 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
             return true
         }
 
-        when (tag.toLowerCase()) {
+        when (tag.lowercase(Locale.getDefault())) {
             LIST_LI -> {
                 val span = createListItemSpan(nestingLevel, alignmentRendering, AztecAttributes(attributes))
                 handleElement(output, opening, span)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -706,7 +706,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             temp
         }
 
-        val emptyEditTextBackspaceDetector = InputFilter { source, start, end, dest, dstart, dend ->
+        val emptyEditTextBackspaceDetector = InputFilter { source, start, _, _, dstart, dend ->
             if (selectionStart == 0 && selectionEnd == 0
                     && start == 0
                     && dstart == 0 && dend == 0

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2083,8 +2083,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         unknownBlockSpanStart = text.getSpanStart(unknownHtmlSpan)
         blockEditorDialog = builder.create()
-        blockEditorDialog!!.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-        blockEditorDialog!!.show()
+        blockEditorDialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        blockEditorDialog?.show()
     }
 
     private fun deleteInlineStyleFromTheBeginning() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -132,6 +132,7 @@ import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.Arrays
 import java.util.LinkedList
+import java.util.Locale
 
 @Suppress("UNUSED_PARAMETER")
 open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlTappedListener, IEventInjector {
@@ -1818,7 +1819,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             // Android 8 Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
             clipboardIdentifier -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < Build.VERSION_CODES.P
-                        && Build.MANUFACTURER.toLowerCase().equals("samsung")) {
+                        && Build.MANUFACTURER.lowercase(Locale.getDefault()).equals("samsung")) {
                     // Nope return true
                     Toast.makeText(context, context.getString(R.string.samsung_disabled_custom_clipboard, Build.VERSION.RELEASE), Toast.LENGTH_LONG).show()
                 } else {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -898,7 +898,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         history.inputLast = InstanceStateUtils.readAndPurgeTempInstance<String>(INPUT_LAST_KEY, "", savedState.state)
         visibility = customState.getInt(VISIBILITY_KEY)
 
-        initialEditorContentParsedSHA256 = customState.getByteArray(RETAINED_INITIAL_HTML_PARSED_SHA256_KEY)
+        customState.getByteArray(RETAINED_INITIAL_HTML_PARSED_SHA256_KEY)?.let {
+            initialEditorContentParsedSHA256 = it
+        }
         val retainedHtml = InstanceStateUtils.readAndPurgeTempInstance<String>(RETAINED_HTML_KEY, "", savedState.state)
         fromHtml(retainedHtml)
 
@@ -943,9 +945,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return false
     }
 
-    override fun onSaveInstanceState(): Parcelable {
+    override fun onSaveInstanceState(): Parcelable? {
         val superState = super.onSaveInstanceState()
-        val savedState = SavedState(superState)
+        val savedState = superState?.let { SavedState(it) }
         val bundle = Bundle()
         InstanceStateUtils.writeTempInstance(context, externalLogger, HISTORY_LIST_KEY, ArrayList<String>(history.historyList), bundle)
         bundle.putInt(HISTORY_CURSOR_KEY, history.historyCursor)
@@ -978,7 +980,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         bundle.putBoolean(IS_MEDIA_ADDED_KEY, isMediaAdded)
 
-        savedState.state = bundle
+        savedState?.state = bundle
         return savedState
     }
 
@@ -988,7 +990,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         constructor(superState: Parcelable) : super(superState)
 
         constructor(parcel: Parcel) : super(parcel) {
-            state = parcel.readBundle(javaClass.classLoader)
+            parcel.readBundle(javaClass.classLoader)?.let {
+                state = it
+            }
         }
 
         override fun writeToParcel(out: Parcel, flags: Int) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -823,7 +823,7 @@ class BlockFormatter(editor: AztecText,
             for (i in lines.indices) {
                 val lineLength = lines[i].length
 
-                val lineStart = (0 until i).sumBy { lines[it].length + 1 }
+                val lineStart = (0 until i).sumOf { lines[it].length + 1 }
 
                 val lineEnd = (lineStart + lineLength).let {
                     if ((start + it) != editableText.length) it + 1 else it // include the newline or not
@@ -843,7 +843,7 @@ class BlockFormatter(editor: AztecText,
         for (i in lines.indices) {
             val splitLength = lines[i].length
 
-            val lineStart = start + (0 until i).sumBy { lines[it].length + 1 }
+            val lineStart = start + (0 until i).sumOf { lines[it].length + 1 }
             val lineEnd = (lineStart + splitLength + 1).coerceAtMost(end) // +1 to include the newline
 
             val lineLength = lineEnd - lineStart
@@ -860,7 +860,7 @@ class BlockFormatter(editor: AztecText,
         for (i in lines.indices) {
             val splitLength = lines[i].length
 
-            val lineStart = start + (0 until i).sumBy { lines[it].length + 1 }
+            val lineStart = start + (0 until i).sumOf { lines[it].length + 1 }
             val lineEnd = (lineStart + splitLength + 1).coerceAtMost(end) // +1 to include the newline
 
             val lineLength = lineEnd - lineStart
@@ -901,7 +901,7 @@ class BlockFormatter(editor: AztecText,
         val list = ArrayList<Int>()
 
         for (i in lines.indices) {
-            val lineStart = (0 until i).sumBy { lines[it].length + 1 }
+            val lineStart = (0 until i).sumOf { lines[it].length + 1 }
             val lineEnd = lineStart + lines[i].length
 
             if (lineStart > lineEnd) {
@@ -947,7 +947,7 @@ class BlockFormatter(editor: AztecText,
             return emptyList()
         }
 
-        val start = (0 until index).sumBy { lines[it].length + 1 }
+        val start = (0 until index).sumOf { lines[it].length + 1 }
         val end = start + lines[index].length
 
         if (start > end) {
@@ -983,7 +983,7 @@ class BlockFormatter(editor: AztecText,
         val list = ArrayList<Int>()
 
         for (i in lines.indices) {
-            val lineStart = (0 until i).sumBy { lines[it].length + 1 }
+            val lineStart = (0 until i).sumOf { lines[it].length + 1 }
             val lineEnd = lineStart + lines[i].length
 
             if (lineStart >= lineEnd) {
@@ -1017,7 +1017,7 @@ class BlockFormatter(editor: AztecText,
             return false
         }
 
-        val start = (0 until index).sumBy { lines[it].length + 1 }
+        val start = (0 until index).sumOf { lines[it].length + 1 }
         val end = start + lines[index].length
 
         if (start >= end) {
@@ -1113,7 +1113,7 @@ class BlockFormatter(editor: AztecText,
         val list = ArrayList<Int>()
 
         for (i in lines.indices) {
-            val lineStart = (0 until i).sumBy { lines[it].length + 1 }
+            val lineStart = (0 until i).sumOf { lines[it].length + 1 }
             val lineEnd = lineStart + lines[i].length
 
             if (lineStart >= lineEnd) {
@@ -1146,7 +1146,7 @@ class BlockFormatter(editor: AztecText,
             return false
         }
 
-        val start = (0 until index).sumBy { lines[it].length + 1 }
+        val start = (0 until index).sumOf { lines[it].length + 1 }
         val end = start + lines[index].length
 
         if (start >= end) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -64,7 +64,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
     fun toggleAny(textFormats: Set<ITextFormat>) {
         if (!textFormats
                 .filter { containsInlineStyle(it) }
-                .fold(false) { found, containedTextFormat -> removeInlineStyle(containedTextFormat); true }) {
+                .fold(false) { _, containedTextFormat -> removeInlineStyle(containedTextFormat); true }) {
             removeAllExclusiveFormats()
             applyInlineStyle(textFormats.first())
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -211,7 +211,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
         joinStyleSpans(start, end)
     }
 
-    private fun applyMarkInlineStyle(start: Int = selectionStart, end: Int = selectionEnd, attrs: AztecAttributes = AztecAttributes()) {
+    private fun applyMarkInlineStyle(start: Int = selectionStart, end: Int = selectionEnd) {
         val previousSpans = editableText.getSpans(start, end, MarkSpan::class.java)
         previousSpans.forEach {
             it.applyInlineStyleAttributes(editableText, start, end)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -30,7 +30,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         val list = ArrayList<Int>()
 
         for (i in lines.indices) {
-            val lineStart = (0..i - 1).sumBy { lines[it].length + 1 }
+            val lineStart = (0..i - 1).sumOf { lines[it].length + 1 }
             val lineEnd = lineStart + lines[i].length
 
             if (lineStart >= lineEnd) {
@@ -64,7 +64,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
             return false
         }
 
-        val start = (0..index - 1).sumBy { lines[it].length + 1 }
+        val start = (0..index - 1).sumOf { lines[it].length + 1 }
         val end = start + lines[index].length
 
         if (start >= end) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -98,7 +98,9 @@ open class SourceViewEditText : AppCompatEditText, TextWatcher {
         visibility = customState.getInt("visibility")
         val retainedContent = InstanceStateUtils.readAndPurgeTempInstance<String>(RETAINED_CONTENT_KEY, "", savedState.state)
         setText(retainedContent)
-        initialEditorContentParsedSHA256 = customState.getByteArray(AztecText.RETAINED_INITIAL_HTML_PARSED_SHA256_KEY)
+        customState.getByteArray(AztecText.RETAINED_INITIAL_HTML_PARSED_SHA256_KEY)?.let {
+            initialEditorContentParsedSHA256 = it
+        }
     }
 
     // Do not include the content of the editor when saving state to bundle.
@@ -109,15 +111,15 @@ open class SourceViewEditText : AppCompatEditText, TextWatcher {
         return false
     }
 
-    override fun onSaveInstanceState(): Parcelable {
+    override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
         bundle.putByteArray(org.wordpress.aztec.AztecText.RETAINED_INITIAL_HTML_PARSED_SHA256_KEY,
                 initialEditorContentParsedSHA256)
         InstanceStateUtils.writeTempInstance(context, null, RETAINED_CONTENT_KEY, text.toString(), bundle)
         val superState = super.onSaveInstanceState()
-        val savedState = SavedState(superState)
+        val savedState = superState?.let { SavedState(it) }
         bundle.putInt("visibility", visibility)
-        savedState.state = bundle
+        savedState?.state = bundle
         return savedState
     }
 
@@ -127,7 +129,9 @@ open class SourceViewEditText : AppCompatEditText, TextWatcher {
         constructor(superState: Parcelable) : super(superState)
 
         constructor(parcel: Parcel) : super(parcel) {
-            state = parcel.readBundle(javaClass.classLoader)
+            parcel.readBundle(javaClass.classLoader)?.let {
+                state = it
+            }
         }
 
         override fun writeToParcel(out: Parcel, flags: Int) {
@@ -265,7 +269,7 @@ open class SourceViewEditText : AppCompatEditText, TextWatcher {
         val str: String
 
         if (withCursorTag) {
-            val withCursor = StringBuffer(text)
+            val withCursor = StringBuffer(text.toString())
             if (!isCursorInsideTag()) {
                 withCursor.insert(selectionEnd, "<aztec_cursor></aztec_cursor>")
             } else {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -20,7 +20,7 @@ fun createHeadingSpan(nestingLevel: Int,
                       alignmentRendering: AlignmentRendering,
                       headerStyle: BlockFormatter.HeaderStyles = BlockFormatter.HeaderStyles(0, emptyMap())
 ): AztecHeadingSpan {
-    val textFormat = when (tag.toLowerCase(Locale.getDefault())) {
+    val textFormat = when (tag.lowercase(Locale.getDefault())) {
         "h1" -> AztecTextFormat.FORMAT_HEADING_1
         "h2" -> AztecTextFormat.FORMAT_HEADING_2
         "h3" -> AztecTextFormat.FORMAT_HEADING_3

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -83,7 +83,7 @@ open class AztecOrderedListSpan(
         p.color = listStyle.indicatorColor
         p.style = Paint.Style.FILL
 
-        val start = if (attributes.hasAttribute("start") == true) {
+        val startAttribute = if (attributes.hasAttribute("start") == true) {
             attributes.getValue("start").toInt()
         } else {
             0
@@ -92,9 +92,9 @@ open class AztecOrderedListSpan(
         var textToDraw = ""
         getIndexOfProcessedLine(text, end)?.let {
             val isReversed = attributes.hasAttribute("reversed")
-            val lineIndex = if (start > 0) {
-                if (isReversed) start - (it - 1)
-                else start + (it - 1)
+            val lineIndex = if (startAttribute > 0) {
+                if (isReversed) startAttribute - (it - 1)
+                else startAttribute + (it - 1)
             } else {
                 val number = getNumberOfItemsInProcessedLine(text)
                 if (isReversed) number - (it - 1)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -378,13 +378,17 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         isMediaToolbarVisible = restoredState.getBoolean("isMediaToolbarVisible")
         setAdvancedState()
         setupMediaToolbar()
-        editorContentParsedSHA256LastSwitch = restoredState.getByteArray(RETAINED_EDITOR_HTML_PARSED_SHA256_KEY)
-        sourceContentParsedSHA256LastSwitch = restoredState.getByteArray(RETAINED_SOURCE_HTML_PARSED_SHA256_KEY)
+        restoredState.getByteArray(RETAINED_EDITOR_HTML_PARSED_SHA256_KEY)?.let {
+            editorContentParsedSHA256LastSwitch = it
+        }
+        restoredState.getByteArray(RETAINED_SOURCE_HTML_PARSED_SHA256_KEY)?.let {
+            sourceContentParsedSHA256LastSwitch = it
+        }
     }
 
-    override fun onSaveInstanceState(): Parcelable {
+    override fun onSaveInstanceState(): Parcelable? {
         val superState = super.onSaveInstanceState()
-        val savedState = SourceViewEditText.SavedState(superState)
+        val savedState = superState?.let { SourceViewEditText.SavedState(it) }
         val bundle = Bundle()
         bundle.putBoolean("isSourceVisible", sourceEditor?.visibility == View.VISIBLE)
         bundle.putBoolean("isMediaMode", isMediaModeEnabled)
@@ -392,7 +396,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         bundle.putBoolean("isMediaToolbarVisible", isMediaToolbarVisible)
         bundle.putByteArray(RETAINED_EDITOR_HTML_PARSED_SHA256_KEY, editorContentParsedSHA256LastSwitch)
         bundle.putByteArray(RETAINED_SOURCE_HTML_PARSED_SHA256_KEY, sourceContentParsedSHA256LastSwitch)
-        savedState.state = bundle
+        savedState?.state = bundle
         return savedState
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -791,6 +791,7 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
                 when (toolbarAction) {
                     ToolbarAction.HEADING -> setHeadingMenu(it)
                     ToolbarAction.LIST -> setListMenu(it)
+                    else -> Unit // Do nothing
                 }
                 if (!hasCustomLayout) {
                     it.setBackgroundDrawableRes(toolbarAction.buttonDrawableRes)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -110,100 +110,100 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         aztecToolbarListener = listener
     }
 
-    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+    override fun onKeyUp(keyCode: Int, keyEvent: KeyEvent): Boolean {
         when (keyCode) {
             KeyEvent.KEYCODE_1 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Heading 1 = Alt + Ctrl + 1
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Heading 1 = Alt + Ctrl + 1
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_HEADING_1, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_HEADING_1)
                     return true
                 }
             }
             KeyEvent.KEYCODE_2 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Heading 2 = Alt + Ctrl + 2
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Heading 2 = Alt + Ctrl + 2
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_HEADING_2, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_HEADING_2)
                     return true
                 }
             }
             KeyEvent.KEYCODE_3 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Heading 3 = Alt + Ctrl + 3
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Heading 3 = Alt + Ctrl + 3
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_HEADING_3, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_HEADING_3)
                     return true
                 }
             }
             KeyEvent.KEYCODE_4 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Heading 4 = Alt + Ctrl + 4
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Heading 4 = Alt + Ctrl + 4
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_HEADING_4, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_HEADING_4)
                     return true
                 }
             }
             KeyEvent.KEYCODE_5 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Heading 5 = Alt + Ctrl + 5
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Heading 5 = Alt + Ctrl + 5
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_HEADING_5, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_HEADING_5)
                     return true
                 }
             }
             KeyEvent.KEYCODE_6 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Heading 6 = Alt + Ctrl + 6
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Heading 6 = Alt + Ctrl + 6
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_HEADING_6, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_HEADING_6)
                     return true
                 }
             }
             KeyEvent.KEYCODE_7 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Heading 6 = Alt + Ctrl + 7
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Heading 6 = Alt + Ctrl + 7
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_PARAGRAPH, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_PARAGRAPH)
                     return true
                 }
             }
             KeyEvent.KEYCODE_8 -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Preformat = Alt + Ctrl + 8
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Preformat = Alt + Ctrl + 8
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_PREFORMAT, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_PREFORMAT)
                     return true
                 }
             }
             KeyEvent.KEYCODE_B -> {
-                if (event.isCtrlPressed) { // Bold = Ctrl + B
+                if (keyEvent.isCtrlPressed) { // Bold = Ctrl + B
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_STRONG, true)
                     findViewById<ToggleButton>(ToolbarAction.BOLD.buttonId).performClick()
                     return true
                 }
             }
             KeyEvent.KEYCODE_D -> {
-                if (event.isCtrlPressed) { // Strikethrough = Ctrl + D
+                if (keyEvent.isCtrlPressed) { // Strikethrough = Ctrl + D
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_STRIKETHROUGH, true)
                     findViewById<ToggleButton>(ToolbarAction.STRIKETHROUGH.buttonId).performClick()
                     return true
                 }
             }
             KeyEvent.KEYCODE_H -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Shortcuts = Alt + Ctrl + H
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Shortcuts = Alt + Ctrl + H
                     showDialogShortcuts()
                     return true
                 }
             }
             KeyEvent.KEYCODE_I -> {
-                if (event.isCtrlPressed) { // Italic = Ctrl + I
+                if (keyEvent.isCtrlPressed) { // Italic = Ctrl + I
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_EMPHASIS, true)
                     findViewById<ToggleButton>(ToolbarAction.ITALIC.buttonId).performClick()
                     return true
                 }
             }
             KeyEvent.KEYCODE_K -> {
-                if (event.isCtrlPressed) { // Link = Ctrl + K
+                if (keyEvent.isCtrlPressed) { // Link = Ctrl + K
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_LINK, true)
                     findViewById<ToggleButton>(ToolbarAction.LINK.buttonId).performClick()
                     return true
                 }
             }
             KeyEvent.KEYCODE_M -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Media = Alt + Ctrl + M
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Media = Alt + Ctrl + M
                     if (aztecToolbarListener != null && aztecToolbarListener!!.onToolbarMediaButtonClicked()) {
                         //event is consumed by listener
                     } else {
@@ -214,59 +214,59 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
                 }
             }
             KeyEvent.KEYCODE_O -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Ordered List = Alt + Ctrl + O
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Ordered List = Alt + Ctrl + O
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_ORDERED_LIST, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_ORDERED_LIST)
                     return true
                 }
             }
             KeyEvent.KEYCODE_Q -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Quote = Alt + Ctrl + Q
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Quote = Alt + Ctrl + Q
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_QUOTE, true)
                     findViewById<ToggleButton>(ToolbarAction.QUOTE.buttonId).performClick()
                     return true
                 }
             }
             KeyEvent.KEYCODE_U -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Unordered List = Alt + Ctrl + U
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Unordered List = Alt + Ctrl + U
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_UNORDERED_LIST, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_UNORDERED_LIST)
                     return true
-                } else if (event.isCtrlPressed) { // Underline = Ctrl + U
+                } else if (keyEvent.isCtrlPressed) { // Underline = Ctrl + U
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_UNDERLINE, true)
                     findViewById<ToggleButton>(ToolbarAction.UNDERLINE.buttonId).performClick()
                     return true
                 }
             }
             KeyEvent.KEYCODE_T -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Task List = Alt + Ctrl + T
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Task List = Alt + Ctrl + T
                     aztecToolbarListener?.onToolbarFormatButtonClicked(AztecTextFormat.FORMAT_TASK_LIST, true)
                     editor?.toggleFormatting(AztecTextFormat.FORMAT_TASK_LIST)
                     return true
                 }
             }
             KeyEvent.KEYCODE_X -> {
-                if (event.isAltPressed && event.isCtrlPressed) { // Code = Alt + Ctrl + X
+                if (keyEvent.isAltPressed && keyEvent.isCtrlPressed) { // Code = Alt + Ctrl + X
 //                    TODO: Add Code action.
 //                    findViewById<ToggleButton>(ToolbarAction.CODE.buttonId).performClick()
                     return true
                 }
             }
             KeyEvent.KEYCODE_Y -> {
-                if (event.isCtrlPressed) { // Redo  = Ctrl + Y
+                if (keyEvent.isCtrlPressed) { // Redo  = Ctrl + Y
                     editor?.redo()
                     return true
                 }
             }
             KeyEvent.KEYCODE_Z -> {
-                if (event.isCtrlPressed) { // Undo  = Ctrl + Z
+                if (keyEvent.isCtrlPressed) { // Undo  = Ctrl + Z
                     editor?.undo()
                     return true
                 }
             }
             else -> {
                 toolbarButtonPlugins.forEach {
-                    if (it.matchesKeyShortcut(keyCode, event)) {
+                    if (it.matchesKeyShortcut(keyCode, keyEvent)) {
                         aztecToolbarListener?.onToolbarFormatButtonClicked(it.action.textFormats.first(), true)
                         it.toggle()
                         return true

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/ColorConverter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/ColorConverter.kt
@@ -209,6 +209,7 @@ class ColorConverter {
          * cannot be translated.
          */
         @ColorInt
+        @Suppress("DEPRECATION")
         fun getColorInt(colorText: String): Int {
             try {
                 if (isColorResource(colorText)) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
@@ -60,7 +60,7 @@ class InstanceStateUtils {
                 return defaultValue
             }
 
-            var obj: T = defaultValue
+            @Suppress("VARIABLE_WITH_REDUNDANT_INITIALIZER") var obj: T = defaultValue
 
             with(file) {
                 FileInputStream(this).use { input ->

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
@@ -23,7 +23,7 @@ class InstanceStateUtils {
             externalLogger?.logException(e, "Error trying to write cache for $varName.")
         }
 
-        open fun writeTempInstance(context: Context, externalLogger: AztecLog.ExternalLogger?, varName: String, obj: Any?, bundle: Bundle) {
+        fun writeTempInstance(context: Context, externalLogger: AztecLog.ExternalLogger?, varName: String, obj: Any?, bundle: Bundle) {
             try {
                 with(File.createTempFile(varName, ".inst", context.getCacheDir())) {
                     deleteOnExit() // just make sure if we miss deleting this cache file the VM will eventually do it
@@ -46,7 +46,7 @@ class InstanceStateUtils {
             }
         }
 
-        open fun <T> readAndPurgeTempInstance(varName: String, defaultValue: T, bundle: Bundle): T {
+        fun <T> readAndPurgeTempInstance(varName: String, defaultValue: T, bundle: Bundle): T {
             // the full path is kept in the bundle so, get it from there
             val filename = bundle.getString(cacheFilenameKey(varName))
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
     repositories {
         maven { url "https://a8c-libs.s3.amazonaws.com/android" }
@@ -24,6 +26,11 @@ allprojects {
         }
         google()
         jcenter()
+    }
+    tasks.withType(KotlinCompile).all {
+        kotlinOptions {
+            allWarningsAsErrors = true
+        }
     }
 }
 

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
@@ -9,6 +9,7 @@ import org.wordpress.aztec.Constants
 import org.wordpress.aztec.plugins.html2visual.IHtmlCommentHandler
 import org.wordpress.aztec.plugins.visual2html.IInlineSpanHandler
 import org.wordpress.aztec.plugins.wpcomments.spans.WordPressCommentSpan
+import java.util.Locale
 
 class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpanHandler, IHtmlCommentHandler {
 
@@ -33,7 +34,8 @@ class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpan
 
         val spanStart = output.length
 
-        if (text.toLowerCase() == WordPressCommentSpan.Comment.MORE.html.toLowerCase()) {
+        if (text.lowercase(Locale.getDefault()) ==
+                WordPressCommentSpan.Comment.MORE.html.lowercase(Locale.getDefault())) {
 
             output.append(Constants.MAGIC_CHAR)
 
@@ -49,7 +51,8 @@ class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpan
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
             )
             return true
-        } else if (text.toLowerCase() == WordPressCommentSpan.Comment.PAGE.html.toLowerCase()) {
+        } else if (text.lowercase(Locale.getDefault()) ==
+                WordPressCommentSpan.Comment.PAGE.html.lowercase(Locale.getDefault())) {
 
             output.append(Constants.MAGIC_CHAR)
 


### PR DESCRIPTION
This PR resolves/suppresses all warnings for all modules and then enables all warnings as errors as the default for this project (a27076dad1c437d27e2dbfd5eef68330ea319c26).

-----

Warnings Resolution List:

1. [Resolve kotlin stdlib's to lower case deprecated warnings](https://github.com/wordpress-mobile/AztecEditor-Android/commit/6ba043cf9fdaeb3e61e400fb7c31e1bf3cac5bd1)
2. [Resolve parameter is never and could be renamed to _ warnings](https://github.com/wordpress-mobile/AztecEditor-Android/commit/0e8e308042580f24d9d751cdbbf97e88d3aeef1d)
3. [Resolve variable is never used warning](https://github.com/wordpress-mobile/AztecEditor-Android/commit/811ca5142a5c2fecd8f608f664b89b93f907ee2f)
4. [Resolve type mismatch type warnings](https://github.com/wordpress-mobile/AztecEditor-Android/commit/f0f47f0cc42506e39fa9644584affa2e9362efd8)
5. [Resolve unsafe use of a nullable receiver type warning](https://github.com/wordpress-mobile/AztecEditor-Android/commit/8ce75c252e344801b71fc969251d6fc590c13a4d)
6. [Resolve kotlin stdlib's sum by deprecated warnings](https://github.com/wordpress-mobile/AztecEditor-Android/commit/1e7f4a91ea17344a85c99ca8fb931c8851d407a5)
7. [Resolve name shadowed warning](https://github.com/wordpress-mobile/AztecEditor-Android/commit/96c966864dd93a9bad2dc76e78598853de67dc88)
8. [Resolve parameter supertype naming type warnings](https://github.com/wordpress-mobile/AztecEditor-Android/commit/56892fd9a4bf176dfceaabe76f9c6ee465d3b788)
9. [Resolve non exhaustive when statements when warning](https://github.com/wordpress-mobile/AztecEditor-Android/commit/3c54be7918739a8028203715d271cf3f5b52e30b)
10. [Resolve open has no effect in an object warnings](https://github.com/wordpress-mobile/AztecEditor-Android/commit/6c5296d8d49412d77a99a2143b87ecf41fa09d07)
11. [Resolve type mismatch type warning for app module](https://github.com/wordpress-mobile/AztecEditor-Android/commit/d09302b48be78bb175f813b05bb7dfb2e7c918f4)
12. [Resolve unnecessary safe call type warning for app module](https://github.com/wordpress-mobile/AztecEditor-Android/commit/fcbb63cd4e49e790e1fce45b6ad3c2a5f8fc589f)
13. [Resolve unnecessary safe call type warning for ui tests](https://github.com/wordpress-mobile/AztecEditor-Android/commit/95df07ba93f9a746729492a8820f36a5ad3c8f09)

Warnings Suppression List:

1. [Suppress get color deprecated warning](https://github.com/wordpress-mobile/AztecEditor-Android/commit/c32e3203674c75195a8ae616804068ff379aaf7f)
2. [Suppress variable initializer is redundant warning](https://github.com/wordpress-mobile/AztecEditor-Android/commit/1315ae8ffa784a47ed5749c0aba626b643968d1b)
3. [Suppress android junit4 deprecated warnings for ui tests](https://github.com/wordpress-mobile/AztecEditor-Android/commit/e190bc1f3e850c9f2b08d950eb70b6b1fe04755f)

-----

### Test
1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could quickly smoke test the example `app` and see if it is working as expected.

-----

### Review
@planarvoid and @danilo04 as you were also involved in #982.

-----

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.