### PR TITLE
[Nullability Annotations to Java Classes] Add `wordpress.lint` Dependency

### DIFF
--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
     implementation 'org.apache.commons:commons-lang3:3.8.1'
+
+    lintChecks "org.wordpress:lint:$wordpressLintVersion"
 }
 
 project.afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ ext {
 }
 
 ext {
+    // mixed
     gradlePluginVersion = '3.3.1'
     kotlinCoroutinesVersion = '1.6.4'
     tagSoupVersion = '1.2.1'
@@ -80,5 +81,9 @@ ext {
     wordpressUtilsVersion = '3.5.0'
     espressoVersion = '3.0.1'
 
+    // other
+    wordpressLintVersion = '2.0.0'
+
+    // project
     aztecProjectDependency = project.hasProperty("aztecVersion") ? "org.wordpress:aztec:${project.getProperty("aztecVersion")}" : project(":aztec")
 }


### PR DESCRIPTION
This PR adds `wordPress-lint` checks to the project ([2.0.0](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.0.0)).

FYI: Since the `aztec` module is still using Java files in it, it makes sense to utilize the `org.wordpress:lint` library on it. All other modules are all Kotlin, with no Java files in it. As such, there is no point in utilizing the `org.wordpress:lint` library on any other module.

-----

## To test:

1. Verifying that all the CI checks are successful (focus on the Lint related [check](https://buildkite.com/automattic/azteceditor-android/builds/559#018b620f-6c5b-4804-9721-9d08a66122eb) and its [report](https://buildkiteartifacts.com/b26f1746-2f0c-49cc-bbd1-a45a5e24c351/ea79608f-290b-49b2-807a-7aa13b8c8ce1/018b620f-496d-4ebc-b11e-13d10d1261b4/018b620f-6c5b-4804-9721-9d08a66122eb/aztec/build/reports/lint-results-release.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LXOOZVLPI%2F20231024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231024T143313Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEBkaCXVzLWVhc3QtMSJHMEUCIQDXsYJdZJXV9k6kya2cMAwE%2Fi%2BWxIryOHQJcl%2BzhKQOdwIgWUcR9h8V1mkVddeHREDNagWejv%2BHl%2FZIKgVHImVASeUq8QMIQhAAGgwwMzIzNzk3MDUzMDMiDOZ6mNxoH1eytuF%2BfyrOAyGM91t7Gu1wpFCqlIzE9RC9gAgI0g4UbxsWW6GKZJ%2BFJ2QiTKVRWgwbylJl5e8dW57p8PPohBmoBAzMCwhZqQTAPHw2j2uPYRQnfnwWDmkYKsIZf9g3COcijpWKCQWfNPwXACiuw%2Br8Q5f86tM2KC%2BYNKrEuWTwKR3cwVtBGuynPgT7iv8HviADHZdoTMWw5Akr%2FprQmKlW5XtPIBtq20JAknNFj4luObKNXRBuNN1aNPH0cHh3NZXpACORaFiKzDeJaVkMqEca8y1bRchc7myWpFjHUUZjS%2B888Fr1izm8W7duKJUh14fSHyYveLcClzgGaoB4oZUE5DmPBskZEbV39rw66wyLtc0wD8Sh1V%2Fl%2FQrat8hR3zy4XPdlQ%2FpcLpVbFD0SDTP22%2BOXV0nWpHCB7a9q4c3ht8%2FNdGlih2aSC39Dyt6iP%2FNypy%2FmN7PazIWDyXlLuleW06eKfOG7WUhxzYz25GS3Ysv9UvmGP76liYHVZZAdY9%2B1KPyf%2BVR9cz1Js47zULWeVjq0p4XrxLPsTytND%2BmY%2BkwxyvmLV6YyoD006v7qbgT61eWLo0AIFJrQlAJLEXfuwRCnAtyLxAq52IWulIKAOOLALkffUTD6jN6pBjqlAQ8A33f2wndeNce9sX4UTZ6%2BGBxqZCY8eIJzdiCYUhYE88X8ihcTi%2BRg1K4mu47vLnz2SnlVXYGjcPFqJi5h5ay2ZmqolAO0t7Txf4NwBnz7rkoW9Gk%2F4MN%2FHDQ1x69SXpPNujxQ2xTZvQAQg3gIUrnjTiHStl%2FDIFQ%2Bun%2B8fH%2BWTvCDtJxRkrRbNBXfihJ7Thw0OeSuqIq9QK23fg%2BhBRMN3wP0xg%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=448302cdb847ab1a58583681cef2a1d06c695d19a99e4b9483decafb84f76792)).
2. Verify that the new `MissingNullAnnotationOn*` correctness related rules are reporting as expected. For a reference, see screenshot below:

`aztec` module:

![image](https://github.com/wordpress-mobile/AztecEditor-Android/assets/9729923/db9bb43d-d836-431a-8daa-70fc60416df8)
