### PR TITLE
Update handleBackspaceAndEnter to prevent removing the current styles using Gutenberg

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -839,6 +839,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         var wasStyleRemoved = false
         if (event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_DEL) {
+            if (isInGutenbergMode && (selectionStart == 0 && isTextSelected())) {
+                return false
+            }
+
             if (!consumeHistoryEvent) {
                 history.beforeTextChanged(this@AztecText)
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -310,6 +310,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     var observationQueue: ObservationQueue = ObservationQueue(this)
     var textWatcherEventBuilder: TextWatcherEvent.Builder = TextWatcherEvent.Builder()
+    var endOfBufferMarkerAdderWatcher: EndOfBufferMarkerAdder? = null
 
     private var accessibilityDelegate = AztecTextAccessibilityDelegate(this)
 
@@ -640,6 +641,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
     }
 
+    fun removeEndOfBufferMarkerAdder() {
+        endOfBufferMarkerAdderWatcher?.uninstallEndOfBuffer(this)
+    }
+
     private fun <T> selectionHasExactlyOneMarker(start: Int, end: Int, type: Class<T>): Boolean {
         val spanFound: Array<T> = editableText.getSpans(
                 start,
@@ -891,7 +896,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         FullWidthImageElementWatcher.install(this)
 
-        EndOfBufferMarkerAdder.install(this)
+        endOfBufferMarkerAdderWatcher = EndOfBufferMarkerAdder.install(this)
         ZeroIndexContentWatcher.install(this)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
@@ -44,10 +44,10 @@ class EndOfBufferMarkerAdder(text: Editable) : TextWatcher {
 
             if (text.isEmpty()) {
                 if (text.getSpans(0, 0, IAztecBlockSpan::class.java).isNotEmpty()) {
-                     // need to add a end-of-text marker so a block element can render in the empty text.
-                     if (!deletedText) {
-                          text.append(Constants.END_OF_BUFFER_MARKER)
-                     }
+                    // need to add a end-of-text marker so a block element can render in the empty text.
+                    if (!deletedText) {
+                        text.append(Constants.END_OF_BUFFER_MARKER)
+                    }
                 }
                 return text
             } else if (text.length == 1 && text[0] == Constants.END_OF_BUFFER_MARKER && deletedText) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
@@ -36,20 +36,18 @@ class EndOfBufferMarkerAdder(text: Editable) : TextWatcher {
     }
 
     companion object {
-        private val watchers = mutableMapOf<AztecText, EndOfBufferMarkerAdder>()
+        private var watcherRef: EndOfBufferMarkerAdder? = null
 
         fun install(editText: AztecText): EndOfBufferMarkerAdder {
             var watcher = EndOfBufferMarkerAdder(editText.text)
             editText.addTextChangedListener(watcher)
-            watchers[editText] = watcher
+            watcherRef = watcher
             return watcher
         }
 
         fun uninstall(editText: AztecText) {
-            val watcher = watchers[editText]
-            if (watcher != null) {
-                editText.removeTextChangedListener(watcher)
-                watchers.remove(editText)
+            if (watcherRef != null) {
+                editText.removeTextChangedListener(watcherRef)
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/EndOfBufferMarkerAdder.kt
@@ -18,7 +18,8 @@ class EndOfBufferMarkerAdder(text: Editable) : TextWatcher {
     override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
 
     override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-        deletedText = before > 0
+        // count < before to take into account auto-corrected words
+        deletedText = before > 0 && count < before
     }
 
     override fun afterTextChanged(text: Editable) {
@@ -43,8 +44,10 @@ class EndOfBufferMarkerAdder(text: Editable) : TextWatcher {
 
             if (text.isEmpty()) {
                 if (text.getSpans(0, 0, IAztecBlockSpan::class.java).isNotEmpty()) {
-                    // need to add a end-of-text marker so a block element can render in the empty text.
-                    text.append(Constants.END_OF_BUFFER_MARKER)
+                     // need to add a end-of-text marker so a block element can render in the empty text.
+                     if (!deletedText) {
+                          text.append(Constants.END_OF_BUFFER_MARKER)
+                     }
                 }
                 return text
             } else if (text.length == 1 && text[0] == Constants.END_OF_BUFFER_MARKER && deletedText) {


### PR DESCRIPTION


### Fix


### Test
1. [STEP_1]
2. [STEP_2]
3. [STEP_3]

### Review
@[USER_NAME]

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.