### PR TITLE
Catches IndexOutOfBoundsException occurring on edge cases

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/SuggestionWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/SuggestionWatcher.kt
@@ -143,7 +143,18 @@ class SuggestionWatcher(aztecText: AztecText) : TextWatcher {
     private fun reapplyCarriedOverInlineSpans(editableText: Spannable) {
         carryOverSpans.forEach {
             if (it.start >= 0 && it.end <= editableText.length && it.start < it.end) {
-                editableText.setSpan(it.span, it.start, it.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                try {
+                    editableText.setSpan(
+                        it.span,
+                        it.start,
+                        it.end,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                } catch (e: IndexOutOfBoundsException) {
+                    // This is a workaround for a possible bug in the Android framework
+                    // https://github.com/wordpress-mobile/WordPress-Android/issues/20481
+                    e.printStackTrace()
+                }
             }
         }
     }


### PR DESCRIPTION
### Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/20481

**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/60107 (https://github.com/WordPress/gutenberg/pull/60115)
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6765
- https://github.com/wordpress-mobile/WordPress-Android/pull/20518

## Description
This PR adds exception handling for an `IndexOutOfBoundsException` thrown from the `SpannableStringBuilder` when the [requested character position >= length](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/text/SpannableStringBuilder.java#125) on rare occasions.

### Test
I did not find a way to reproduce the issue. Thus I suggest a sanity check like the following:
1. Open the editor
2. Apply some style
3. Place the cursor inside the style span
4. Accept a keyboard suggestion
5. Verify that no crash occurs and that the style is applied after the text change

https://github.com/wordpress-mobile/AztecEditor-Android/assets/304044/0a1b1b4d-1425-4d1e-89db-7e3c9847980b

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.