### PR TITLE
Placeholder doesn't have correct proportions when drawing the first time

### DIFF
--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -318,7 +318,12 @@ class PlaceholderManager(
                 spans.forEach {
                     val type = it.attributes.getValue(TYPE_ATTRIBUTE)
                     val adapter = adapters[type] ?: return@forEach
+                    val start = aztecText.editableText.getSpanStart(it)
+                    val end = aztecText.editableText.getSpanEnd(it)
+                    val flags = aztecText.editableText.getSpanFlags(it)
+                    aztecText.editableText.removeSpan(it)
                     updateDrawableBounds(adapter, it.attributes, it.drawable)
+                    aztecText.editableText.setSpan(it, start, end, flags)
                     aztecText.refreshText(false)
                     insertInPosition(it.attributes, aztecText.editableText.getSpanStart(it))
                 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -322,7 +322,7 @@ class PlaceholderManager(
                     val end = aztecText.editableText.getSpanEnd(it)
                     val flags = aztecText.editableText.getSpanFlags(it)
                     aztecText.editableText.removeSpan(it)
-                    updateDrawableBounds(adapter, it.attributes, it.drawable)
+                    it.drawable = buildPlaceholderDrawable(adapter, it.attributes)
                     aztecText.editableText.setSpan(it, start, end, flags)
                     aztecText.refreshText(false)
                     insertInPosition(it.attributes, aztecText.editableText.getSpanStart(it))

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -7,7 +7,6 @@ import android.graphics.drawable.Drawable
 import android.text.Editable
 import android.text.Layout
 import android.text.Spanned
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewTreeObserver
@@ -111,7 +110,10 @@ class PlaceholderManager(
 
     private suspend fun buildPlaceholderDrawable(adapter: PlaceholderAdapter, attrs: AztecAttributes): Drawable {
         val drawable = ContextCompat.getDrawable(aztecText.context, android.R.color.transparent)!!
-        updateDrawableBounds(adapter, attrs, drawable)
+        val editorWidth = if (aztecText.width > 0) {
+            aztecText.width - aztecText.paddingStart - aztecText.paddingEnd
+        } else aztecText.maxImagesWidth
+        drawable.setBounds(0, 0, adapter.calculateWidth(attrs, editorWidth), adapter.calculateHeight(attrs, editorWidth))
         return drawable
     }
 
@@ -318,28 +320,11 @@ class PlaceholderManager(
                 spans.forEach {
                     val type = it.attributes.getValue(TYPE_ATTRIBUTE)
                     val adapter = adapters[type] ?: return@forEach
-                    val start = aztecText.editableText.getSpanStart(it)
-                    val end = aztecText.editableText.getSpanEnd(it)
-                    val flags = aztecText.editableText.getSpanFlags(it)
-                    aztecText.editableText.removeSpan(it)
                     it.drawable = buildPlaceholderDrawable(adapter, it.attributes)
-                    aztecText.editableText.setSpan(it, start, end, flags)
                     aztecText.refreshText(false)
                     insertInPosition(it.attributes, aztecText.editableText.getSpanStart(it))
                 }
             }
-        }
-    }
-
-    private suspend fun updateDrawableBounds(adapter: PlaceholderAdapter, attrs: AztecAttributes, drawable: Drawable?) {
-        val editorWidth = if (aztecText.width > 0) {
-            aztecText.width - aztecText.paddingStart - aztecText.paddingEnd
-        } else aztecText.maxImagesWidth
-        Log.d(TAG, "Updating drawable bounds - editor width: $editorWidth")
-        if (drawable?.bounds?.right != editorWidth) {
-            Log.d(TAG, "Bounds before - right - ${drawable?.bounds?.right} - bottom - ${drawable?.bounds?.bottom}")
-            drawable?.setBounds(0, 0, adapter.calculateWidth(attrs, editorWidth), adapter.calculateHeight(attrs, editorWidth))
-            Log.d(TAG, "Bounds after - right - ${drawable?.bounds?.right} - bottom - ${drawable?.bounds?.bottom}")
         }
     }
 

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -161,7 +161,7 @@ class PlaceholderManager(
         val parentTextViewTopAndBottomOffset = aztecText.scrollY + aztecText.compoundPaddingTop
 
         val adapter = adapters[type]!!
-        val windowWidth = parentTextViewRect.right - parentTextViewRect.left - 20
+        val windowWidth = parentTextViewRect.right - parentTextViewRect.left - EDITOR_INNER_PADDING
         val height = adapter.calculateHeight(attrs, windowWidth)
         parentTextViewRect.top += parentTextViewTopAndBottomOffset
         parentTextViewRect.bottom = parentTextViewRect.top + height
@@ -176,8 +176,8 @@ class PlaceholderManager(
             box = adapter.createView(container.context, uuid, attrs)
         }
         val params = FrameLayout.LayoutParams(
-                adapter.calculateWidth(attrs, windowWidth) - 20,
-                height - 20
+                adapter.calculateWidth(attrs, windowWidth) - EDITOR_INNER_PADDING,
+                height - EDITOR_INNER_PADDING
         )
         val padding = 10
         params.setMargins(
@@ -326,7 +326,9 @@ class PlaceholderManager(
     }
 
     private suspend fun updateDrawableBounds(adapter: PlaceholderAdapter, attrs: AztecAttributes, drawable: Drawable?) {
-        val editorWidth = if (aztecText.width > 0) aztecText.width else aztecText.maxImagesWidth
+        val editorWidth = if (aztecText.width > 0) {
+            aztecText.width - aztecText.paddingStart - aztecText.paddingEnd - EDITOR_INNER_PADDING
+        } else aztecText.maxImagesWidth
         if (drawable?.bounds?.right != editorWidth) {
             drawable?.setBounds(0, 0, adapter.calculateWidth(attrs, editorWidth), adapter.calculateHeight(attrs, editorWidth))
         }
@@ -466,5 +468,6 @@ class PlaceholderManager(
         private const val DEFAULT_HTML_TAG = "placeholder"
         private const val UUID_ATTRIBUTE = "uuid"
         private const val TYPE_ATTRIBUTE = "type"
+        private const val EDITOR_INNER_PADDING = 20
     }
 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -7,6 +7,7 @@ import android.graphics.drawable.Drawable
 import android.text.Editable
 import android.text.Layout
 import android.text.Spanned
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewTreeObserver
@@ -329,8 +330,11 @@ class PlaceholderManager(
         val editorWidth = if (aztecText.width > 0) {
             aztecText.width - aztecText.paddingStart - aztecText.paddingEnd
         } else aztecText.maxImagesWidth
+        Log.d(TAG, "Updating drawable bounds - editor width: $editorWidth")
         if (drawable?.bounds?.right != editorWidth) {
+            Log.d(TAG, "Bounds before - right - ${drawable?.bounds?.right} - bottom - ${drawable?.bounds?.bottom}")
             drawable?.setBounds(0, 0, adapter.calculateWidth(attrs, editorWidth), adapter.calculateHeight(attrs, editorWidth))
+            Log.d(TAG, "Bounds after - right - ${drawable?.bounds?.right} - bottom - ${drawable?.bounds?.bottom}")
         }
     }
 
@@ -465,6 +469,7 @@ class PlaceholderManager(
     data class Placeholder(val elementPosition: Int, val uuid: String)
 
     companion object {
+        private const val TAG = "PlaceholderManager"
         private const val DEFAULT_HTML_TAG = "placeholder"
         private const val UUID_ATTRIBUTE = "uuid"
         private const val TYPE_ATTRIBUTE = "type"

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -327,7 +327,7 @@ class PlaceholderManager(
 
     private suspend fun updateDrawableBounds(adapter: PlaceholderAdapter, attrs: AztecAttributes, drawable: Drawable?) {
         val editorWidth = if (aztecText.width > 0) {
-            aztecText.width - aztecText.paddingStart - aztecText.paddingEnd - EDITOR_INNER_PADDING
+            aztecText.width - aztecText.paddingStart - aztecText.paddingEnd
         } else aztecText.maxImagesWidth
         if (drawable?.bounds?.right != editorWidth) {
             drawable?.setBounds(0, 0, adapter.calculateWidth(attrs, editorWidth), adapter.calculateHeight(attrs, editorWidth))


### PR DESCRIPTION
### Fix
When implementing a placeholder in the Day One repo I've discovered that the width used when building placeholder drawable is incorrect because it doesn't take into account the editor padding and the arbitrary 20 px that's used when drawing placeholders. 

### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.