### PR TITLE
Check for selectionStart being -1 to fix talkback crash in Day One

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/IndentFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/IndentFormatter.kt
@@ -167,6 +167,9 @@ class IndentFormatter(editor: AztecText) : AztecFormatter(editor) {
      * Checks whether any line of the selection can be outdented
      */
     fun isOutdentAvailable(): Boolean {
+        if (selectionStart == -1) {
+            return false
+        }
         val previousLineBreak = editableText.substring(0, selectionStart).lastIndexOf("\n")
         if (previousLineBreak > 0 && selectionCanBeOutdented(previousLineBreak + 1, selectionStart)) {
             return true


### PR DESCRIPTION
Fixes #1075 

To test, first try the Day One app unchanged to reproduce the crash:

- Enable Talkback
- Open a Day One entry
- Simply click around the screen
- Boom!

Next, repeat the same steps with using this PR as a local build with Day One. Note that you'll want to temporarily change Aztec's APG version to 8.1.2 for the local build to work.

Once this is merged, I'll submit a Day One PR which updates the hash.

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.