### PR TITLE
Issue/880 center point not in rectangle

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -65,9 +65,7 @@ class AztecExceptionHandler(private var logHelper: WeakReference<ExceptionHandle
                 visualEditor.get()?.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
             }
         // See: https://github.com/wordpress-mobile/AztecEditor-Android/issues/880
-        } else if (ex is java.lang.IllegalArgumentException &&
-                Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU &&
-                ex.message?.contains("Center point is not inside any of the rectangles") == true) {
+        } else if (ex is java.lang.IllegalArgumentException && ex.message?.contains("Center point is not inside any of the rectangles") == true) {
             visualEditor.get()?.externalLogger?.logException(ex)
             return
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -64,12 +64,7 @@ class AztecExceptionHandler(private var logHelper: WeakReference<ExceptionHandle
             if (detected) {
                 visualEditor.get()?.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
             }
-        // See: https://github.com/wordpress-mobile/AztecEditor-Android/issues/880
-        } else if (ex is java.lang.IllegalArgumentException && ex.message?.contains("Center point is not inside any of the rectangles") == true) {
-            visualEditor.get()?.externalLogger?.logException(ex)
-            return
         }
-
         rootHandler?.uncaughtException(thread, ex)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -65,7 +65,9 @@ class AztecExceptionHandler(private var logHelper: WeakReference<ExceptionHandle
                 visualEditor.get()?.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
             }
         // See: https://github.com/wordpress-mobile/AztecEditor-Android/issues/880
-        } else if (ex is java.lang.IllegalArgumentException && ex.message?.contains("Center point is not inside any of the rectangles") == true) {
+        } else if (ex is java.lang.IllegalArgumentException &&
+                Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU &&
+                ex.message?.contains("Center point is not inside any of the rectangles") == true) {
             visualEditor.get()?.externalLogger?.logException(ex)
             return
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecExceptionHandler.kt
@@ -64,6 +64,10 @@ class AztecExceptionHandler(private var logHelper: WeakReference<ExceptionHandle
             if (detected) {
                 visualEditor.get()?.externalLogger?.logException(DynamicLayoutGetBlockIndexOutOfBoundsException("Error #8828", ex))
             }
+        // See: https://github.com/wordpress-mobile/AztecEditor-Android/issues/880
+        } else if (ex is java.lang.IllegalArgumentException && ex.message?.contains("Center point is not inside any of the rectangles") == true) {
+            visualEditor.get()?.externalLogger?.logException(ex)
+            return
         }
 
         rootHandler?.uncaughtException(thread, ex)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1891,6 +1891,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     return super.onTextContextMenuItem(id)
                 }
             }
+            android.R.id.selectAll -> {
+                return if (text.toString() == Constants.END_OF_BUFFER_MARKER.toString()) {
+                    deleteInlineStyleFromTheBeginning()
+                    return true
+                } else {
+                    super.onTextContextMenuItem(id)
+                }
+            }
             else -> return super.onTextContextMenuItem(id)
         }
 


### PR DESCRIPTION
Fixes #880 

We have 37 Sentry users experiencing the "IllegalArgumentException: Center point is not inside any of the rectangles" crash [in Day One](2255-gh-bloom/DayOne-Android), all of which are on Android 13 (Tiramisu). This appears to be a platform issue rather than a problem with Aztec itself.

**Update:** It turns out the crash isn't limited to Android 13.

This PR resolves the problem by detecting and ignoring that crash on Android 13. I'm not well-versed with the Aztec codebase, so if there's a better way to resolve this please let me know.

To test:

- In trunk, clear the example app's editor
- Long press in the empty editor
- Choose "Select all"
- Boom!
- Then pull this branch and observe the problem no longer occurs

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.