### PR TITLE
Improve Mark formatting

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1344,6 +1344,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             AztecTextFormat.FORMAT_CODE -> inlineFormatter.toggle(textFormat)
             AztecTextFormat.FORMAT_BOLD,
             AztecTextFormat.FORMAT_STRONG -> inlineFormatter.toggleAny(ToolbarAction.BOLD.textFormats)
+            AztecTextFormat.FORMAT_MARK -> inlineFormatter.toggle(textFormat)
             AztecTextFormat.FORMAT_UNORDERED_LIST -> blockFormatter.toggleUnorderedList()
             AztecTextFormat.FORMAT_TASK_LIST -> blockFormatter.toggleTaskList()
             AztecTextFormat.FORMAT_ORDERED_LIST -> blockFormatter.toggleOrderedList()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -109,6 +109,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
                     }
                     AztecTextFormat.FORMAT_MARK -> {
                         applyInlineStyle(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)
+                        applyAfterMarkInlineStyle(textChangedEvent.inputStart, textChangedEvent.inputEnd)
                     }
                     else -> {
                         // do nothing
@@ -246,27 +247,32 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
         }
     }
 
-    public fun updateMarkStyle(start: Int = selectionStart, end: Int = selectionEnd) {
+    private fun applyAfterMarkInlineStyle(start: Int = selectionStart, end: Int = selectionEnd) {
+        // If there's no new mark style color to update, it skips applying the style updates.
+        if (markStyleColor == null) {
+            return
+        }
+
         val spans = editableText.getSpans(start, end, MarkSpan::class.java)
         spans.forEach { span ->
             if (span != null) {
-                val currentSpanStart = editableText.getSpanStart(span)
-                val currentSpanEnd = editableText.getSpanEnd(span)
                 val color = span.getTextColor()
+                val currentSpanStart = editableText.getSpanStart(span)
 
                 editableText.removeSpan(span)
                 editableText.setSpan(
                     MarkSpan(AztecAttributes(), color),
                     currentSpanStart,
-                    currentSpanEnd,
+                    start,
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
                 editableText.setSpan(
                     MarkSpan(AztecAttributes(), markStyleColor),
                     start,
                     end,
-                    Spanned.SPAN_INCLUSIVE_INCLUSIVE
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
+                markStyleColor = null;
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -127,8 +127,8 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
 
         // Clear Mark formatting styles
         if (!editor.selectedStyles.contains(AztecTextFormat.FORMAT_MARK) && start >= 1 && end > 1 ) {
-            val previousMarkSpan = editableText.getSpans(start - 1, start, MarkSpan::class.java);
-            val markSpan = editableText.getSpans(start, end, MarkSpan::class.java);
+            val previousMarkSpan = editableText.getSpans(start - 1, start, MarkSpan::class.java)
+            val markSpan = editableText.getSpans(start, end, MarkSpan::class.java)
             if (markSpan.isNotEmpty() || (previousMarkSpan.isNotEmpty() && markStyleColor == null)) {
                 removeInlineCssStyle(start, end)
                 return

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -272,7 +272,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
                     end,
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
-                markStyleColor = null;
+                markStyleColor = null
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -37,10 +37,10 @@ import org.wordpress.aztec.watchers.TextChangedEvent
 class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val highlightStyle: HighlightStyle) : AztecFormatter(editor) {
 
     var backgroundSpanColor: Int? = null
+    var markStyleColor: String? = null
 
     data class CodeStyle(val codeBackground: Int, val codeBackgroundAlpha: Float, val codeColor: Int)
     data class HighlightStyle(@ColorRes val color: Int)
-    var markStyleColor: String? = null
 
     fun toggle(textFormat: ITextFormat) {
         if (!containsInlineStyle(textFormat)) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -133,6 +133,14 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
             return
         }
 
+        // Remove leading Mark formatting styles if the format is not active
+        if (!editor.selectedStyles.contains(AztecTextFormat.FORMAT_MARK) && newStart >=1 && end > 1) {
+            val markSpan = editableText.getSpans(newStart - 1, newStart, MarkSpan::class.java);
+            if (markSpan.isNotEmpty()) {
+                removeInlineCssStyle(newStart, end)
+            }
+        }
+
         editableText.getSpans(newStart, end, IAztecInlineSpan::class.java).forEach {
             if (!editor.selectedStyles.contains(spanToTextFormat(it)) || ignoreSelectedStyles || (newStart == 0 && end == 0) ||
                     (newStart > end && editableText.length > end && editableText[end] == '\n')) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -129,7 +129,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, private val h
         if (!editor.selectedStyles.contains(AztecTextFormat.FORMAT_MARK) && start >= 1 && end > 1 ) {
             val previousMarkSpan = editableText.getSpans(start - 1, start, MarkSpan::class.java)
             val markSpan = editableText.getSpans(start, end, MarkSpan::class.java)
-            if (markSpan.isNotEmpty() || (previousMarkSpan.isNotEmpty() && markStyleColor == null)) {
+            if (markSpan.isNotEmpty() || previousMarkSpan.isNotEmpty()) {
                 removeInlineCssStyle(start, end)
                 return
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/plugins/MarkPlugin.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/plugins/MarkPlugin.kt
@@ -1,0 +1,25 @@
+package org.wordpress.aztec.plugins
+
+import android.text.SpannableStringBuilder
+import org.wordpress.aztec.plugins.visual2html.ISpanPreprocessor
+import org.wordpress.aztec.source.CssStyleFormatter
+import org.wordpress.aztec.spans.MarkSpan
+
+class MarkPlugin : ISpanPreprocessor {
+
+    override fun beforeSpansProcessed(spannable: SpannableStringBuilder) {
+        spannable.getSpans(0, spannable.length, MarkSpan::class.java).forEach {
+            if (!CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleFormatter.CSS_BACKGROUND_COLOR_ATTRIBUTE)) {
+                CssStyleFormatter.addStyleAttribute(it.attributes, CssStyleFormatter.CSS_BACKGROUND_COLOR_ATTRIBUTE, "rgba(0, 0, 0, 0)")
+            }
+
+            if (!CssStyleFormatter.containsStyleAttribute(it.attributes, CssStyleFormatter.CSS_COLOR_ATTRIBUTE)) {
+                CssStyleFormatter.addStyleAttribute(it.attributes, CssStyleFormatter.CSS_COLOR_ATTRIBUTE, it.getTextColor())
+            }
+
+            if (!it.attributes.hasAttribute("class")) {
+                it.attributes.setValue("class", "has-inline-color")
+            }
+        }
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
@@ -10,38 +10,36 @@ class MarkSpan : CharacterStyle, IAztecInlineSpan {
     override var TAG = "mark"
 
     override var attributes: AztecAttributes = AztecAttributes()
-    var textColor: Int? = null
+    private val textColorValue: Int?
 
     constructor(attributes: AztecAttributes = AztecAttributes()) : super() {
         this.attributes = attributes
 
         val color = CssStyleFormatter.getStyleAttribute(attributes,
             CssStyleFormatter.CSS_COLOR_ATTRIBUTE)
-        if (color.isNotEmpty()) {
-            textColor = Color.parseColor(color)
+        textColorValue = if (color.isNotEmpty()) {
+            Color.parseColor(color)
+        } else {
+            null
         }
     }
 
     constructor(attributes: AztecAttributes = AztecAttributes(), colorString: String?) : super() {
         this.attributes = attributes
 
-        if (colorString != null) {
-            textColor = Color.parseColor(colorString)
+        textColorValue = if (colorString != null) {
+            Color.parseColor(colorString)
+        } else {
+            null
         }
     }
 
     override fun updateDrawState(tp: TextPaint) {
-        configureTextPaint(tp)
-    }
-
-    private fun configureTextPaint(tp: TextPaint) {
-        if (textColor != null) {
-            tp.color = textColor as Int
-        }
+        textColorValue?.let { tp.color = it }
     }
 
     fun getTextColor(): String {
-        val currentColor = textColor ?: 0
+        val currentColor = textColorValue ?: 0
         return String.format("#%06X", 0xFFFFFF and currentColor)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
@@ -34,6 +34,7 @@ class MarkSpan : CharacterStyle, IAztecInlineSpan {
     }
 
     fun getTextColor(): String {
-        return java.lang.String.format("#%06X", 0xFFFFFF and textColor!!)
+        val currentColor = textColor ?: 0
+        return String.format("#%06X", 0xFFFFFF and currentColor)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
@@ -1,12 +1,40 @@
 package org.wordpress.aztec.spans
 
+import android.graphics.Color
 import android.text.TextPaint
 import android.text.style.CharacterStyle
 import org.wordpress.aztec.AztecAttributes
 
-class MarkSpan(override var attributes: AztecAttributes = AztecAttributes()) : CharacterStyle(), IAztecInlineSpan {
+
+class MarkSpan : CharacterStyle, IAztecInlineSpan {
     override var TAG = "mark"
 
-    override fun updateDrawState(tp: TextPaint?) {
+    override var attributes: AztecAttributes = AztecAttributes()
+    var textColor: Int? = null
+
+    constructor(attributes: AztecAttributes = AztecAttributes()) : super() {
+        this.attributes = attributes
+    }
+
+    constructor(attributes: AztecAttributes = AztecAttributes(), colorString: String?) : super() {
+        this.attributes = attributes
+
+        if (colorString != null) {
+            textColor = Color.parseColor(colorString)
+        }
+    }
+
+    override fun updateDrawState(tp: TextPaint) {
+        configureTextPaint(tp)
+    }
+
+    private fun configureTextPaint(tp: TextPaint) {
+        if (textColor != null) {
+            tp.color = textColor as Int
+        }
+    }
+
+    fun getTextColor(): String {
+        return java.lang.String.format("#%06X", 0xFFFFFF and textColor!!);
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import android.text.TextPaint
 import android.text.style.CharacterStyle
 import org.wordpress.aztec.AztecAttributes
+import org.wordpress.aztec.source.CssStyleFormatter
 
 class MarkSpan : CharacterStyle, IAztecInlineSpan {
     override var TAG = "mark"
@@ -13,6 +14,12 @@ class MarkSpan : CharacterStyle, IAztecInlineSpan {
 
     constructor(attributes: AztecAttributes = AztecAttributes()) : super() {
         this.attributes = attributes
+
+        val color = CssStyleFormatter.getStyleAttribute(attributes,
+            CssStyleFormatter.CSS_COLOR_ATTRIBUTE)
+        if (color.isNotEmpty()) {
+            textColor = Color.parseColor(color)
+        }
     }
 
     constructor(attributes: AztecAttributes = AztecAttributes(), colorString: String?) : super() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
@@ -5,7 +5,6 @@ import android.text.TextPaint
 import android.text.style.CharacterStyle
 import org.wordpress.aztec.AztecAttributes
 
-
 class MarkSpan : CharacterStyle, IAztecInlineSpan {
     override var TAG = "mark"
 
@@ -35,6 +34,6 @@ class MarkSpan : CharacterStyle, IAztecInlineSpan {
     }
 
     fun getTextColor(): String {
-        return java.lang.String.format("#%06X", 0xFFFFFF and textColor!!);
+        return java.lang.String.format("#%06X", 0xFFFFFF and textColor!!)
     }
 }


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6517
- https://github.com/WordPress/gutenberg/pull/57650
- https://github.com/wordpress-mobile/WordPress-Android/pull/19988

This PR adds missing implementation for the Mark formatting style.

- Adds a new `MarkPlugin` that will handle adding the needed CSS attributes.
- Updates the `MarkSpan` to receive a color param and to set it as the current color.
- Removes `applyMarkInlineStyle` in favor of `applyAfterMarkInlineStyle` which will handle if the color changes while editing a Mark span.

### Test
Please follow the testing instructions in [this PR's description](https://github.com/WordPress/gutenberg/pull/57650).

This shouldn't affect other Aztec functionalities.

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.