### PR TITLE
Feature/implement delete or update

### DIFF
--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -168,9 +168,13 @@ class PlaceholderManager(
         } ?: return false
         if (shouldUpdateItem(currentItem.attributes)) {
             val type = currentItem.attributes.getValue(TYPE_ATTRIBUTE)
+            val selectionStart = aztecText.selectionStart
+            val selectionEnd = aztecText.selectionEnd
+            aztecText.setSelection(aztecText.editableText.getSpanStart(currentItem))
             updateSpan(type, currentItem, updateItem = { attributes, _ ->
                 updateItem(attributes)
             }, type)
+            aztecText.setSelection(selectionStart, selectionEnd)
         } else {
             removeItem(uuid)
         }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -169,7 +169,7 @@ class PlaceholderManager(
         if (shouldUpdateItem(currentItem.attributes)) {
             val type = currentItem.attributes.getValue(TYPE_ATTRIBUTE)
             updateSpan(type, currentItem, updateItem = { attributes, _ ->
-                 updateItem(attributes)
+                updateItem(attributes)
             }, type)
         } else {
             removeItem(uuid)

--- a/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
+++ b/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
@@ -122,4 +122,44 @@ class PlaceholderTest {
             Assert.assertEquals(initialHtml, editText.toHtml())
         }
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun updatePlaceholderWhenItShouldBe() {
+        runBlocking {
+            val initialHtml = "<placeholder uuid=\"uuid123\" type=\"image_with_caption\" src=\"image.jpg;image2.jpg\" caption=\"Caption - 1, 2\" /><p>Line</p>"
+            editText.fromHtml(initialHtml)
+
+            placeholderManager.removeOrUpdate("uuid123", shouldUpdateItem = {
+                true
+            }) { currentAttributes ->
+                val result = mutableMapOf<String, String>()
+                result["src"] = currentAttributes["src"]?.split(";")?.firstOrNull() ?: ""
+                result["caption"] = "Updated caption"
+                result
+            }
+
+            Assert.assertEquals("<placeholder src=\"image.jpg\" caption=\"Updated caption\" uuid=\"uuid123\" type=\"image_with_caption\" /><p>Line</p>", editText.toHtml())
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun removePlaceholderWhenItShouldNotBeUpdated() {
+        runBlocking {
+            val initialHtml = "<placeholder uuid=\"uuid123\" type=\"image_with_caption\" src=\"image.jpg;image2.jpg\" caption=\"Caption - 1, 2\" /><p>Line</p>"
+            editText.fromHtml(initialHtml)
+
+            placeholderManager.removeOrUpdate("uuid123", shouldUpdateItem = {
+                false
+            }) { currentAttributes ->
+                val result = mutableMapOf<String, String>()
+                result["src"] = currentAttributes["src"]?.split(";")?.firstOrNull() ?: ""
+                result["caption"] = "Updated caption"
+                result
+            }
+
+            Assert.assertEquals("<p>Line</p>", editText.toHtml())
+        }
+    }
 }

--- a/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
+++ b/media-placeholders/src/test/java/org/wordpress/aztec/placeholders/PlaceholderTest.kt
@@ -145,6 +145,31 @@ class PlaceholderTest {
 
     @Test
     @Throws(Exception::class)
+    fun updatePlaceholderAtTheEnd() {
+        runBlocking {
+            val initialHtml = "<p>First Line</p><placeholder uuid=\"uuid123\" type=\"image_with_caption\" src=\"image.jpg;image2.jpg\" caption=\"Caption - 1, 2\" /><p>Second Line</p>"
+            editText.fromHtml(initialHtml)
+            editText.setSelection(editText.editableText.indexOf("First") + 1)
+            val initialSelectionStart = editText.selectionStart
+            val initialSelectionEnd = editText.selectionEnd
+
+            placeholderManager.removeOrUpdate("uuid123", shouldUpdateItem = {
+                true
+            }) { currentAttributes ->
+                val result = mutableMapOf<String, String>()
+                result["src"] = currentAttributes["src"]?.split(";")?.firstOrNull() ?: ""
+                result["caption"] = "Updated caption"
+                result
+            }
+
+            Assert.assertEquals("<p>First Line</p><placeholder src=\"image.jpg\" caption=\"Updated caption\" uuid=\"uuid123\" type=\"image_with_caption\" /><p>Second Line</p>", editText.toHtml())
+            Assert.assertEquals(initialSelectionStart, editText.selectionStart)
+            Assert.assertEquals(initialSelectionEnd, editText.selectionEnd)
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun removePlaceholderWhenItShouldNotBeUpdated() {
         runBlocking {
             val initialHtml = "<placeholder uuid=\"uuid123\" type=\"image_with_caption\" src=\"image.jpg;image2.jpg\" caption=\"Caption - 1, 2\" /><p>Line</p>"


### PR DESCRIPTION
### Fix
In this PR I'm adding a method that allows users to either remove or update a placeholder based on conditions. This is useful in cases like removing an image from a gallery. If the image is the last item in the gallery, we want to remove it instead of just updating the parameters. If it's not the last item, we'd probably want to remove the image params from the gallery.


### Test
1. This can be tested with the related Day One PR

### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.