### PR TITLE
[Build] Resolve Post Merge Warnings

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -1108,6 +1108,7 @@ class BlockFormatter(editor: AztecText,
                 }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun containsPreformat(selStart: Int = selectionStart, selEnd: Int = selectionEnd): Boolean {
         val lines = TextUtils.split(editableText.toString(), "\n")
         val list = ArrayList<Int>()

--- a/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/PreformatTest.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.view.MenuItem
 import android.widget.PopupMenu
 import android.widget.ToggleButton
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
👋 @planarvoid @khaykov !

FYI: This #994 PR that got merged 21 hours ago added two new warnings that are now failing the build. This is due to the newly introduced `allWarningsAsErrors = true` configuration.

As such, this simple fix PR resolves/suppresses there two warnings to make it possible for the `assemble` and `testUnitTest` task to be successful again.