### PR TITLE
Update compile sdk to 33

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -642,6 +642,7 @@ open class MainActivity : AppCompatActivity(),
             val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
 
             mediaFile = "wp-" + System.currentTimeMillis() + ".jpg"
+            @Suppress("DEPRECATION")
             mediaPath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM).toString() +
                     File.separator + "Camera" + File.separator + mediaFile
             intent.putExtra(MediaStore.EXTRA_OUTPUT, FileProvider.getUriForFile(this,

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -511,15 +511,13 @@ open class MainActivity : AppCompatActivity(),
         }
     }
 
-    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
 
         aztec.initSourceEditorHistory()
 
-        savedInstanceState?.let {
-            if (savedInstanceState.getBoolean("isMediaUploadDialogVisible")) {
-                showMediaUploadDialog()
-            }
+        if (savedInstanceState.getBoolean("isMediaUploadDialogVisible")) {
+            showMediaUploadDialog()
         }
     }
 

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -27,6 +27,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupMenu
 import android.widget.ToggleButton
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
@@ -386,6 +387,20 @@ open class MainActivity : AppCompatActivity(),
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                mIsKeyboardOpen = false
+                showActionBarIfNeeded()
+
+                // Disable the callback temporarily to allow the system to handle the back pressed event. This usage
+                // breaks predictive back gesture behavior and should be reviewed before enabling the predictive back
+                // gesture feature.
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
+                isEnabled = true
+            }
+        })
+
         // Setup hiding the action bar when the soft keyboard is displayed for narrow viewports
         if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
                 && !resources.getBoolean(R.bool.is_large_tablet_landscape)) {
@@ -574,13 +589,6 @@ open class MainActivity : AppCompatActivity(),
             hideActionBarIfNeeded()
         }
         return false
-    }
-
-    override fun onBackPressed() {
-        mIsKeyboardOpen = false
-        showActionBarIfNeeded()
-
-        return super.onBackPressed()
     }
 
     /**

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -17,6 +17,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
 import android.os.Handler
+import android.os.Looper
 import android.provider.MediaStore
 import android.util.DisplayMetrics
 import android.view.Gravity
@@ -372,11 +373,11 @@ open class MainActivity : AppCompatActivity(),
             }
         }
 
-        Handler().post(runnable)
-        Handler().postDelayed(runnable, 2000)
-        Handler().postDelayed(runnable, 4000)
-        Handler().postDelayed(runnable, 6000)
-        Handler().postDelayed(runnable, 8000)
+        Handler(Looper.getMainLooper()).post(runnable)
+        Handler(Looper.getMainLooper()).postDelayed(runnable, 2000)
+        Handler(Looper.getMainLooper()).postDelayed(runnable, 4000)
+        Handler(Looper.getMainLooper()).postDelayed(runnable, 6000)
+        Handler(Looper.getMainLooper()).postDelayed(runnable, 8000)
 
         aztec.visualEditor.refreshText()
     }
@@ -477,7 +478,7 @@ open class MainActivity : AppCompatActivity(),
             aztec.initSourceEditorHistory()
         }
 
-        invalidateOptionsHandler = Handler()
+        invalidateOptionsHandler = Handler(Looper.getMainLooper())
         invalidateOptionsRunnable = Runnable { invalidateOptionsMenu() }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1926,8 +1926,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         val html = Format.removeSourceEditorFormatting(parser.toHtml(output), isInCalypsoMode, isInGutenbergMode)
 
-        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-        clipboard.primaryClip = ClipData.newHtmlText("aztec", output.toString(), html)
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newHtmlText("aztec", output.toString(), html))
     }
 
     // copied from TextView with some changes

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2112,7 +2112,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         source.displayStyledAndFormattedHtml(editHtml)
         builder.setView(dialogView)
 
-        builder.setPositiveButton(R.string.block_editor_dialog_button_save, { _, _ ->
+        builder.setPositiveButton(R.string.block_editor_dialog_button_save) { _, _ ->
             val spanStart = text.getSpanStart(unknownHtmlSpan)
 
             val textBuilder = SpannableStringBuilder()
@@ -2137,14 +2137,15 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             enableTextChangedListener()
 
             inlineFormatter.joinStyleSpans(0, text.length)
-        })
+        }
 
-        builder.setNegativeButton(R.string.block_editor_dialog_button_cancel, { dialogInterface, _ ->
+        builder.setNegativeButton(R.string.block_editor_dialog_button_cancel) { dialogInterface, _ ->
             dialogInterface.dismiss()
-        })
+        }
 
         unknownBlockSpanStart = text.getSpanStart(unknownHtmlSpan)
         blockEditorDialog = builder.create()
+        @Suppress("DEPRECATION")
         blockEditorDialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         blockEditorDialog?.show()
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1993,7 +1993,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                                 plugin.itemToHtml(itemToPaste, acc ?: selectedText?.takeIf { it.isNotBlank() }) ?: acc
                             } ?: when (itemToPaste) {
                         is IClipboardPastePlugin.PastedItem.HtmlText -> itemToPaste.text
-                        is IClipboardPastePlugin.PastedItem.Url -> itemToPaste.uri.path
+                        is IClipboardPastePlugin.PastedItem.Url -> itemToPaste.uri.path.toString()
                         is IClipboardPastePlugin.PastedItem.PastedIntent -> itemToPaste.intent.toString()
                     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -49,7 +49,6 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnLongClickListener
-import android.view.WindowManager
 import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
@@ -2099,7 +2098,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     @SuppressLint("InflateParams")
     fun showBlockEditorDialog(unknownHtmlSpan: UnknownHtmlSpan, html: String = "") {
-        val builder = AlertDialog.Builder(context)
+        val builder = AlertDialog.Builder(context, R.style.ResizableDialogTheme)
 
         val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_block_editor, null)
         val source = dialogView.findViewById<SourceViewEditText>(R.id.source)
@@ -2145,8 +2144,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         unknownBlockSpanStart = text.getSpanStart(unknownHtmlSpan)
         blockEditorDialog = builder.create()
-        @Suppress("DEPRECATION")
-        blockEditorDialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         blockEditorDialog?.show()
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -33,17 +33,17 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
     }
 
     fun beforeTextChanged(editText: EditText) {
-        if (historyEnabled && !historyWorking) {
+        if (historyRunnable != null && historyEnabled && !historyWorking) {
             mainHandler.removeCallbacks(historyRunnable)
             if (!textChangedPending) {
                 textChangedPending = true
-                historyRunnable?.text =
+                historyRunnable.text =
                     when (editText) {
                         is AztecText -> editText.toFormattedHtml()
                         is SourceViewEditText -> editText.text.toString()
                         else -> ""
                     }
-                historyRunnable?.editText = editText
+                historyRunnable.editText = editText
             }
             mainHandler.postDelayed(historyRunnable, historyThrottleTime)
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/InputConnectionWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/InputConnectionWrapper.kt
@@ -106,11 +106,11 @@ abstract class InputConnectionWrapper(private val inputConnection: InputConnecti
         return inputConnection.getSelectedText(flags)
     }
 
-    override fun getTextAfterCursor(length: Int, flags: Int): CharSequence {
+    override fun getTextAfterCursor(length: Int, flags: Int): CharSequence? {
         return inputConnection.getTextAfterCursor(length, flags)
     }
 
-    override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence {
+    override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence? {
         return inputConnection.getTextBeforeCursor(length, flags)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/SamsungInputConnection.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/SamsungInputConnection.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.Selection
 import android.text.Spanned
-import android.text.TextUtils
 import android.text.style.SuggestionSpan
 import android.view.KeyEvent
 import android.view.inputmethod.BaseInputConnection
@@ -22,7 +21,7 @@ import android.view.inputmethod.InputContentInfo
  */
 class SamsungInputConnection(
         private val mTextView: AztecText,
-        private val baseInputConnection: InputConnection,
+        private val baseInputConnection: InputConnection
 ) : BaseInputConnection(mTextView, true) {
 
     override fun getEditable(): Editable {
@@ -178,11 +177,11 @@ class SamsungInputConnection(
         return baseInputConnection.getSelectedText(flags)
     }
 
-    override fun getTextAfterCursor(length: Int, flags: Int): CharSequence {
+    override fun getTextAfterCursor(length: Int, flags: Int): CharSequence? {
         return baseInputConnection.getTextAfterCursor(length, flags)
     }
 
-    override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence {
+    override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence? {
         return baseInputConnection.getTextBeforeCursor(length, flags)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/CssStyleFormatter.kt
@@ -1,11 +1,11 @@
 package org.wordpress.aztec.source
 
-import androidx.core.text.TextDirectionHeuristicsCompat
 import android.text.Editable
 import android.text.Layout
 import android.text.Spannable
 import android.text.style.BackgroundColorSpan
 import android.text.style.ForegroundColorSpan
+import androidx.core.text.TextDirectionHeuristicsCompat
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.spans.IAztecAlignmentSpan
 import org.wordpress.aztec.spans.IAztecAttributedSpan
@@ -121,7 +121,7 @@ class CssStyleFormatter {
 
             var styleAttributeValue = ""
             if (m.find()) {
-                styleAttributeValue = m.group(1)
+                m.group(1)?.let { styleAttributeValue = it }
             }
             return styleAttributeValue
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -33,22 +33,22 @@ class AztecCodeSpan(override var attributes: AztecAttributes = AztecAttributes()
         this.codeStyle = codeStyle
     }
 
-    override fun updateDrawState(tp: TextPaint?) {
+    override fun updateDrawState(tp: TextPaint) {
         configureTextPaint(tp)
     }
 
-    override fun updateMeasureState(tp: TextPaint?) {
+    override fun updateMeasureState(tp: TextPaint) {
         configureTextPaint(tp)
     }
 
-    private fun configureTextPaint(tp: TextPaint?) {
+    private fun configureTextPaint(tp: TextPaint) {
         val alpha: Int = (codeStyle.codeBackgroundAlpha * 255).toInt()
-        tp?.typeface = Typeface.MONOSPACE
-        tp?.bgColor = Color.argb(
+        tp.typeface = Typeface.MONOSPACE
+        tp.bgColor = Color.argb(
                 alpha,
                 Color.red(codeStyle.codeBackground),
                 Color.green(codeStyle.codeBackground),
                 Color.blue(codeStyle.codeBackground))
-        tp?.color = codeStyle.codeColor
+        tp.color = codeStyle.codeColor
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecPreformatSpan.kt
@@ -125,7 +125,7 @@ open class AztecPreformatSpan(
     }
 
     override fun drawBackground(canvas: Canvas, paint: Paint, left: Int, right: Int, top: Int, baseline: Int,
-                                bottom: Int, text: CharSequence?, start: Int, end: Int, lnum: Int) {
+                                bottom: Int, text: CharSequence, start: Int, end: Int, lnum: Int) {
         val spanned = text as Spanned
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/InstanceStateUtils.kt
@@ -2,7 +2,6 @@ package org.wordpress.aztec.util
 
 import android.content.Context
 import android.os.Bundle
-import android.text.TextUtils
 import org.wordpress.android.util.AppLog
 import java.io.File
 import java.io.FileInputStream
@@ -50,7 +49,7 @@ class InstanceStateUtils {
             // the full path is kept in the bundle so, get it from there
             val filename = bundle.getString(cacheFilenameKey(varName))
 
-            if (TextUtils.isEmpty(filename)) {
+            if (filename.isNullOrEmpty()) {
                 return defaultValue
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcherAPI25AndHigher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/DeleteMediaElementWatcherAPI25AndHigher.kt
@@ -39,7 +39,7 @@ class DeleteMediaElementWatcherAPI25AndHigher(aztecText: AztecText) : TextWatche
             // real user deletions.
             aztecTextRef.get()?.postDelayed({
                 while (!queueHasBeenPopulatedInThisTimeframe && deletedSpans.isNotEmpty()) {
-                    deletedSpans.poll().onMediaDeleted()
+                    deletedSpans.poll()?.onMediaDeleted()
                 }
                 queueHasBeenPopulatedInThisTimeframe = false
             }, 500)

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -119,4 +119,7 @@
         <item name="android:layout_alignParentLeft">true</item>
     </style>
 
+    <style name="ResizableDialogTheme" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="android:windowSoftInputMode">adjustResize</item>
+    </style>
 </resources>

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ClipboardTest.kt
@@ -346,7 +346,7 @@ class ClipboardTest {
 
         editText.setSelection(0)
         val clipboard = editText.context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-        clipboard.primaryClip = ClipData.newPlainText("aztec", "Heading")
+        clipboard.setPrimaryClip(ClipData.newPlainText("aztec", "Heading"))
 
         TestUtils.pasteFromClipboard(editText)
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
 
 ext {
     minSdkVersion = 24
-    compileSdkVersion = 28
+    compileSdkVersion = 31
     targetSdkVersion = 31
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
 
 ext {
     minSdkVersion = 24
-    compileSdkVersion = 31
+    compileSdkVersion = 33
     targetSdkVersion = 31
 }
 


### PR DESCRIPTION
### Fix
This updates `compileSdk` to 33 and makes the required changes. 

- Deprecated `getExternalStoragePublicDirectory()` warning was suppressed and opened an [issue](https://github.com/wordpress-mobile/AztecEditor-Android/issues/1036). It's a low-priority task since it's on the sample activity.
- `LayoutParams.SOFT_INPUT_ADJUST_RESIZE` was deprecated in API level 30. I [suppressed](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1037/commits/e56f841865de5cec1d01f021d0617215d8353375) it at first but then found a [way](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1037/commits/0d2a0db8e10249ea60fe15a7288aa2cf0474aa89) to resolve it. 

### Test
Being able to build and basic smoke test should be enough.
Updating `LayoutParams.SOFT_INPUT_ADJUST_RESIZE` may be worth a special test. To test:
1. Run AztecDemo.
2. Scroll down and find the HTML block (It's shown as "?", below "if (value == 5) printf(value)")
3. Tap the HTML block and type a long text to increase the dialog size.
4. Ensure "CANCEL", "SAVE" buttons are still visible and there is a margin between the keyboard and dialog.
<img src="https://user-images.githubusercontent.com/2471769/225133639-7a85f370-0bf1-4c2b-b52c-8702c08ec34a.png" width=300>

### Review
@ParaskP7 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.