### PR TITLE
Android 13 update target sdk to 33

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,16 @@
 
     <!-- Required for adding media and requested at runtime -->
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- Allows for storing and retrieving screenshots, photos, videos and audios -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
         android:label="@string/app_name"
@@ -43,5 +52,13 @@
         </provider>
 
     </application>
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+        </intent>
+        <!-- required for Android 11 (API level 30) or higher -->
+        <package android:name="com.wordpress.aztec" />
+    </queries>
 
 </manifest>

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -14,12 +14,14 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.provider.MediaStore
 import android.util.DisplayMetrics
+import android.util.Log
 import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
@@ -262,6 +264,7 @@ open class MainActivity : AppCompatActivity(),
                     val options = BitmapFactory.Options()
                     options.inDensity = DisplayMetrics.DENSITY_DEFAULT
                     val bitmap = BitmapFactory.decodeFile(mediaPath, options)
+                    Log.d("MediaPath", mediaPath)
                     insertImageAndSimulateUpload(bitmap, mediaPath)
                 }
                 REQUEST_MEDIA_PHOTO -> {
@@ -649,10 +652,20 @@ open class MainActivity : AppCompatActivity(),
         if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_CAMERA_PHOTO_PERMISSION_REQUEST_CODE)) {
             val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
 
-            mediaFile = "wp-" + System.currentTimeMillis() + ".jpg"
-            @Suppress("DEPRECATION")
-            mediaPath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM).toString() +
-                    File.separator + "Camera" + File.separator + mediaFile
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                mediaFile = "wp-" + System.currentTimeMillis()
+                mediaPath = File.createTempFile(
+                        mediaFile,
+                        ".jpg",
+                        getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+                ).absolutePath
+
+            } else {
+                mediaFile = "wp-" + System.currentTimeMillis() + ".jpg"
+                @Suppress("DEPRECATION")
+                mediaPath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM).toString() +
+                        File.separator + "Camera" + File.separator + mediaFile
+            }
             intent.putExtra(MediaStore.EXTRA_OUTPUT, FileProvider.getUriForFile(this,
                     BuildConfig.APPLICATION_ID + ".provider", File(mediaPath)))
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -2,12 +2,9 @@
 
 package org.wordpress.aztec
 
-import android.test.AndroidTestCase
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
-import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +15,7 @@ import org.robolectric.RuntimeEnvironment
  * Tests for [AztecParser].
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-class AztecParserTest(alignmentRendering: AlignmentRendering) : AndroidTestCase() {
+class AztecParserTest(alignmentRendering: AlignmentRendering) {
     private var mParser = AztecParser(alignmentRendering)
     private val HTML_BOLD = "<b>Bold</b><br><br>"
     private val HTML_LIST_ORDERED = "<ol><li>Ordered</li></ol>"
@@ -94,14 +91,6 @@ class AztecParserTest(alignmentRendering: AlignmentRendering) : AndroidTestCase(
                     arrayOf(AlignmentRendering.VIEW_LEVEL)
             )
         }
-    }
-
-    /**
-     * Initialize variables.
-     */
-    @Before
-    fun init() {
-        context = ApplicationProvider.getApplicationContext()
     }
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CalypsoFormattingTest.kt
@@ -2,12 +2,9 @@
 
 package org.wordpress.aztec
 
-import android.test.AndroidTestCase
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
-import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -15,7 +12,7 @@ import org.robolectric.RuntimeEnvironment
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-class CalypsoFormattingTest : AndroidTestCase() {
+class CalypsoFormattingTest {
     private var parser = AztecParser(AlignmentRendering.SPAN_LEVEL)
 
     private val HTML_LINE_BREAKS = "HI<br><br><br><br><br><br>BYE"
@@ -96,14 +93,6 @@ class CalypsoFormattingTest : AndroidTestCase() {
                     "<a href=\"https://github.com/wordpress-mobile/Word\\Press-Aztec-Android\">Link</a>\n" +
                     "<div class=\"sec $8 ond\"></div>\n" +
                     "</div>"
-
-    /**
-     * Initialize variables.
-     */
-    @Before
-    fun init() {
-        context = ApplicationProvider.getApplicationContext()
-    }
 
     /**
      * Test the conversion from HTML to visual mode with nested HTML (Calypso format)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/CssStyleAttributeTest.kt
@@ -2,9 +2,7 @@
 
 package org.wordpress.aztec
 
-import android.test.AndroidTestCase
 import android.text.SpannableString
-import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
 import org.junit.Before
 import org.junit.Test
@@ -17,7 +15,7 @@ import org.wordpress.aztec.spans.AztecStyleBoldSpan
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24, 25])
-class CssStyleAttributeTest : AndroidTestCase() {
+class CssStyleAttributeTest {
 
     private val EMPTY_STYLE_HTML = "<b>bold</b>"
     private val HTML = "<b style=\"name:value;\">bold</b>"
@@ -27,7 +25,6 @@ class CssStyleAttributeTest : AndroidTestCase() {
 
     @Before
     fun init() {
-        context = ApplicationProvider.getApplicationContext()
         parser = AztecParser(AlignmentRendering.SPAN_LEVEL)
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlAttributeStyleColorTest.kt
@@ -2,10 +2,8 @@
 
 package org.wordpress.aztec
 
-import android.test.AndroidTestCase
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
-import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
 import org.junit.Before
 import org.junit.Test
@@ -30,7 +28,7 @@ import org.wordpress.aztec.spans.IAztecAttributedSpan
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24, 25])
-class HtmlAttributeStyleColorTest : AndroidTestCase() {
+class HtmlAttributeStyleColorTest {
 
     private val HTML_BOLD_STYLE_COLOR = "<b style=\"color:blue;\">Blue</b>"
     private val HTML_BOLD_STYLE_INVALID = "<b style=\"color:@java;\">Blue</b>"
@@ -45,7 +43,6 @@ class HtmlAttributeStyleColorTest : AndroidTestCase() {
 
     @Before
     fun init() {
-        context = ApplicationProvider.getApplicationContext()
         parser = AztecParser(AlignmentRendering.SPAN_LEVEL)
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -2,11 +2,8 @@
 
 package org.wordpress.aztec
 
-import android.test.AndroidTestCase
 import android.text.SpannableString
-import androidx.test.core.app.ApplicationProvider
 import junit.framework.Assert
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -14,7 +11,7 @@ import org.robolectric.RuntimeEnvironment
 import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
-class HtmlFormattingTest : AndroidTestCase() {
+class HtmlFormattingTest {
 
     private var parser = AztecParser(AlignmentRendering.SPAN_LEVEL)
 
@@ -165,14 +162,6 @@ class HtmlFormattingTest : AndroidTestCase() {
             "<b>Test post</b><b> </b><br><br>Our room with a view[/caption] Test end"
     private val HTML_NESTED_BOLD_TAGS_HTML_PROCESSING_OUTPUT =
             "<b>Test post</b> <b></b><br><br>Our room with a view[/caption] Test end"
-
-    /**
-     * Initialize variables.
-     */
-    @Before
-    fun init() {
-        context = ApplicationProvider.getApplicationContext()
-    }
 
     /**
      * Test the conversion from HTML to visual mode with nested HTML

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://a8c-libs.s3.amazonaws.com/android" }
     }
     dependencies {
-        classpath 'com.automattic.android:configure:0.6.3'
+        classpath 'com.automattic.android:configure:0.6.5'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
     robolectricVersion = '4.9'
     jUnitVersion = '4.12'
     jSoupVersion = '1.11.3'
-    wordpressUtilsVersion = '3.4.0'
+    wordpressUtilsVersion = '3.5.0'
     espressoVersion = '3.0.1'
 
     aztecProjectDependency = project.hasProperty("aztecVersion") ? "org.wordpress:aztec:${project.getProperty("aztecVersion")}" : project(":aztec")

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
             }
         }
         google()
-        jcenter()
+        mavenCentral()
     }
     tasks.withType(KotlinCompile).all {
         kotlinOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
 ext {
     minSdkVersion = 24
     compileSdkVersion = 33
-    targetSdkVersion = 31
+    targetSdkVersion = 33
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
     robolectricVersion = '4.9'
     jUnitVersion = '4.12'
     jSoupVersion = '1.11.3'
-    wordpressUtilsVersion = 'trunk-1ed207c03d2242b6fc3d74f9e388e9163cbc82a6'
+    wordpressUtilsVersion = '3.4.0'
     espressoVersion = '3.0.1'
 
     aztecProjectDependency = project.hasProperty("aztecVersion") ? "org.wordpress:aztec:${project.getProperty("aztecVersion")}" : project(":aztec")


### PR DESCRIPTION
### Fix #1035 and #1036

This PR updates the following for Android 13
- `targetSdkVersion` from 31 to 33
- `Utils` version to 3.5.0
- `configure` version to 0.6.5


<img src="https://user-images.githubusercontent.com/2471769/225133639-7a85f370-0bf1-4c2b-b52c-8702c08ec34a.png" width=300>


### Test
Being able to build and basic smoke test should be enough.

1. Run AztecDemo app.
2. Scroll down and find the HTML block (It's shown as "?", below "if (value == 5) printf(value)")
3. Tap the HTML block and type a long text to increase the dialog size.
4. Ensure "CANCEL", "SAVE" buttons are still visible and there is a margin between the keyboard and dialog.

### Review
@irfano 
@fluiddot 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.