### PR TITLE
Update a8c-ci-toolkit Buildkite plugin to new name and latest version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ agents:
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#2.14.0
 
 steps:
   - label: "Gradle Wrapper Validation"


### PR DESCRIPTION
## What

- Update the `bash-cache` Buildkite plugin name to `a8c-ci-toolkit`
- Update the `a8c-ci-toolkit` plugin to version `2.14.0` 

## Testing

Ensure that CI is green and that all checks passed.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR. N/A