### PR TITLE
Safely parse color string

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/MarkSpan.kt
@@ -17,19 +17,22 @@ class MarkSpan : CharacterStyle, IAztecInlineSpan {
 
         val color = CssStyleFormatter.getStyleAttribute(attributes,
             CssStyleFormatter.CSS_COLOR_ATTRIBUTE)
-        textColorValue = if (color.isNotEmpty()) {
-            Color.parseColor(color)
-        } else {
-            null
-        }
+        textColorValue = safelyParseColor(color)
     }
 
     constructor(attributes: AztecAttributes = AztecAttributes(), colorString: String?) : super() {
         this.attributes = attributes
+        textColorValue = safelyParseColor(colorString)
+    }
 
-        textColorValue = if (colorString != null) {
+    private fun safelyParseColor(colorString: String?): Int? {
+        if (colorString == null) {
+            return null
+        }
+        return try {
             Color.parseColor(colorString)
-        } else {
+        } catch (e: IllegalArgumentException) {
+            // Unknown color
             null
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/20694 and https://github.com/wordpress-mobile/WordPress-Android/issues/20698

**Related PRs:**
- https://github.com/wordpress-mobile/WordPress-Android/pull/20704

### Fix
This PR adds exception handling for the `Color.parseColor` function call to prevent the app from crashing. Similar handling is done in two other case in Aztec ([one](https://github.com/wordpress-mobile/AztecEditor-Android/blob/trunk/aztec/src/main/java/org/wordpress/aztec/Html.java#L661), [two](https://github.com/wordpress-mobile/AztecEditor-Android/blob/trunk/aztec/src/main/kotlin/org/wordpress/aztec/util/ColorConverter.kt#L229))


### Test
I was not able to reproduce the crash thus I suggest a sanity check of the functionality introduced in https://github.com/wordpress-mobile/AztecEditor-Android/pull/1073

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.