### PR TITLE
Do not remove empty line after a paragraph

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -567,8 +567,8 @@ class AztecParser @JvmOverloads constructor(private val alignmentRendering: Alig
             i = next
         }
 
-        for (z in 0..nl - 1) {
-            val parentSharesEnd = parents?.any { text.getSpanEnd(it) == end + 1 + z } ?: false
+        for (z in 0 until nl) {
+            val parentSharesEnd = parents?.any { text.getSpanEnd(it) == end + z } ?: false
             if (parentSharesEnd) {
                 continue
             }


### PR DESCRIPTION
### Fix
Changes necessary to stop removing empty line between paragraphs.

### Test
1. Use the linked PR to test it
### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.