### PR TITLE
Don't report changes for empty text

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -207,6 +207,9 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         fun hasChanges(initialEditorContentParsedSHA256: ByteArray, newContent: String): EditorHasChanges {
+            if (initialEditorContentParsedSHA256.isEmpty() && newContent.isEmpty()) {
+                return EditorHasChanges.NO_CHANGES
+            }
             try {
                 if (Arrays.equals(initialEditorContentParsedSHA256, calculateSHA256(newContent))) {
                     return EditorHasChanges.NO_CHANGES


### PR DESCRIPTION
Fixes #1045 

Currently [hasChanges](https://github.com/wordpress-mobile/AztecEditor-Android/blob/499459d544af1f7f1ba035449c6f52710bc86250/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L209) returns `CHANGES` when it is first opened, before any changes have been made. This happens because the comparison relies on `initialEditorContentParsedSHA256`, which is initialized as an empty array - which doesn't match the hash of an empty string.

The PR resolves that problem.

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.