### PR TITLE
Make sure to save remove action to history

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2205,6 +2205,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     fun removeMedia(attributePredicate: AttributePredicate) {
+        history.beforeTextChanged(this@AztecText)
         text.getSpans(0, text.length, AztecMediaSpan::class.java)
                 .filter {
                     attributePredicate.matches(it.attributes)
@@ -2252,6 +2253,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     }
                     mediaSpan.onMediaDeleted()
                 }
+        contentChangeWatcher.notifyContentChanged()
     }
 
     fun replaceMediaSpan(aztecMediaSpan: AztecMediaSpan, predicate: (Attributes) -> Boolean) {


### PR DESCRIPTION
### Fix
Add undo action to `removeItem` operation in the placeholders.

Before you start make sure you setup the `MainActivity` like this: 

Set the EXAMPLE to: 
```
        private val EXAMPLE = """
            <p>Line</p>
            <placeholder type="image_with_caption" src="https://file-examples.com/storage/fed220eb286401af1a43037/2017/10/file_example_JPG_100kB.jpg" caption="Caption 1"
            <p>Line</p>
        """.trimIndent()
```
Create a `placeholderManager` field:
```
    protected lateinit var placeholderManager: PlaceholderManager
```
and initialize it in `onCreate`: 
```
        placeholderManager = PlaceholderManager(visualEditor, findViewById(R.id.container_frame_layout))
        placeholderManager.registerAdapter(ImageWithCaptionAdapter())
```
and set it on `aztec` as media deleted listener and as a plugin: 
```
 aztec = Aztec.with(visualEditor, sourceEditor, toolbar, this)
                ...
                .addOnMediaDeletedListener(placeholderManager)
               ...
                .addPlugin(placeholderManager)
```

### Test
1. Launch the `MainActivity`
2. Press backspace behind the placeholder
3. Notice it disappears
4. Click on "undo"
5. Notice it jumps back

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.