### PR TITLE
[Docs] Remove Supports Android Info from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 Aztec (which extends EditText) is a rich-text editor component for writing HTML
 documents in Android.
 
+## Minimum Android Supported Version
+
+You can check the minimum Android version supported by looking at the `minSdkVersion` configuration within [build.gradle](https://github.com/wordpress-mobile/AztecEditor-Android/blob/trunk/build.gradle).
+
 <img align="center" width=360px height=640px src="https://github.com/wordpress-mobile/AztecEditor-Android/raw/trunk/visual_editor.png" alt="Visual Editor"/> <img align="center" width=360px height=640px src="https://github.com/wordpress-mobile/AztecEditor-Android/raw/trunk/code_editor.png" alt="Visual Editor"/>
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 Aztec (which extends EditText) is a rich-text editor component for writing HTML
 documents in Android.
 
-Supports Android 4.1+ (API 16 - Jelly Bean)
-
 <img align="center" width=360px height=640px src="https://github.com/wordpress-mobile/AztecEditor-Android/raw/trunk/visual_editor.png" alt="Visual Editor"/> <img align="center" width=360px height=640px src="https://github.com/wordpress-mobile/AztecEditor-Android/raw/trunk/code_editor.png" alt="Visual Editor"/>
 
 ## Getting started


### PR DESCRIPTION
Fixes #1029

With this change the `Supports Android 4.1+ (API 16 - Jelly Bean)` information is removed from the [README.md](https://github.com/wordpress-mobile/AztecEditor-Android#readme) documentation as this information has been outdated for years now and it has the ability to become outdated with every year passing by. Users of this library should refer to the `minSdkVersion` within the root level [build.gradle](https://github.com/wordpress-mobile/AztecEditor-Android/blob/trunk/build.gradle#L66) file to understand what's the latest min SDK version this library supports.