### PR TITLE
Implement merging of placeholders

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2161,6 +2161,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         lineBlockFormatter.insertVideo(shouldAddMediaInline, drawable, attributes, onVideoTappedListener, onMediaDeletedListener)
     }
 
+    fun removeMedia(predicate: (Attributes) -> Boolean) {
+        removeMedia(object : AttributePredicate {
+            override fun matches(attrs: Attributes): Boolean {
+                return predicate(attrs)
+            }
+        })
+    }
+
     fun removeMedia(attributePredicate: AttributePredicate) {
         text.getSpans(0, text.length, AztecMediaSpan::class.java)
                 .filter {
@@ -2198,8 +2206,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         spans.forEach { temporarySpan ->
                             text.setSpan(
                                     temporarySpan.span,
-                                    temporarySpan.start - 2,
-                                    temporarySpan.end - 2,
+                                    (temporarySpan.start - 2).coerceAtLeast(0),
+                                    (temporarySpan.end - 2).coerceAtMost(text.length),
                                     temporarySpan.flags
                             )
                         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2174,14 +2174,15 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 .filter {
                     attributePredicate.matches(it.attributes)
                 }
-                .forEach {
-                    val start = text.getSpanStart(it)
-                    val end = text.getSpanEnd(it)
+                .forEach { mediaSpan ->
+                    mediaSpan.beforeMediaDeleted()
+                    val start = text.getSpanStart(mediaSpan)
+                    val end = text.getSpanEnd(mediaSpan)
 
                     val clickableSpan = text.getSpans(start, end, AztecMediaClickableSpan::class.java).firstOrNull()
 
                     text.removeSpan(clickableSpan)
-                    text.removeSpan(it)
+                    text.removeSpan(mediaSpan)
                     val endPlus1 = (end + 1).coerceAtMost(text.length - 1)
                     if (text.length > end + 2 && text[end] == '\n') {
                         data class TemporarySpan(
@@ -2214,6 +2215,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     } else {
                         text.delete(start, end)
                     }
+                    mediaSpan.onMediaDeleted()
                 }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2161,15 +2161,18 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         lineBlockFormatter.insertVideo(shouldAddMediaInline, drawable, attributes, onVideoTappedListener, onMediaDeletedListener)
     }
 
-    fun removeMedia(predicate: (Attributes) -> Boolean) {
+    fun removeMedia(notifyContentChange: Boolean = true, predicate: (Attributes) -> Boolean) {
         removeMedia(object : AttributePredicate {
             override fun matches(attrs: Attributes): Boolean {
                 return predicate(attrs)
             }
-        })
+        }, notifyContentChange)
     }
 
-    fun removeMedia(attributePredicate: AttributePredicate) {
+    fun removeMedia(attributePredicate: AttributePredicate, notifyContentChange: Boolean = true) {
+        if (!notifyContentChange) {
+            disableTextChangedListener()
+        }
         text.getSpans(0, text.length, AztecMediaSpan::class.java)
                 .filter {
                     attributePredicate.matches(it.attributes)
@@ -2217,6 +2220,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     }
                     mediaSpan.onMediaDeleted()
                 }
+        if (!notifyContentChange) {
+            enableTextChangedListener()
+        }
     }
 
     interface AttributePredicate {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2174,8 +2174,38 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
                     text.removeSpan(clickableSpan)
                     text.removeSpan(it)
+                    val endPlus1 = (end + 1).coerceAtMost(text.length - 1)
+                    if (text.length > end + 2 && text[end] == '\n') {
+                        data class TemporarySpan(
+                                val span: IAztecBlockSpan,
+                                val start: Int,
+                                val end: Int,
+                                val flags: Int
+                        )
 
-                    text.delete(start, end)
+                        val spans = text.getSpans(end, end + 2, IAztecBlockSpan::class.java).map { blockSpan ->
+                            TemporarySpan(
+                                    blockSpan,
+                                    text.getSpanStart(blockSpan),
+                                    text.getSpanEnd(blockSpan),
+                                    text.getSpanFlags(blockSpan)
+                            )
+                        }
+                        spans.forEach { temporarySpan ->
+                            text.removeSpan(temporarySpan)
+                        }
+                        text.delete(start, endPlus1)
+                        spans.forEach { temporarySpan ->
+                            text.setSpan(
+                                    temporarySpan.span,
+                                    temporarySpan.start - 2,
+                                    temporarySpan.end - 2,
+                                    temporarySpan.flags
+                            )
+                        }
+                    } else {
+                        text.delete(start, end)
+                    }
                 }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -150,6 +150,24 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         }
     }
 
+    fun insertMediaSpanOverCurrentChar(span: AztecMediaSpan, position: Int) {
+        editor.removeInlineStylesFromRange(selectionStart, selectionEnd)
+
+        editor.editableText.setSpan(
+                span,
+                position,
+                position + 1,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+
+        editor.editableText.setSpan(
+                AztecMediaClickableSpan(span),
+                position,
+                position + 1,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+    }
+
     private fun insertMediaInline(span: AztecMediaSpan) {
         editor.removeInlineStylesFromRange(selectionStart, selectionEnd)
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
@@ -11,6 +11,7 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
+import org.xml.sax.Attributes
 
 @RunWith(RobolectricTestRunner::class)
 class ImageBlockTest {
@@ -210,5 +211,71 @@ class ImageBlockTest {
         editText.insertImage(null, attributes)
 
         Assert.assertEquals("<p>Line 1</p><img id=\"1234\" /><p>Line 2</p><p>Line 3</p>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addAndRemoveImage() {
+        val initialHtml = "<p>Line 1</p><p>Line 2</p>"
+        editText.fromHtml(initialHtml)
+
+        editText.setSelection(editText.editableText.indexOf("1") + 2)
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("<p>Line 1</p><img id=\"1234\" /><p>Line 2</p>", editText.toHtml())
+
+        editText.removeMedia(object : AztecText.AttributePredicate {
+            override fun matches(attrs: Attributes): Boolean {
+                return attrs.getValue("id") == "1234"
+            }
+        })
+
+        Assert.assertEquals(initialHtml, editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addAndRemoveImageAtTheBeginning() {
+        val initialHtml = "Line 1"
+        editText.fromHtml(initialHtml)
+
+        editText.setSelection(0)
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("<img id=\"1234\" />Line 1", editText.toHtml())
+
+        editText.removeMedia(object : AztecText.AttributePredicate {
+            override fun matches(attrs: Attributes): Boolean {
+                return attrs.getValue("id") == "1234"
+            }
+        })
+
+        Assert.assertEquals(initialHtml, editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addAndRemoveImageAtTheBeginningOfPlaceholder() {
+        val initialHtml = "<p>Line 1</p>"
+        editText.fromHtml(initialHtml)
+
+        editText.setSelection(0)
+        val attributes = AztecAttributes()
+        attributes.setValue("id", "1234")
+        editText.insertImage(null, attributes)
+
+        Assert.assertEquals("<img id=\"1234\" /><p>Line 1</p>", editText.toHtml())
+
+        editText.removeMedia(object : AztecText.AttributePredicate {
+            override fun matches(attrs: Attributes): Boolean {
+                return attrs.getValue("id") == "1234"
+            }
+        })
+
+        Assert.assertEquals(initialHtml, editText.toHtml())
     }
 }

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     testImplementation "junit:junit:$jUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }
 
 project.afterEvaluate {

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
@@ -82,12 +82,17 @@ class ImageWithCaptionAdapter(
         private const val SRC_ATTRIBUTE = "src"
 
         suspend fun insertImageWithCaption(placeholderManager: PlaceholderManager, src: String, caption: String) {
-            placeholderManager.insertOrUpdateItem(ADAPTER_TYPE) { currentAttributes, type ->
+            placeholderManager.insertOrUpdateItem(ADAPTER_TYPE) { currentAttributes, type, placeAtStart ->
                 if (currentAttributes == null || type != ADAPTER_TYPE) {
                     mapOf(SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to caption)
                 } else {
                     val currentCaption = currentAttributes[CAPTION_ATTRIBUTE]
-                    mapOf(SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to "$caption - $currentCaption")
+                    val newCaption = if (placeAtStart) {
+                        "$caption - $currentCaption"
+                    } else {
+                        "$currentCaption - $caption"
+                    }
+                    mapOf(SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to newCaption)
                 }
             }
         }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
@@ -82,7 +82,15 @@ class ImageWithCaptionAdapter(
         private const val SRC_ATTRIBUTE = "src"
 
         suspend fun insertImageWithCaption(placeholderManager: PlaceholderManager, src: String, caption: String) {
-            placeholderManager.insertItem(ADAPTER_TYPE, SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to caption)
+//            placeholderManager.insertItem(ADAPTER_TYPE, SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to caption)
+            placeholderManager.insertOrUpdateItem(ADAPTER_TYPE) { currentAttributes, type ->
+                if (currentAttributes == null || type != ADAPTER_TYPE) {
+                    mapOf(SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to caption)
+                } else {
+                    val currentCaption = currentAttributes[CAPTION_ATTRIBUTE]
+                    mapOf(SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to "$caption - $currentCaption")
+                }
+            }
         }
     }
 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/ImageWithCaptionAdapter.kt
@@ -82,7 +82,6 @@ class ImageWithCaptionAdapter(
         private const val SRC_ATTRIBUTE = "src"
 
         suspend fun insertImageWithCaption(placeholderManager: PlaceholderManager, src: String, caption: String) {
-//            placeholderManager.insertItem(ADAPTER_TYPE, SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to caption)
             placeholderManager.insertOrUpdateItem(ADAPTER_TYPE) { currentAttributes, type ->
                 if (currentAttributes == null || type != ADAPTER_TYPE) {
                     mapOf(SRC_ATTRIBUTE to src, CAPTION_ATTRIBUTE to caption)

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -157,7 +157,7 @@ class PlaceholderManager(
             selectionStartMinusOne to selectionStart
         } else if (editableText[selectionStartMinusOne] == '\n' && editableText[selectionStartMinusTwo] == Constants.IMG_CHAR) {
             selectionStartMinusTwo to selectionStart
-        } else if (editableText[selectionEndPlusOne] == Constants.IMG_CHAR){
+        } else if (editableText[selectionEndPlusOne] == Constants.IMG_CHAR) {
             selectionEndPlusOne to (selectionEndPlusOne + 1).coerceAtMost(aztecText.length())
         } else if (editableText[selectionEndPlusOne] == '\n' && editableText[selectionEndPlusTwo] == Constants.IMG_CHAR) {
             selectionEndPlusTwo to (selectionEndPlusTwo + 1).coerceAtMost(aztecText.length())

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -112,9 +112,9 @@ class PlaceholderManager(
     suspend fun insertOrUpdateItem(type: String, shouldMergeItem: (currentItemType: String) -> Boolean = { true }, updateItem: (currentAttributes: Map<String, String>?, currentType: String?) -> Map<String, String>) {
         val previousIndex = (aztecText.selectionStart - 1).coerceAtLeast(0)
         val indexBeforePrevious = (aztecText.selectionStart - 2).coerceAtLeast(0)
-        val from = if (aztecText.editableText[previousIndex] == Constants.IMG_CHAR) {
+        val from = if (aztecText.editableText.length > previousIndex && aztecText.editableText[previousIndex] == Constants.IMG_CHAR) {
             previousIndex
-        } else if (aztecText.editableText[previousIndex] == '\n') {
+        } else if (aztecText.editableText.length > previousIndex && aztecText.editableText[previousIndex] == '\n') {
             indexBeforePrevious
         } else {
             aztecText.selectionStart

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecContentChangeWatcher
 import org.wordpress.aztec.AztecText
@@ -52,6 +54,7 @@ class PlaceholderManager(
         AztecText.OnVisibilityChangeListener,
         CoroutineScope {
     private val adapters = mutableMapOf<String, PlaceholderAdapter>()
+    private val positionToIdMutex = Mutex()
     private val positionToId = mutableSetOf<Placeholder>()
     private val job = Job()
     override val coroutineContext: CoroutineContext
@@ -163,8 +166,10 @@ class PlaceholderManager(
      * Call this method to reload all the placeholders
      */
     suspend fun reloadAllPlaceholders() {
-        positionToId.forEach {
-            insertContentOverSpanWithId(it.uuid)
+        positionToIdMutex.withLock {
+            positionToId.forEach {
+                insertContentOverSpanWithId(it.uuid)
+            }
         }
     }
 
@@ -219,8 +224,10 @@ class PlaceholderManager(
         parentTextViewRect.top += parentTextViewTopAndBottomOffset
         parentTextViewRect.bottom = parentTextViewRect.top + height
 
-        positionToId.removeAll {
-            it.uuid == uuid
+        positionToIdMutex.withLock {
+            positionToId.removeAll {
+                it.uuid == uuid
+            }
         }
 
         var box = container.findViewWithTag<View>(uuid)
@@ -243,7 +250,9 @@ class PlaceholderManager(
         box.tag = uuid
         box.setBackgroundColor(Color.TRANSPARENT)
         box.setOnTouchListener(adapter)
-        positionToId.add(Placeholder(targetPosition, uuid))
+        positionToIdMutex.withLock {
+            positionToId.add(Placeholder(targetPosition, uuid))
+        }
         if (!exists && box.parent == null) {
             container.addView(box)
             adapter.onViewCreated(box, uuid)
@@ -283,7 +292,11 @@ class PlaceholderManager(
             val uuid = attrs.getValue(UUID_ATTRIBUTE)
             val adapter = adapters[attrs.getValue(TYPE_ATTRIBUTE)]
             adapter?.onPlaceholderDeleted(uuid)
-            positionToId.removeAll { it.uuid == uuid }
+            launch {
+                positionToIdMutex.withLock {
+                    positionToId.removeAll { it.uuid == uuid }
+                }
+            }
             container.findViewWithTag<View>(uuid)?.let {
                 it.visibility = View.GONE
                 container.removeView(it)
@@ -387,19 +400,25 @@ class PlaceholderManager(
         }
     }
 
-    private fun clearAllViews() {
-        for (placeholder in positionToId) {
-            container.findViewWithTag<View>(placeholder.uuid)?.let {
-                it.visibility = View.GONE
-                container.removeView(it)
+    private suspend fun clearAllViews() {
+        positionToIdMutex.withLock {
+            for (placeholder in positionToId) {
+                container.findViewWithTag<View>(placeholder.uuid)?.let {
+                    it.visibility = View.GONE
+                    container.removeView(it)
+                }
             }
+            positionToId.clear()
         }
-        positionToId.clear()
     }
 
     override fun onVisibility(visibility: Int) {
-        for (placeholder in positionToId) {
-            container.findViewWithTag<View>(placeholder.uuid)?.visibility = visibility
+        launch {
+            positionToIdMutex.withLock {
+                for (placeholder in positionToId) {
+                    container.findViewWithTag<View>(placeholder.uuid)?.visibility = visibility
+                }
+            }
         }
     }
 

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -25,6 +25,7 @@ import org.wordpress.aztec.AztecContentChangeWatcher
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.Constants
 import org.wordpress.aztec.Html
+import org.wordpress.aztec.plugins.html2visual.IHtmlPreprocessor
 import org.wordpress.aztec.plugins.html2visual.IHtmlTagHandler
 import org.wordpress.aztec.spans.AztecMediaClickableSpan
 import org.xml.sax.Attributes
@@ -52,7 +53,8 @@ class PlaceholderManager(
         Html.MediaCallback,
         AztecText.OnMediaDeletedListener,
         AztecText.OnVisibilityChangeListener,
-        CoroutineScope {
+        CoroutineScope,
+        IHtmlPreprocessor {
     private val adapters = mutableMapOf<String, PlaceholderAdapter>()
     private val positionToIdMutex = Mutex()
     private val positionToId = mutableSetOf<Placeholder>()
@@ -584,5 +586,12 @@ class PlaceholderManager(
         private const val UUID_ATTRIBUTE = "uuid"
         private const val TYPE_ATTRIBUTE = "type"
         private const val EDITOR_INNER_PADDING = 20
+    }
+
+    override fun beforeHtmlProcessed(source: String): String {
+        runBlocking {
+            clearAllViews()
+        }
+        return source
     }
 }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -7,7 +7,6 @@ import android.graphics.drawable.Drawable
 import android.text.Editable
 import android.text.Layout
 import android.text.Spanned
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewTreeObserver
@@ -414,9 +413,7 @@ class PlaceholderManager(
     }
 
     private suspend fun clearAllViews() {
-        Log.d("vojta", "Before clearing all with lock")
         positionToIdMutex.withLock {
-            Log.d("vojta", "Clearing all with lock")
             for (placeholder in positionToId) {
                 container.findViewWithTag<View>(placeholder.uuid)?.let {
                     it.visibility = View.GONE
@@ -424,7 +421,6 @@ class PlaceholderManager(
                 }
             }
             positionToId.clear()
-            Log.d("vojta", "Cleared all with lock")
         }
     }
 

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -157,12 +157,13 @@ class PlaceholderManager(
         if (aztecText.length() == 0) {
             return null
         }
+        val limitLength = aztecText.length() - 1
         val selectionStart = aztecText.selectionStart
-        val selectionStartMinusOne = (selectionStart - 1).coerceAtLeast(0)
-        val selectionStartMinusTwo = (selectionStart - 2).coerceAtLeast(0)
+        val selectionStartMinusOne = (selectionStart - 1).coerceIn(0, limitLength)
+        val selectionStartMinusTwo = (selectionStart - 2).coerceIn(0, limitLength)
         val selectionEnd = aztecText.selectionEnd
-        val selectionEndPlusOne = (selectionStart + 1).coerceAtMost(aztecText.length())
-        val selectionEndPlusTwo = (selectionStart + 2).coerceAtMost(aztecText.length())
+        val selectionEndPlusOne = (selectionStart + 1).coerceIn(0, limitLength)
+        val selectionEndPlusTwo = (selectionStart + 2).coerceIn(0, limitLength)
         val editableText = aztecText.editableText
         var placeAtStart = false
         val (from, to) = if (editableText[selectionStartMinusOne] == Constants.IMG_CHAR) {
@@ -171,10 +172,10 @@ class PlaceholderManager(
             selectionStartMinusTwo to selectionStart
         } else if (editableText[selectionEndPlusOne] == Constants.IMG_CHAR) {
             placeAtStart = true
-            selectionEndPlusOne to (selectionEndPlusOne + 1).coerceAtMost(aztecText.length())
+            selectionEndPlusOne to (selectionEndPlusOne + 1).coerceIn(0, limitLength)
         } else if (editableText[selectionEndPlusOne] == '\n' && editableText[selectionEndPlusTwo] == Constants.IMG_CHAR) {
             placeAtStart = true
-            selectionEndPlusTwo to (selectionEndPlusTwo + 1).coerceAtMost(aztecText.length())
+            selectionEndPlusTwo to (selectionEndPlusTwo + 1).coerceIn(0, limitLength)
         } else {
             selectionStart to selectionEnd
         }

--- a/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
+++ b/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar

--- a/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
+++ b/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
@@ -64,8 +64,6 @@ class PlaceholderTest {
             editText.fromHtml(initialHtml)
 
             editText.setSelection(0)
-            val attributes = AztecAttributes()
-            attributes.setValue("id", "1234")
             ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 123")
 
             Assert.assertEquals("<placeholder uuid=\"$uuid\" type=\"image_with_caption\" src=\"image.jpg\" caption=\"Caption 123\" /><p>Line 1</p>", editText.toHtml())
@@ -86,8 +84,6 @@ class PlaceholderTest {
             editText.fromHtml(initialHtml)
 
             editText.setSelection(editText.editableText.indexOf("1"))
-            val attributes = AztecAttributes()
-            attributes.setValue("id", "1234")
             ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 123")
 
             Assert.assertEquals("<p>Line 123<placeholder uuid=\"uuid123\" type=\"image_with_caption\" src=\"image.jpg\" caption=\"Caption 123\" /></p><p>Line 2</p>", editText.toHtml())
@@ -108,12 +104,10 @@ class PlaceholderTest {
             editText.fromHtml(initialHtml)
 
             editText.setSelection(0)
-            val attributes = AztecAttributes()
-            attributes.setValue("id", "1234")
             ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 1")
             ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 2")
 
-            Assert.assertEquals("<placeholder src=\"image.jpg\" caption=\"Caption 2 - Caption 1\" uuid=\"uuid123\" type=\"image_with_caption\" /><p>Line 1</p>", editText.toHtml())
+            Assert.assertEquals("${placeholderWithCaption("Caption 2 - Caption 1")}<p>Line 1</p>", editText.toHtml())
 
             placeholderManager.removeItem {
                 it.getValue("uuid") == uuid
@@ -121,5 +115,37 @@ class PlaceholderTest {
 
             Assert.assertEquals(initialHtml, editText.toHtml())
         }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun insertOrUpdateAPlaceholderWhenInsertingBeforeNewLine() {
+        runBlocking {
+            val initialHtml = "<p>Line 1</p>${placeholderWithCaption("First")}<p>Line 2</p>"
+            editText.fromHtml(initialHtml)
+
+            editText.setSelection(editText.editableText.indexOf("1"))
+            ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Second")
+
+            Assert.assertEquals("<p>Line 1</p>${placeholderWithCaption("Second - First")}<p>Line 2</p>", editText.toHtml())
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun insertOrUpdateAPlaceholderWhenInsertingRightBefore() {
+        runBlocking {
+            val initialHtml = "<p>Line 1</p>${placeholderWithCaption("First")}<p>Line 2</p>"
+            editText.fromHtml(initialHtml)
+
+            editText.setSelection(editText.editableText.indexOf("1") + 1)
+            ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Second")
+
+            Assert.assertEquals("<p>Line 1</p>${placeholderWithCaption("Second - First")}<p>Line 2</p>", editText.toHtml())
+        }
+    }
+
+    private fun placeholderWithCaption(caption: String): String {
+        return "<placeholder src=\"image.jpg\" caption=\"$caption\" uuid=\"uuid123\" type=\"image_with_caption\" />"
     }
 }

--- a/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
+++ b/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
@@ -1,0 +1,129 @@
+package org.wordpress.aztec.placeholders
+
+import android.app.Activity
+import android.text.BoringLayout
+import android.text.Layout
+import android.text.TextPaint
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.FrameLayout
+import android.widget.PopupMenu
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.source.SourceViewEditText
+import org.wordpress.aztec.toolbar.AztecToolbar
+
+@RunWith(RobolectricTestRunner::class)
+class PlaceholderTest {
+    lateinit var container: FrameLayout
+    lateinit var editText: AztecText
+    lateinit var menuList: PopupMenu
+    lateinit var menuListOrdered: MenuItem
+    lateinit var menuListUnordered: MenuItem
+    lateinit var sourceText: SourceViewEditText
+    lateinit var toolbar: AztecToolbar
+    lateinit var placeholderManager: PlaceholderManager
+
+    private val uuid: String = "uuid123"
+
+    /**
+     * Initialize variables.
+     */
+    @Before
+    fun init() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+        container = FrameLayout(activity)
+        editText = AztecText(activity)
+        container.addView(editText, FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT))
+        placeholderManager = PlaceholderManager(editText, container, generateUuid = {
+            uuid
+        })
+        placeholderManager.registerAdapter(ImageWithCaptionAdapter())
+        editText.setCalypsoMode(false)
+        editText.addMediaAfterBlocks()
+        editText.plugins.add(placeholderManager)
+        sourceText = SourceViewEditText(activity)
+        sourceText.setCalypsoMode(false)
+        toolbar = AztecToolbar(activity)
+        toolbar.setEditor(editText, sourceText)
+        menuList = toolbar.getListMenu() as PopupMenu
+        menuListOrdered = menuList.menu.getItem(1)
+        menuListUnordered = menuList.menu.getItem(0)
+        activity.setContentView(container)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addAndRemovePlaceholderAtTheBeginning() {
+        runBlocking {
+            val initialHtml = "<p>Line 1</p>"
+            editText.fromHtml(initialHtml)
+
+            editText.setSelection(0)
+            val attributes = AztecAttributes()
+            attributes.setValue("id", "1234")
+            ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 123")
+
+            Assert.assertEquals("<placeholder uuid=\"$uuid\" type=\"image_with_caption\" src=\"image.jpg\" caption=\"Caption 123\" /><p>Line 1</p>", editText.toHtml())
+
+            placeholderManager.removeItem {
+                it.getValue("uuid") == uuid
+            }
+
+            Assert.assertEquals(initialHtml, editText.toHtml())
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addAndRemovePlaceholderAtTheEndOfLine() {
+        runBlocking {
+            val initialHtml = "<p>Line 123</p><p>Line 2</p>"
+            editText.fromHtml(initialHtml)
+
+            editText.setSelection(editText.editableText.indexOf("1"))
+            val attributes = AztecAttributes()
+            attributes.setValue("id", "1234")
+            ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 123")
+
+            Assert.assertEquals("<p>Line 123<placeholder uuid=\"uuid123\" type=\"image_with_caption\" src=\"image.jpg\" caption=\"Caption 123\" /></p><p>Line 2</p>", editText.toHtml())
+
+            placeholderManager.removeItem {
+                it.getValue("uuid") == uuid
+            }
+
+            Assert.assertEquals(initialHtml, editText.toHtml())
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun insertOrUpdateAPlaceholderAtTheBeginning() {
+        runBlocking {
+            val initialHtml = "<p>Line 1</p>"
+            editText.fromHtml(initialHtml)
+
+            editText.setSelection(0)
+            val attributes = AztecAttributes()
+            attributes.setValue("id", "1234")
+            ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 1")
+            ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 2")
+
+            Assert.assertEquals("<placeholder src=\"image.jpg\" caption=\"Caption 2 - Caption 1\" uuid=\"uuid123\" type=\"image_with_caption\" /><p>Line 1</p>", editText.toHtml())
+
+            placeholderManager.removeItem {
+                it.getValue("uuid") == uuid
+            }
+
+            Assert.assertEquals(initialHtml, editText.toHtml())
+        }
+    }
+}

--- a/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
+++ b/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
@@ -106,7 +106,7 @@ class PlaceholderTest {
             ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 1")
             ImageWithCaptionAdapter.insertImageWithCaption(placeholderManager, "image.jpg", "Caption 2")
 
-            Assert.assertEquals("${placeholderWithCaption("Caption 2 - Caption 1")}<p>Line 1</p>", editText.toHtml())
+            Assert.assertEquals("${placeholderWithCaption("Caption 1 - Caption 2")}<p>Line 1</p>", editText.toHtml())
 
             placeholderManager.removeItem {
                 it.getValue("uuid") == uuid

--- a/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
+++ b/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
@@ -1,11 +1,7 @@
 package org.wordpress.aztec.placeholders
 
 import android.app.Activity
-import android.text.BoringLayout
-import android.text.Layout
-import android.text.TextPaint
 import android.view.MenuItem
-import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import android.widget.PopupMenu


### PR DESCRIPTION
### Fix
Implement method that allows the user to merge the created placeholder into the previous one. 

### Test
- This can be tested with the related DayOne PR

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.