### PR TITLE
Fix issue when removing media in the middle of a paragraph

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2254,16 +2254,15 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                                     text.getSpanEnd(blockSpan),
                                     text.getSpanFlags(blockSpan)
                             )
-                        }
+                        }.filter { it.start >= start }
                         spans.forEach { temporarySpan ->
                             text.removeSpan(temporarySpan)
                         }
                         text.delete(start, endPlus1)
                         spans.forEach { temporarySpan ->
-                            val newStart = if (temporarySpan.start >= start) temporarySpan.start - 2 else temporarySpan.start
                             text.setSpan(
                                     temporarySpan.span,
-                                    newStart.coerceAtLeast(0),
+                                    (temporarySpan.start - 2).coerceAtLeast(0),
                                     (temporarySpan.end - 2).coerceAtMost(text.length),
                                     temporarySpan.flags
                             )

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2260,9 +2260,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                         }
                         text.delete(start, endPlus1)
                         spans.forEach { temporarySpan ->
+                            val newStart = if (temporarySpan.start >= start) temporarySpan.start - 2 else temporarySpan.start
                             text.setSpan(
                                     temporarySpan.span,
-                                    (temporarySpan.start - 2).coerceAtLeast(0),
+                                    newStart.coerceAtLeast(0),
                                     (temporarySpan.end - 2).coerceAtMost(text.length),
                                     temporarySpan.flags
                             )

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ImageBlockTest.kt
@@ -278,4 +278,38 @@ class ImageBlockTest {
 
         Assert.assertEquals(initialHtml, editText.toHtml())
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun removeImageInSpanBeforeBlankLine() {
+        val initialHtml = "<p>Line 1</p><p>Line 2<img id=\"1234\" /><br>Line 3</p><p>Line 4</p>"
+        editText.fromHtml(initialHtml)
+
+        editText.setSelection(1)
+
+        editText.removeMedia(object : AztecText.AttributePredicate {
+            override fun matches(attrs: Attributes): Boolean {
+                return attrs.getValue("id") == "1234"
+            }
+        })
+
+        Assert.assertEquals("<p>Line 1</p><p>Line 2<br><br>Line 3</p><p>Line 4</p>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun removeImageInSpanAfterBlankLine() {
+        val initialHtml = "<p>Line 1</p><p>Line 2<br><img id=\"1234\" />Line 3</p><p>Line 4</p>"
+        editText.fromHtml(initialHtml)
+
+        editText.setSelection(1)
+
+        editText.removeMedia(object : AztecText.AttributePredicate {
+            override fun matches(attrs: Attributes): Boolean {
+                return attrs.getValue("id") == "1234"
+            }
+        })
+
+        Assert.assertEquals("<p>Line 1</p><p>Line 2<br>Line 3</p><p>Line 4</p>", editText.toHtml())
+    }
 }


### PR DESCRIPTION
### Fix
This PR fixes a crash that's happening when a media item is removed in the middle of a paragraph. The fix is to ignore the spans that are wrapping the media, only to handle the ones starting right after the media end.

### Test
1. Run the unit tests without the fix
2. Notice the `PARAGRAPH span must start at paragraph boundary` exception
3. Run the unit tests with the fix

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.