### PR TITLE
Fix crash when history cache file is missing

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -946,10 +946,18 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         val list = LinkedList<String>()
 
         list += array
+        val historyCursor = customState.getInt(HISTORY_CURSOR_KEY)
+        // if cursor does not match the number of history entries, it means the temp file with history has been deleted
+        if (historyCursor == list.size) {
+            history.historyList = list
+            history.historyCursor = historyCursor
+            history.inputLast = InstanceStateUtils.readAndPurgeTempInstance<String>(
+                INPUT_LAST_KEY,
+                "",
+                savedState.state
+            )
+        }
 
-        history.historyList = list
-        history.historyCursor = customState.getInt(HISTORY_CURSOR_KEY)
-        history.inputLast = InstanceStateUtils.readAndPurgeTempInstance<String>(INPUT_LAST_KEY, "", savedState.state)
         visibility = customState.getInt(VISIBILITY_KEY)
 
         customState.getByteArray(RETAINED_INITIAL_HTML_PARSED_SHA256_KEY)?.let {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -947,15 +947,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         list += array
         val historyCursor = customState.getInt(HISTORY_CURSOR_KEY)
+        val inputLast = InstanceStateUtils.readAndPurgeTempInstance(INPUT_LAST_KEY, "", savedState.state)
         // if cursor does not match the number of history entries, it means the temp file with history has been deleted
         if (historyCursor == list.size) {
             history.historyList = list
             history.historyCursor = historyCursor
-            history.inputLast = InstanceStateUtils.readAndPurgeTempInstance<String>(
-                INPUT_LAST_KEY,
-                "",
-                savedState.state
-            )
+            history.inputLast = inputLast
         }
 
         visibility = customState.getInt(VISIBILITY_KEY)


### PR DESCRIPTION
This PR fixes a crash that can happen when Aztec state with history is restored, but the history cache file was removed by OS.

This crash is pretty rare, but can happen on devices with low storage, when you reopen editor that was destroyed by OS (usually happens if you don't open it for some time).

### Test
1. For easier access to file system consider using an emulator.
2. Enabled "Do not keep activities".
3. Open editor, and make a couple of changes.
4. Confirm that the changes are added to history.
5. Minimize the app.
6. From AS device manager, open file browser of the emulator.
7. Navigate to `data/data/org.wordpress.aztec/cache`
8. Delete files that start with `HISTORY_LIST_KEY`.
9. Go back to the editor from app drawer.
10. Confirm that the app is not crashing, and there is no history.

### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.