### PR TITLE
Fix issue when adding an image on a blank line after a paragraph

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -247,8 +247,12 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
                     }
                 }
         if (position <= 0 && selectionEnd != 0) {
-            // If the text contains "\n" return that as the position, else set the position to the end of the text
-            position = editableText.indexOf("\n", selectionEnd).takeIf { it >= 0 } ?: editableText.length
+            position = if (editableText[selectionEnd - 1] == '\n') {
+                selectionEnd
+            } else {
+                // If the text contains "\n" return that as the position, else set the position to the end of the text
+                editableText.indexOf("\n", selectionEnd).takeIf { it >= 0 } ?: editableText.length
+            }
         }
         return position
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
@@ -198,4 +198,17 @@ class ImageBlockTest {
 
         Assert.assertEquals("Test 1<br>test 2<img id=\"1234\" /><br>test 3", editText.toHtml())
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun addImageInTheMiddleOfParagraphsWhenNoBlocksPresent() {
+        editText.fromHtml("<p>Line 1</p><p>Line 2</p><p>Line 3</p>")
+
+        editText.setSelection(editText.editableText.indexOf("1") + 2)
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("<p>Line 1</p><img id=\"1234\" /><p>Line 2</p><p>Line 3</p>", editText.toHtml())
+    }
 }


### PR DESCRIPTION
### Fix
The issue fixed here is:
- turn the `addMediaAfterBlocks` on the visual editor
- Make sure you have 3 paragraphs (for example `<p>Line 1</p><p>Line 2</p><p>Line 3</p>`
- Click at the end of "Line 1"
- Add a new line ("enter")
- Add an image (or a placeholder)
- Notice it gets actually added after the "Line 2" instead of "Line 1"

The reason for this was that when the cursor is in a paragraph block, it's trying to add the image at the next line break. However, if it's on a line break, it should use that instead of looking for the next one after the current cursor position.
 
### Test (or test it with the linked PR)
1. turn the `addMediaAfterBlocks` on the visual editor
2. Make sure you have 3 paragraphs (for example `<p>Line 1</p><p>Line 2</p><p>Line 3</p>`
3. Click at the end of "Line 1"
4. Add a new line ("enter")
5. Add an image (or a placeholder)
6. Notice it gets added after "Line 1"

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.