### PR TITLE
Update `minSdkVersion` (from `21` to `24`)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
         applicationId "org.wordpress.aztec"
-        minSdkVersion commonMinSdkVersion
-        targetSdkVersion commonTargetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionCode 1
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/drawable/ic_action_redo_selector.xml
+++ b/app/src/main/res/drawable/ic_action_redo_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/ic_action_redo_white_30_24dp" android:state_enabled="false" />
     <item android:drawable="@drawable/ic_action_redo_white_24dp" />

--- a/app/src/main/res/drawable/ic_action_undo_selector.xml
+++ b/app/src/main/res/drawable/ic_action_undo_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/ic_action_undo_white_30_24dp" android:state_enabled="false" />
     <item android:drawable="@drawable/ic_action_undo_white_24dp" />

--- a/app/src/main/res/drawable/media_bar_button_camera_selector.xml
+++ b/app/src/main/res/drawable/media_bar_button_camera_selector.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/media_bar_button_camera_disabled" android:state_enabled="false"/>
     <item android:drawable="@drawable/media_bar_button_camera_highlighted" android:state_focused="true"/>

--- a/app/src/main/res/drawable/media_bar_button_image_multiple_selector.xml
+++ b/app/src/main/res/drawable/media_bar_button_image_multiple_selector.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/media_bar_button_image_multiple_disabled" android:state_enabled="false"/>
     <item android:drawable="@drawable/media_bar_button_image_multiple_highlighted" android:state_focused="true"/>

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion commonMinSdkVersion
-        targetSdkVersion commonTargetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1822,7 +1822,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             // Android 7 Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/10872
             // Android 8 Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/8827
             clipboardIdentifier -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < Build.VERSION_CODES.P
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P
                         && Build.MANUFACTURER.lowercase(Locale.getDefault()).equals("samsung")) {
                     // Nope return true
                     Toast.makeText(context, context.getString(R.string.samsung_disabled_custom_clipboard, Build.VERSION.RELEASE), Toast.LENGTH_LONG).show()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -1108,6 +1108,7 @@ class BlockFormatter(editor: AztecText,
                 }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun containsPreformat(selStart: Int = selectionStart, selEnd: Int = selectionEnd): Boolean {
         val lines = TextUtils.split(editableText.toString(), "\n")
         val list = ArrayList<Int>()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/ColorConverter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/ColorConverter.kt
@@ -2,7 +2,6 @@ package org.wordpress.aztec.util
 
 import android.content.res.Resources
 import android.graphics.Color
-import android.os.Build
 import android.text.TextUtils
 import androidx.annotation.ColorInt
 import org.wordpress.aztec.util.ColorConverter.Companion.COLOR_NOT_FOUND
@@ -209,7 +208,6 @@ class ColorConverter {
          * cannot be translated.
          */
         @ColorInt
-        @Suppress("DEPRECATION")
         fun getColorInt(colorText: String): Int {
             try {
                 if (isColorResource(colorText)) {
@@ -217,11 +215,7 @@ class ColorConverter {
                     val name = colorText.substring(1)
                     val colorRes = res.getIdentifier(name, "color", "android")
                     if (colorRes != 0) {
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                            return res.getColor(colorRes)
-                        } else {
-                            return res.getColor(colorRes, null)
-                        }
+                        return res.getColor(colorRes, null)
                     }
                 }
                 //

--- a/aztec/src/main/res/drawable/format_bar_button_align_center_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_align_center_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_align_center_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_align_center_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_align_left_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_align_left_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_align_left_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_align_left_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_align_right_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_align_right_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_align_right_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_align_right_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_bold_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_bold_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_bold_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_bold_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_code_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_code_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_code_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_code_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_ellipsis_horizontal_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ellipsis_horizontal_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_ellipsis_horizontal_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_ellipsis_horizontal" />

--- a/aztec/src/main/res/drawable/format_bar_button_ellipsis_vertical_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ellipsis_vertical_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_ellipsis_vertical_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_ellipsis_vertical" />

--- a/aztec/src/main/res/drawable/format_bar_button_heading_1_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_1_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_heading_1_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_heading_1_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_heading_2_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_2_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_heading_2_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_heading_2_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_heading_3_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_3_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_heading_3_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_heading_3_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_heading_4_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_4_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_heading_4_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_heading_4_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_heading_5_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_5_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_heading_5_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_heading_5_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_heading_6_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_6_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_heading_6_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_heading_6_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_heading_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_heading_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_heading_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_heading_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_highlight_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_highlight_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_highlight_disabled_with_background" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_highlight_highlighted_with_background" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_horizontal_rule_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_horizontal_rule_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_horizontal_rule_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_horizontal_rule_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_html_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_html_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_html_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_html_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_indent_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_indent_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_indent_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_indent_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_italic_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_italic_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_italic_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_italic_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_link_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_link_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_link_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_link_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_media_collapsed_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_collapsed_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_media_collapsed_disabled" android:state_enabled="false"/>
     <item android:drawable="@drawable/format_bar_button_media_collapsed_highlighted" android:state_focused="true"/>

--- a/aztec/src/main/res/drawable/format_bar_button_media_expanded_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_expanded_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_media_expanded_disabled" android:state_enabled="false"/>
     <item android:drawable="@drawable/format_bar_button_media_expanded_highlighted" android:state_focused="true"/>

--- a/aztec/src/main/res/drawable/format_bar_button_ol_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ol_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_ol_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_outdent_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_outdent_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_outdent_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_outdent_highlighted" android:state_focused="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_pre_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_pre_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_pre_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_pre_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_quote_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_quote_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_quote_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_quote_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_strikethrough_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_strikethrough_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_tasklist_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_tasklist_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_tasklist_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_tasklist_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_ul_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ul_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_ul_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/drawable/format_bar_button_underline_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_underline_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_underline_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_underline_highlighted" android:state_checked="true" />

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -13,7 +13,7 @@
     </style>
 
     <style name="ToolbarLayoutDirection">
-        <item name="android:layoutDirection" tools:targetApi="jelly_bean_mr1">ltr</item>
+        <item name="android:layoutDirection">ltr</item>
     </style>
 
     <style name="DividerVertical">

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -7,7 +7,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.TestUtils.safeAppend
 import org.wordpress.aztec.TestUtils.safeLength
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
@@ -16,7 +15,6 @@ import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
  * Testing attribute preservation for supported HTML elements
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class AttributeTest {
     companion object {
         private val HEADING =

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -13,13 +13,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 
 /**
  * Tests for [AztecParser].
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [23])
 class AztecParserTest(alignmentRendering: AlignmentRendering) : AndroidTestCase() {
     private var mParser = AztecParser(alignmentRendering)
     private val HTML_BOLD = "<b>Bold</b><br><br>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -433,6 +433,16 @@ class AztecToolbarTest {
         italicButton.performClick()
         Assert.assertTrue(boldButton.isChecked)
         editText.append("bolditalic")
+        /**
+         * <strong>
+         *     bold
+         * </strong>
+         * <strong>
+         *     <em>
+         *         bolditalic
+         *     </em>
+         * </strong>
+         */
         Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong>", editText.toHtml())
         boldButton.performClick()
         Assert.assertFalse(boldButton.isChecked)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -437,13 +437,13 @@ class AztecToolbarTest {
          * <strong>
          *     bold
          * </strong>
-         * <strong>
-         *     <em>
+         * <em>
+         *     <strong>
          *         bolditalic
-         *     </em>
-         * </strong>
+         *     </strong>
+         * </em>
          */
-        Assert.assertEquals("<strong>bold</strong><strong><em>bolditalic</em></strong>", editText.toHtml())
+        Assert.assertEquals("<strong>bold</strong><em><strong>bolditalic</strong></em>", editText.toHtml())
         boldButton.performClick()
         Assert.assertFalse(boldButton.isChecked)
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 
@@ -16,7 +15,6 @@ import org.wordpress.aztec.toolbar.AztecToolbar
  * Combined test for toolbar and inline styles.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class AztecToolbarTest {
     lateinit var editText: AztecText
     lateinit var sourceText: SourceViewEditText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
@@ -7,7 +7,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.Robolectric
-import org.robolectric.annotation.Config
 
 import org.wordpress.aztec.TestUtils.backspaceAt
 import org.wordpress.aztec.TestUtils.safeAppend
@@ -18,7 +17,6 @@ import org.wordpress.aztec.TestUtils.safeLength
  * Testing interactions of multiple block elements
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [23])
 class BlockElementsTest(val alignmentRendering: AlignmentRendering) {
     lateinit var editText: AztecText
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
@@ -12,11 +12,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class CalypsoFormattingTest : AndroidTestCase() {
     private var parser = AztecParser(AlignmentRendering.SPAN_LEVEL)
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -10,11 +10,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class ClipboardTest {
     private val HEADING =
             "<h1>Heading 1</h1>" +

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecStyleBoldSpan
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(21, 25))
+@Config(sdk = [24, 25])
 class CssStyleAttributeTest : AndroidTestCase() {
 
     private val EMPTY_STYLE_HTML = "<b>bold</b>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssUnderlinePluginTest.kt
@@ -7,7 +7,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.plugins.CssUnderlinePlugin
 import org.wordpress.aztec.source.CssStyleFormatter
 import org.wordpress.aztec.spans.AztecUnderlineSpan
@@ -16,7 +15,6 @@ import org.wordpress.aztec.spans.AztecUnderlineSpan
  * Combined test for toolbar and inline styles.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class CssUnderlinePluginTest {
     lateinit var editText: AztecText
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
@@ -10,7 +10,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.TestUtils.safeAppend
 import org.wordpress.aztec.TestUtils.safeLength
 import org.wordpress.aztec.source.SourceViewEditText
@@ -20,7 +19,6 @@ import org.wordpress.aztec.toolbar.AztecToolbar
  * Testing heading behaviour.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class HeadingTest {
     lateinit var editText: AztecText
     lateinit var sourceText: SourceViewEditText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
@@ -29,7 +29,7 @@ import org.wordpress.aztec.spans.IAztecAttributedSpan
  * Also tests invalid html style attribute color properties.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(21, 25))
+@Config(sdk = [24, 25])
 class HtmlAttributeStyleColorTest : AndroidTestCase() {
 
     private val HTML_BOLD_STYLE_COLOR = "<b style=\"color:blue;\">Blue</b>"

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -11,11 +11,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class HtmlFormattingTest : AndroidTestCase() {
 
     private var parser = AztecParser(AlignmentRendering.SPAN_LEVEL)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
@@ -9,12 +9,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class ImageBlockTest {
     lateinit var editText: AztecText
     lateinit var menuList: PopupMenu

--- a/aztec/src/test/kotlin/org/wordpress/aztec/IndentTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/IndentTest.kt
@@ -7,12 +7,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class IndentTest {
     lateinit var editText: AztecText
     lateinit var sourceText: SourceViewEditText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/InlineElementsTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/InlineElementsTest.kt
@@ -7,14 +7,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.spans.AztecCodeSpan
 import org.wordpress.aztec.spans.AztecStyleStrongSpan
 import org.wordpress.aztec.spans.AztecURLSpan
 import org.wordpress.aztec.spans.IAztecInlineSpan
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class InlineElementsTest {
 
     lateinit var editText: AztecText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
@@ -7,10 +7,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class LinkTest {
 
     lateinit var editText: AztecText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
@@ -49,6 +49,25 @@ class LinkTest {
         editText.setSelection(4)
         editText.link("http://wordpress.com", "WordPress")
         // Still valid, but order of b and del is switched here for some reason.
+        /**
+         * <b>
+         *     <s>
+         *         left
+         *     </s>
+         * </b>
+         * <b>
+         *     <s>
+         *         <a href="http://wordpress.com">
+         *             WordPress
+         *         </a>
+         *     </s>
+         * </b>
+         * <s>
+         *     <i>
+         *         right
+         *     </i>
+         * </s>
+         */
         Assert.assertEquals("<b><s>left</s></b><b><s><a href=\"http://wordpress.com\">WordPress</a></s></b><s><i>right</i></s>", editText.toHtml())
     }
 
@@ -160,6 +179,16 @@ class LinkTest {
         editText.setSelection(0, editText.length())
 
         editText.link("http://automattic.com", editText.getSelectedText())
+        /**
+         * <a href="http://automattic.com">
+         *     FirstUrl Hello
+         * </a>
+         * <a href="http://automattic.com">
+         *     <b>
+         *         SecondUrl
+         *     </b>
+         * </a>
+         */
         Assert.assertEquals("<a href=\"http://automattic.com\">FirstUrl Hello </a>" +
                 "<a href=\"http://automattic.com\"><b>SecondUrl</b></a>", editText.toHtml())
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
@@ -55,20 +55,20 @@ class LinkTest {
          *         left
          *     </s>
          * </b>
-         * <b>
-         *     <s>
-         *         <a href="http://wordpress.com">
+         * <a href="http://wordpress.com">
+         *     <b>
+         *         <s>
          *             WordPress
-         *         </a>
-         *     </s>
-         * </b>
-         * <s>
-         *     <i>
+         *         </s>
+         *     </b>
+         * </a>
+         * <i>
+         *     <s>
          *         right
-         *     </i>
-         * </s>
+         *     </s>
+         * </i>
          */
-        Assert.assertEquals("<b><s>left</s></b><b><s><a href=\"http://wordpress.com\">WordPress</a></s></b><s><i>right</i></s>", editText.toHtml())
+        Assert.assertEquals("<b><s>left</s></b><a href=\"http://wordpress.com\"><b><s>WordPress</s></b></a><i><s>right</s></i>", editText.toHtml())
     }
 
     @Test
@@ -183,14 +183,14 @@ class LinkTest {
          * <a href="http://automattic.com">
          *     FirstUrl Hello
          * </a>
-         * <a href="http://automattic.com">
-         *     <b>
+         * <b>
+         *     <a href="http://automattic.com">
          *         SecondUrl
-         *     </b>
-         * </a>
+         *     </a>
+         * </b>
          */
-        Assert.assertEquals("<a href=\"http://automattic.com\">FirstUrl Hello </a>" +
-                "<a href=\"http://automattic.com\"><b>SecondUrl</b></a>", editText.toHtml())
+        Assert.assertEquals("<a href=\"http://automattic.com\">FirstUrl Hello </a><b>" +
+                "<a href=\"http://automattic.com\">SecondUrl</a></b>", editText.toHtml())
     }
 
     @Test

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ListIndentTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ListIndentTest.kt
@@ -9,7 +9,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.Robolectric
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 
@@ -19,7 +18,6 @@ import org.wordpress.aztec.toolbar.AztecToolbar
  * This test uses ParameterizedRobolectricTestRunner and runs twice - for ol and ul tags.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [23])
 class ListIndentTest(listTextFormat: ITextFormat, listHtmlTag: String) {
 
     val listType = listTextFormat

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ListTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ListTest.kt
@@ -9,7 +9,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.Robolectric
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
@@ -20,7 +19,6 @@ import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
  * This test uses ParameterizedRobolectricTestRunner and runs twice - for ol and ul tags.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [23])
 class ListTest(listTextFormat: ITextFormat, listHtmlTag: String) {
 
     val listType = listTextFormat

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ListToggleTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ListToggleTest.kt
@@ -9,7 +9,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 
@@ -19,7 +18,6 @@ import org.wordpress.aztec.toolbar.AztecToolbar
  * This test uses ParameterizedRobolectricTestRunner and runs twice - for ol and ul tags.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class ListToggleTest {
 
     lateinit var editText: AztecText

--- a/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.view.MenuItem
 import android.widget.PopupMenu
 import android.widget.ToggleButton
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
@@ -5,7 +5,6 @@ package org.wordpress.aztec
 // * Testing preformat behavior.
 // */
 //@RunWith(RobolectricTestRunner::class)
-//@Config(sdk = [23])
 //class PreformatTest {
 //    val tag = "pre"
 //

--- a/aztec/src/test/kotlin/org/wordpress/aztec/QuoteTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/QuoteTest.kt
@@ -7,7 +7,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.TestUtils.safeAppend
 import org.wordpress.aztec.TestUtils.safeEmpty
 import org.wordpress.aztec.TestUtils.safeLength
@@ -17,7 +16,6 @@ import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
  * Testing quote behaviour.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class QuoteTest {
 
     val formattingType = AztecTextFormat.FORMAT_QUOTE

--- a/aztec/src/test/kotlin/org/wordpress/aztec/TaskListTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/TaskListTest.kt
@@ -9,7 +9,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.Robolectric
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
@@ -20,7 +19,6 @@ import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder
  * This test uses ParameterizedRobolectricTestRunner and runs twice - for ol and ul tags.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [23])
 class TaskListTest(listTextFormat: ITextFormat, listHtmlTag: String) {
 
     val listType = listTextFormat

--- a/aztec/src/test/kotlin/org/wordpress/aztec/util/ColorConverterTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/util/ColorConverterTest.kt
@@ -4,13 +4,11 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Tests for translating various strings to colors using [ColorConverter].
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class ColorConverterTest {
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ subprojects {
 }
 
 ext {
-    minSdkVersion = 21
+    minSdkVersion = 24
     compileSdkVersion = 28
     targetSdkVersion = 31
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ subprojects {
 }
 
 ext {
+    minSdkVersion = 21
+    compileSdkVersion = 28
+    targetSdkVersion = 31
+}
+
+ext {
     gradlePluginVersion = '3.3.1'
     kotlinCoroutinesVersion = '1.1.0'
     tagSoupVersion = '1.2.1'
@@ -73,8 +79,6 @@ ext {
     jSoupVersion = '1.11.3'
     wordpressUtilsVersion = 'trunk-1ed207c03d2242b6fc3d74f9e388e9163cbc82a6'
     espressoVersion = '3.0.1'
-    commonTargetSdkVersion = 31
-    commonMinSdkVersion = 21
 
     aztecProjectDependency = project.hasProperty("aztecVersion") ? "org.wordpress:aztec:${project.getProperty("aztecVersion")}" : project(":aztec")
 }

--- a/glide-loader/build.gradle
+++ b/glide-loader/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion commonMinSdkVersion
-        targetSdkVersion commonTargetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 28
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion commonMinSdkVersion
-        targetSdkVersion commonTargetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionName "1.0"
     }
 

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion commonMinSdkVersion
-        targetSdkVersion commonTargetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion commonMinSdkVersion
-        targetSdkVersion commonTargetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true
     }

--- a/wordpress-comments/src/main/res/drawable/format_bar_button_more_selector.xml
+++ b/wordpress-comments/src/main/res/drawable/format_bar_button_more_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_more_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_more_highlighted" android:state_focused="true" />

--- a/wordpress-comments/src/main/res/drawable/format_bar_button_page_selector.xml
+++ b/wordpress-comments/src/main/res/drawable/format_bar_button_page_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:targetApi="lollipop">
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/format_bar_button_page_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_page_highlighted" android:state_focused="true" />

--- a/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
+++ b/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/CommentsToolbarTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.ITextFormat
@@ -24,7 +23,6 @@ import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
  * Combined test for toolbar and inline styles.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23])
 class CommentsToolbarTest {
 
     lateinit var editText: AztecText

--- a/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/WordPressCommentTest.kt
+++ b/wordpress-comments/src/test/java/org/wordpress/aztec/plugins/WordPressCommentTest.kt
@@ -24,7 +24,7 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
  * Tests for special comments ([WordPressCommentSpan.Comment.MORE] and [WordPressCommentSpan.Comment.PAGE])
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(25))
+@Config(sdk = [25])
 class WordPressCommentTest {
     lateinit var editText: AztecText
 

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion commonMinSdkVersion
-        targetSdkVersion commonTargetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionName "1.0"
     }
 

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/AudioShortcodeTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.aztec.plugins.shortcodes.TestUtils.safeEmpty
  * Tests for the audio shortcode plugin
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(25))
+@Config(sdk = [25])
 class AudioShortcodeTest {
     lateinit var editText: AztecText
 

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/ImageCaptionTest.kt
@@ -25,7 +25,7 @@ import org.xml.sax.Attributes
  * Tests for the caption shortcode plugin
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(25))
+@Config(sdk = [25])
 class ImageCaptionTest {
     lateinit var editText: AztecText
 

--- a/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
+++ b/wordpress-shortcodes/src/test/java/org/wordpress/aztec/plugins/shortcodes/VideoShortcodeTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.aztec.plugins.shortcodes.TestUtils.safeEmpty
  * Tests for the video shortcode plugin
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = intArrayOf(25))
+@Config(sdk = [25])
 class VideoShortcodeTest {
     lateinit var editText: AztecText
 


### PR DESCRIPTION
This PR upgrades FluxC to `minSdkVersion` to `24`. This has been unblocked because:

- `WPAndroid` was already on `minSdkVersion = 24`, for some time now (see [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15135)).
- `DOAndroid` has been recently upgraded to `minSdkVersion = 24` as well ([here](https://github.com/bloom/DayOne-Android/pull/1628) and [commit](https://github.com/bloom/DayOne-Android/pull/1628/commits/928215f702b281b356a4de1caf440d1355c07ecc)).

-----

As part of this `minSdkVersion = 24` upgrade the below changes were also applied in order to fix any additional warnings that this change brought-up:

Warnings Resolution List:

1. [Resolve obsolete sdk int lint warnings.](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1017/commits/de2dba275f172dd655d5843f9ba77464e6af3f92)
2. [Resolve obsolete sdk int lint warnings for all xml files.](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1017/commits/29e499974e6e2c450112ce3dd74c86b033e78cd6)

Test List:

1. [Resolve robolectric package parser exception due to config sdk 23.](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1017/commits/bbdd329fc68dbe965f8b10aeb1ebdcc629e7c227)
3. [Document test failures due to expected actual assertion mismatch.](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1017/commits/39fdd732da69d1860752273c449e8a897bcc193e)
4. [Fix edit text to html related test failures.](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1017/commits/9655577afd909ab357a4658a6ea69a36b60e2cf1)

-----

Warning (⚠️): Please be very mindful of [this fix test failures](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1017/commits/9655577afd909ab357a4658a6ea69a36b60e2cf1) change and verify that this is not a breaking change of some sorts. See commit description for more info.

-----

### Test

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could:
    1. Quickly smoke test the example `app` and see if it is working as expected.
    2. Perform a quick check in [gutenberg](https://github.com/WordPress/gutenberg) using this PR as a double-check. Cc @fluiddot 

-----

### Review

@fluiddot as per the discussion on updating and testing [gutenberg](https://github.com/WordPress/gutenberg) as well, this might be a good opportunity for you see what's coming to `Aztec`. As such, it might be good if we merge this change along with merging the equivalent `minSdkVersion = 24` upgrade on [gutenberg](https://github.com/WordPress/gutenberg), that is, when that gets ready by you. PS: there is no time pressure here.

PS: Also, and based on [this comment](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1016#issuecomment-1319756975) of yours, it might be better for your to perform a quick check in [gutenberg](https://github.com/WordPress/gutenberg) using this PR instead, and not #1016 in order to save yourself some time, as this one includes that in it as well.

-----

### Merge instructions

- [x] Wait for #1016 to be approved and merged to `trunk`.
- [x] Make sure this PR's base is automatically updated to `trunk`.
- [x] Update PR with latest `trunk`.
- [x] Wait for confirmation from @fluiddot that this PR is fully tested with [gutenberg](https://github.com/WordPress/gutenberg) and can be merged.
- [x] Remove `[PR] Not Ready For Merge]` label.
- [x] Merge PR to `trunk`.

-----

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.