### PR TITLE
Update all the placeholders on content change

### DIFF
--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -114,12 +114,20 @@ class PlaceholderManager(
         return drawable
     }
 
-    private suspend fun updateAllBelowSelection(selectionStart: Int) {
-        positionToId.filter {
-            it.elementPosition >= selectionStart - 1
-        }.forEach {
+    /**
+     * Call this method to reload all the placeholders
+     */
+    suspend fun refresh() {
+        positionToId.forEach {
             insertContentOverSpanWithId(it.uuid)
         }
+    }
+
+    /**
+     * Call this method to relaod a placeholder with UUID
+     */
+    suspend fun refreshWithUuid(uuid: String) {
+        insertContentOverSpanWithId(uuid)
     }
 
     private suspend fun insertContentOverSpanWithId(uuid: String) {
@@ -218,7 +226,7 @@ class PlaceholderManager(
      */
     override fun onContentChanged() {
         launch {
-            updateAllBelowSelection(aztecText.selectionStart)
+            refresh()
         }
     }
 

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -117,7 +117,7 @@ class PlaceholderManager(
     /**
      * Call this method to reload all the placeholders
      */
-    suspend fun refresh() {
+    suspend fun reloadAllPlaceholders() {
         positionToId.forEach {
             insertContentOverSpanWithId(it.uuid)
         }
@@ -226,7 +226,7 @@ class PlaceholderManager(
      */
     override fun onContentChanged() {
         launch {
-            refresh()
+            reloadAllPlaceholders()
         }
     }
 


### PR DESCRIPTION
### Fix
The PlaceholderManager contained an optimization that would only update placeholders after the selection start on content change. This works normally fine. However, there is an issue when typing with gestures. Since the inserted word moves the selection start further, the placeholder right after the word wasn't updated. As a fix I've removed this optimization. If we notice any performance issues, we can be smarter about it (and for example only update everything after the previous linebreak). 

### Test
1. Set up the `MainActivity` with the `PlaceholderManager`. For this you need to initialize the manager and register it with Aztec. Create a `ImageWithCaptionAdapter` instance and register it with the `PlaceholderManager`. Replace the `EXAMPLE_HTML` content with something like `<placeholder type=\"image_with_caption\" src=\"and_valid_image_url\" caption=\"test\"></placeholder>`
2. Run the Aztec
3. Notice only the image with caption visible
4. Click before the image
5. Type anything with a gesture
6. Notice the text is no longer under the image
7. Notice the images jumps to the next line.


https://user-images.githubusercontent.com/1079756/220354686-863f38a1-1e06-45b2-9980-f63bcf208947.mp4




### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.