### PR TITLE
Address `NullPointerException` crash in `AztecHeadingSpan`

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -127,10 +127,10 @@ open class AztecHeadingSpan(
         // save original font metrics
         if (previousFontMetrics == null) {
             previousFontMetrics = Paint.FontMetricsInt()
-            previousFontMetrics!!.top = fm.top
-            previousFontMetrics!!.ascent = fm.ascent
-            previousFontMetrics!!.bottom = fm.bottom
-            previousFontMetrics!!.descent = fm.descent
+            previousFontMetrics?.top = fm.top
+            previousFontMetrics?.ascent = fm.ascent
+            previousFontMetrics?.bottom = fm.bottom
+            previousFontMetrics?.descent = fm.descent
         }
 
         var addedTopPadding = false
@@ -151,13 +151,17 @@ open class AztecHeadingSpan(
 
         // apply original font metrics to lines that should not have vertical padding
         if (!addedTopPadding) {
-            fm.ascent = previousFontMetrics!!.ascent
-            fm.top = previousFontMetrics!!.top
+            previousFontMetrics?.let {
+                fm.ascent = it.ascent
+                fm.top = it.top
+            }
         }
 
         if (!addedBottomPadding) {
-            fm.descent = previousFontMetrics!!.descent
-            fm.bottom = previousFontMetrics!!.bottom
+            previousFontMetrics?.let {
+                fm.descent = it.descent
+                fm.bottom = it.bottom
+            }
         }
     }
 


### PR DESCRIPTION
A potential fix for the crash described at https://github.com/wordpress-mobile/WordPress-Android/issues/18657.

### Related PRs

* `Gutenberg`: https://github.com/WordPress/gutenberg/pull/56757
* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6435
* `Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/19724

### Description

Sentry has been reporting the following crash for both the WordPress and Jetpack Android apps:

```
NullPointerException
org.wordpress.aztec.spans.AztecHeadingSpan in chooseHeight
```

The stack trace for each individual event specifically references one of the following lines (the specific line varies for each event), all of which are within the `chooseHeight` function and include a reference to `previousFontMetrics`:

* [Line 131](https://github.com/wordpress-mobile/AztecEditor-Android/blob/d93ce9f3a2a6cafdb0c05a630e2bdff5275d6f9f/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt#L131)
* [Line 132](https://github.com/wordpress-mobile/AztecEditor-Android/blob/d93ce9f3a2a6cafdb0c05a630e2bdff5275d6f9f/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt#L132)
* [Line 155](https://github.com/wordpress-mobile/AztecEditor-Android/blob/d93ce9f3a2a6cafdb0c05a630e2bdff5275d6f9f/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt#L155)
* [Line 159](https://github.com/wordpress-mobile/AztecEditor-Android/blob/d93ce9f3a2a6cafdb0c05a630e2bdff5275d6f9f/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt#L159)
* [Line 160](https://github.com/wordpress-mobile/AztecEditor-Android/blob/d93ce9f3a2a6cafdb0c05a630e2bdff5275d6f9f/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt#L160)

As described at https://github.com/wordpress-mobile/WordPress-Android/issues/18657#issuecomment-1835995579, it has proven difficult to reproduce this crash. It's suspected that there are specific instances with lower performing devices or devices on poor connections that can lead to `previousFontMetrics` being set as null elsewhere in the code while `chooseHeight` is running.

Given the difficulty reproducing, it hasn't been possible to get to the heart of this issue. Instead, with this PR, the previous non-null assertions previously used with `previousFontMetrics` have been replaced with safe calls. With this approach, the functionality should remain the same, while guarding against `NullPointerException` crashes.

### Test

#### Verify Aztec demo continues to function as expected

1. Load the Aztec demo with this PR's changes applied.
2. Verify that you can add headings with no unexpected side effects.

#### Verify Gutenberg continues to function as expected

1. Using the installable build available from https://github.com/wordpress-mobile/WordPress-Android/pull/19724, install the app and navigate to the post editor.
2. Add some heading blocks and ensure there are no unexpected side effects when performing tasks. Example tasks to test include splitting the block, applying new font sizes and line heights, etc. 