### PR TITLE
Do not iterate in while when history cursor is outside of list range

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -61,7 +61,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
             return
         }
 
-        while (historyCursor != historyList.size && historyCursor >= 0) {
+        while (historyCursor in 0 until historyList.size) {
             historyList.removeAt(historyCursor)
         }
 


### PR DESCRIPTION
### Fix

This PR fixes the following crash. We shouldn't iterate the list if the cursor points out of it.

```
IndexOutOfBoundsException: Index: 10, Size: 0
    at java.util.LinkedList.checkElementIndex(LinkedList.java:559)
    at java.util.LinkedList.remove(LinkedList.java:529)
    at org.wordpress.aztec.History.doHandleHistory(History.kt:65)
    at org.wordpress.aztec.History$HistoryRunnable.run(History.kt:0)
    at android.os.Handler.handleCallback(Handler.java:938)
```


### Test
1. I think this is a race condition so there is no way to test this

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.