### PR TITLE
Limit predictive text override to Samsung keyboard

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -33,6 +33,7 @@ import android.os.Bundle
 import android.os.Looper
 import android.os.Parcel
 import android.os.Parcelable
+import android.provider.Settings
 import android.text.Editable
 import android.text.InputFilter
 import android.text.Spannable
@@ -659,13 +660,18 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
         val baseInputConnection = requireNotNull(super.onCreateInputConnection(outAttrs))
-        return if (Build.MANUFACTURER.lowercase(Locale.US) == "samsung" && Build.VERSION.SDK_INT == 33
-                && overrideSamsungPredictiveBehavior) {
-            AppLog.d(AppLog.T.EDITOR, "Overriding predictive text behavior on Samsung device with API 33")
+        return if (shouldOverridePredictiveTextBehavior()) {
+            AppLog.d(AppLog.T.EDITOR, "Overriding predictive text behavior on Samsung device with Samsung Keyboard with API 33")
             SamsungInputConnection(this, baseInputConnection)
         } else {
             baseInputConnection
         }
+    }
+
+    private fun shouldOverridePredictiveTextBehavior(): Boolean {
+        val currentKeyboard = Settings.Secure.getString(context.contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        return Build.MANUFACTURER.lowercase(Locale.US) == "samsung" && Build.VERSION.SDK_INT >= 33 &&
+                (currentKeyboard !== null && currentKeyboard.startsWith("com.samsung.android.honeyboard")) && overrideSamsungPredictiveBehavior
     }
 
     // Setup the keyListener(s) for Backspace and Enter key.


### PR DESCRIPTION
This PR restricts the fix introduced in #1024 to Samsung keyboards only. Since other keyboards actually work ok, this fix can limit their functionality.

I also changed the API level fix targeting to an open ended `>= 33` since we do not know when or if it's going to be fixed.

### Test (Using Samsung device running Android 13)
1. Make sure default Samsung keyboard is installed on your device.
2. Open the demo app and tap in the editor (this will initialize the Input Connection between keyboard and editor).
3. Check logcat and confirm that you see the `Overriding predictive text behavior on Samsung device with Samsung 
Keyboard with API 33` message.
4. Install any other keyboard (eg. Gboard, Swift Keyboard)
5. Open tap app and tap in the editor.
6. Confirm that the log message from step 3 is not visible.

Voila.