### PR TITLE
Make setSelection safe

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -2433,6 +2433,18 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         this.uncaughtExceptionHandler = null
     }
 
+    override fun setSelection(index: Int) {
+        if (index in 0..this.length()) {
+            super.setSelection(index)
+        } else if (index < 0) {
+            AppLog.e(AppLog.T.EDITOR, "Attempted to set selection to incorrect value $index")
+            setSelection(0)
+        } else if (index > this.length()) {
+            AppLog.e(AppLog.T.EDITOR, "Attempted to set selection to incorrect value $index")
+            setSelection(this.length())
+        }
+    }
+
     override fun dispatchHoverEvent(event: MotionEvent): Boolean {
         return if (accessibilityDelegate.onHoverEvent(event)) true else super.dispatchHoverEvent(event)
     }


### PR DESCRIPTION
### Fix
We're having occasional issues when the `setSelection` is called out of bounds of the text. While it would be better to fix the underlying issues, I think this is a safe approach to handling this. What usually crashes the app is something like this: 

- Preserve cursor position N at the end of text
- Set the cursor position to 0
- Do some modification to the text that shorten the text to N - 1
- Try to set the cursor position to N
- Crash because text length is N-1 < N

This solution handles that case and if this happens, sets the selection to N-1 instead. I can't think of a case where this might be an issue but let me know if you think it's unsafe.

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.