### PR TITLE
Implement backspace soft override

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/Aztec.kt
@@ -36,6 +36,12 @@ open class Aztec private constructor(
             onMediaDeletedListeners.forEach { it.beforeMediaDeleted(attrs) }
         }
     }
+    private var beforeBackSpaceListeners: MutableList<AztecText.BeforeBackSpaceListener> = mutableListOf()
+    private val beforeBackSpaceListener = object : AztecText.BeforeBackSpaceListener {
+        override fun shouldOverrideBackSpace(position: Int): Boolean {
+            return beforeBackSpaceListeners.any { it.shouldOverrideBackSpace(position) }
+        }
+    }
     private var onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener? = null
     private var onLinkTappedListener: AztecText.OnLinkTappedListener? = null
     private var isLinkTapEnabled: Boolean = false
@@ -145,6 +151,12 @@ open class Aztec private constructor(
         return this
     }
 
+    fun addBeforeBackSpaceListener(beforeBackSpaceListener: AztecText.BeforeBackSpaceListener): Aztec {
+        this.beforeBackSpaceListeners.add(beforeBackSpaceListener)
+        initBeforeBackSpaceListener()
+        return this
+    }
+
     fun setOnVideoInfoRequestedListener(onVideoInfoRequestedListener: AztecText.OnVideoInfoRequestedListener): Aztec {
         this.onVideoInfoRequestedListener = onVideoInfoRequestedListener
         initVideoInfoRequestedListener()
@@ -251,6 +263,10 @@ open class Aztec private constructor(
 
     private fun initMediaDeletedListener() {
         visualEditor.setOnMediaDeletedListener(onMediaDeletedListener)
+    }
+
+    private fun initBeforeBackSpaceListener() {
+        visualEditor.setBeforeBackSpaceListener(beforeBackSpaceListener)
     }
 
     private fun initVideoInfoRequestedListener() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/DeleteOverrideInputConnection.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/DeleteOverrideInputConnection.kt
@@ -1,0 +1,17 @@
+package org.wordpress.aztec
+
+import android.view.inputmethod.InputConnection
+
+/**
+ * Wrapper around proprietary Samsung InputConnection. Forwards all the calls to it, except for getExtractedText and
+ * some custom logic in commitText
+ */
+class DeleteOverrideInputConnection(
+        inputConnection: InputConnection,
+        private val shouldDeleteSurroundingText: (beforeLength: Int, afterLength: Int) -> Boolean
+) : InputConnectionWrapper(inputConnection) {
+    override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
+        return shouldDeleteSurroundingText(beforeLength, afterLength)
+                && super.deleteSurroundingText(beforeLength, afterLength)
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/InputConnectionWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/InputConnectionWrapper.kt
@@ -1,0 +1,124 @@
+package org.wordpress.aztec
+
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.view.KeyEvent
+import android.view.inputmethod.CompletionInfo
+import android.view.inputmethod.CorrectionInfo
+import android.view.inputmethod.ExtractedText
+import android.view.inputmethod.ExtractedTextRequest
+import android.view.inputmethod.InputConnection
+import android.view.inputmethod.InputContentInfo
+import androidx.annotation.RequiresApi
+
+/**
+ * Wrapper around proprietary Samsung InputConnection. Forwards all the calls to it, except for getExtractedText and
+ * some custom logic in commitText
+ */
+abstract class InputConnectionWrapper(private val inputConnection: InputConnection) : InputConnection {
+    override fun beginBatchEdit(): Boolean {
+        return inputConnection.beginBatchEdit()
+    }
+
+    override fun endBatchEdit(): Boolean {
+        return inputConnection.endBatchEdit()
+    }
+
+    override fun clearMetaKeyStates(states: Int): Boolean {
+        return inputConnection.clearMetaKeyStates(states)
+    }
+
+    override fun sendKeyEvent(event: KeyEvent?): Boolean {
+        return inputConnection.sendKeyEvent(event)
+    }
+
+    override fun commitCompletion(text: CompletionInfo?): Boolean {
+        return inputConnection.commitCompletion(text)
+    }
+
+    override fun commitCorrection(correctionInfo: CorrectionInfo?): Boolean {
+        return inputConnection.commitCorrection(correctionInfo)
+    }
+
+    override fun performEditorAction(actionCode: Int): Boolean {
+        return inputConnection.performEditorAction(actionCode)
+    }
+
+    override fun performContextMenuAction(id: Int): Boolean {
+        return inputConnection.performContextMenuAction(id)
+    }
+
+    override fun getExtractedText(request: ExtractedTextRequest?, flags: Int): ExtractedText? {
+        return inputConnection.getExtractedText(request, flags)
+    }
+
+    override fun performPrivateCommand(action: String?, data: Bundle?): Boolean {
+        return inputConnection.performPrivateCommand(action, data)
+    }
+
+    override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
+        return inputConnection.setComposingText(text, newCursorPosition)
+    }
+
+    override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
+        return inputConnection.commitText(text, newCursorPosition)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N_MR1)
+    override fun commitContent(inputContentInfo: InputContentInfo, flags: Int, opts: Bundle?): Boolean {
+        return inputConnection.commitContent(inputContentInfo, flags, opts)
+    }
+
+    override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
+        return inputConnection.deleteSurroundingText(beforeLength, afterLength)
+    }
+
+    override fun requestCursorUpdates(cursorUpdateMode: Int): Boolean {
+        return inputConnection.requestCursorUpdates(cursorUpdateMode)
+    }
+
+    override fun reportFullscreenMode(enabled: Boolean): Boolean {
+        return inputConnection.reportFullscreenMode(enabled)
+    }
+
+    override fun setSelection(start: Int, end: Int): Boolean {
+        return inputConnection.setSelection(start, end)
+    }
+
+    override fun finishComposingText(): Boolean {
+        return inputConnection.finishComposingText()
+    }
+
+    override fun setComposingRegion(start: Int, end: Int): Boolean {
+        return inputConnection.setComposingRegion(start, end)
+    }
+
+    override fun deleteSurroundingTextInCodePoints(beforeLength: Int, afterLength: Int): Boolean {
+        return inputConnection.deleteSurroundingTextInCodePoints(beforeLength, afterLength)
+    }
+
+    override fun getCursorCapsMode(reqModes: Int): Int {
+        return inputConnection.getCursorCapsMode(reqModes)
+    }
+
+    override fun getSelectedText(flags: Int): CharSequence? {
+        return inputConnection.getSelectedText(flags)
+    }
+
+    override fun getTextAfterCursor(length: Int, flags: Int): CharSequence {
+        return inputConnection.getTextAfterCursor(length, flags)
+    }
+
+    override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence {
+        return inputConnection.getTextBeforeCursor(length, flags)
+    }
+
+    override fun getHandler(): Handler? {
+        return inputConnection.handler
+    }
+
+    override fun closeConnection() {
+        inputConnection.closeConnection()
+    }
+}

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderBackspaceListener.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderBackspaceListener.kt
@@ -1,0 +1,18 @@
+package org.wordpress.aztec.placeholders
+
+import org.wordpress.aztec.AztecText
+
+/**
+ * This class overrides the backspace event and stops backspace if the previous item is a placeholder span. This is
+ * useful to show some kind of a dialog that will let the user decide if they want to really remove the placeholder.
+ */
+class PlaceholderBackspaceListener(private val visualEditor: AztecText, private val predicate: (span: AztecPlaceholderSpan) -> Boolean) : AztecText.BeforeBackSpaceListener {
+    override fun shouldOverrideBackSpace(position: Int): Boolean {
+        val editableText = visualEditor.editableText
+
+        return editableText.getSpans(position, position + 1, AztecPlaceholderSpan::class.java).any {
+            predicate(it)
+        }
+    }
+}
+


### PR DESCRIPTION
### Fix
In this PR I'm adding an option to override the backspace on the soft keyboard. This is useful if you want to show a dialog instead of deleting a certain item (like an image). 

In order to test it you have to:
- Create a placeholder manager instance and register it with Aztec
- Create ImageWithCaptionsAdapter and register it with the placeholder manager
- Change the `EXAMPLE` string to something like this: 
```
        private val EXAMPLE = """
            <p>Line</p>
            <placeholder type="image_with_caption" src="https://file-examples.com/storage/fe1aa0c9d563ea1e4a1fd34/2017/10/file_example_JPG_100kB.jpg" caption="test"
            <p>LIne</p>
        """.trimIndent()
```
- Register the placeholder backspace listener with the aztec like this: 
```
.addBeforeBackSpaceListener(PlaceholderBackspaceListener(visualEditor) {
    true
})
```

### Test 1
1. Do the initial steps
2. Click right behind the placeholder image 
3. Click on "Backspace"
4. Notice the image is not deleted


### Test 2
1. Do the initial steps
2. Click at the beginning of the next line behind the image 
3. Click on "Backspace"
4. Notice the image is not deleted


### Test 3
1. Do the initial steps
2. Click anywhere that's not right behind the image
3. Try backspace
4. Notice the text is deleted as expected

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.