### PR TITLE
[Fix] Update targetSdk to 34 from 33.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
 ext {
     minSdkVersion = 24
     compileSdkVersion = 34
-    targetSdkVersion = 33
+    targetSdkVersion = 34
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext {
     tagSoupVersion = '1.2.1'
     glideVersion = '4.10.0'
     picassoVersion = '2.5.2'
-    robolectricVersion = '4.9'
+    robolectricVersion = '4.11'
     jUnitVersion = '4.12'
     jSoupVersion = '1.11.3'
     wordpressUtilsVersion = '3.5.0'


### PR DESCRIPTION
### Fix

Issue: #1072
Related: https://github.com/wordpress-mobile/gutenberg-mobile/issues/6533.

This PR bumps the `targetSdk` version from 33 to 34. It depends on WP Utils 141: https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/141


### Test

- [ ] Ensure build passes.
- [ ] Ensure the sample app is showing rich text properly.

### Review

@irfano

### Note 

I'm not 100% sure how to test this against WP-util, other than waiting until that one is merged and then updating it here. Thoughts @ravishanker

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.