### PR TITLE
Fix highlight function in the editor

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -363,6 +363,8 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
             start(spannableStringBuilder, AztecTextFormat.FORMAT_CODE, attributes);
         } else if (tag.equalsIgnoreCase("mark")) {
             start(spannableStringBuilder, AztecTextFormat.FORMAT_MARK, attributes);
+        } else if (tag.equalsIgnoreCase("highlight")) {
+            start(spannableStringBuilder, AztecTextFormat.FORMAT_HIGHLIGHT, attributes);
         } else if (!UnknownHtmlSpan.Companion.getKNOWN_TAGS().contains(tag.toLowerCase())) {
             // Initialize a new "Unknown" node
             if (contentHandlerLevel == 0) {
@@ -458,6 +460,8 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
             end(spannableStringBuilder, AztecTextFormat.FORMAT_CODE);
         } else if (tag.equalsIgnoreCase("mark")) {
             end(spannableStringBuilder, AztecTextFormat.FORMAT_MARK);
+        } else if (tag.equalsIgnoreCase("highlight")) {
+            end(spannableStringBuilder, AztecTextFormat.FORMAT_HIGHLIGHT);
         }
     }
 
@@ -615,6 +619,9 @@ class HtmlToSpannedConverter implements org.xml.sax.ContentHandler, LexicalHandl
                 break;
             case FORMAT_MARK:
                 span = (MarkSpan) getLast(text, MarkSpan.class);
+                break;
+            case FORMAT_HIGHLIGHT:
+                span = (HighlightSpan) getLast(text, HighlightSpan.class);
                 break;
             default:
                 throw new IllegalArgumentException("Style not supported");

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -295,6 +295,5 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
         private val VIDEO = "video"
         private val AUDIO = "audio"
         private val LINE = "hr"
-        private val MARK = "mark"
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1857,6 +1857,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_CODE, start, end)
         inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_BACKGROUND, start, end)
         inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_MARK, start, end)
+        inlineFormatter.removeInlineStyle(AztecTextFormat.FORMAT_HIGHLIGHT, start, end)
     }
 
     fun removeBlockStylesFromRange(start: Int, end: Int, ignoreLineBounds: Boolean = false) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -442,7 +442,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
             AztecTextFormat.FORMAT_CODE -> AztecCodeSpan(codeStyle)
             AztecTextFormat.FORMAT_BACKGROUND -> AztecBackgroundColorSpan(backgroundSpanColor ?: R.color.background)
             AztecTextFormat.FORMAT_HIGHLIGHT -> {
-                HighlightSpan(highlightStyle = highlightStyle, context = editor.context)
+                HighlightSpan.create(context = editor.context, defaultStyle = highlightStyle)
             }
             AztecTextFormat.FORMAT_MARK -> MarkSpan()
             else -> AztecStyleSpan(Typeface.NORMAL)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
@@ -13,8 +13,6 @@ class HighlightSpan(
         override var attributes: AztecAttributes = AztecAttributes(),
         val colorHex: Int
 ) : BackgroundColorSpan(colorHex), IAztecInlineSpan {
-    var alpha: Int = 220
-
     override var TAG = HIGHLIGHT_TAG
 
     companion object {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/HighlightSpan.kt
@@ -6,16 +6,42 @@ import androidx.core.content.ContextCompat
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.R
 import org.wordpress.aztec.formatting.InlineFormatter
+import org.wordpress.aztec.source.CssStyleFormatter
+import org.wordpress.aztec.util.ColorConverter
 
 class HighlightSpan(
         override var attributes: AztecAttributes = AztecAttributes(),
-        highlightStyle: InlineFormatter.HighlightStyle = InlineFormatter.HighlightStyle(R.color.grey_lighten_10),
-        context: Context
-) : BackgroundColorSpan(ContextCompat.getColor(context, highlightStyle.color)), IAztecInlineSpan {
+        val colorHex: Int
+) : BackgroundColorSpan(colorHex), IAztecInlineSpan {
+    var alpha: Int = 220
 
-    override var TAG = "highlight"
+    override var TAG = HIGHLIGHT_TAG
+
     companion object {
+        const val HIGHLIGHT_TAG = "highlight"
+
         @JvmStatic
-        fun create(attributes: AztecAttributes, context: Context) = HighlightSpan(attributes = attributes, context = context)
+        @JvmOverloads
+        fun create(attributes: AztecAttributes = AztecAttributes(),
+                   context: Context,
+                   defaultStyle: InlineFormatter.HighlightStyle? = null
+        ) = HighlightSpan(attributes = attributes,
+                colorHex = buildColor(context, attributes, defaultStyle))
+
+        private fun buildColor(context: Context, attrs: AztecAttributes, defaultStyle: InlineFormatter.HighlightStyle?): Int {
+            return if (CssStyleFormatter.containsStyleAttribute(
+                            attrs,
+                            CssStyleFormatter.CSS_BACKGROUND_COLOR_ATTRIBUTE
+                    )
+            ) {
+                val att = CssStyleFormatter.getStyleAttribute(attrs,
+                        CssStyleFormatter.CSS_BACKGROUND_COLOR_ATTRIBUTE)
+                return ColorConverter.getColorInt(att)
+            } else if (defaultStyle != null) {
+                ContextCompat.getColor(context, defaultStyle.color)
+            } else {
+                ContextCompat.getColor(context, R.color.grey_lighten_10)
+            }
+        }
     }
 }


### PR DESCRIPTION
### Fix
Highlight action was only partially implemented in the Aztec editor. This PR fixes that. The color for highlight can come from 2 places. It's either set in parameters or it can be passed as part of the css styles (this takes precedence over android styles). 

### Test
Test this with the linked PR

### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.