### PR TITLE
[Dependency Update] Update `a8c-ci-toolkit` to 3.4.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.14.0
+    - automattic/a8c-ci-toolkit#3.4.2
 
 # Run everything on the `android` queue
 agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 # Run everything on the `android` queue
 agents:
   queue: android
@@ -15,7 +9,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -23,60 +17,60 @@ steps:
   - label: "Lint"
     key: "lint"
     command: .buildkite/commands/lint.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "aztec/build/reports/*"
 
   - label: "Unit Tests"
     key: "test"
     command: .buildkite/commands/unit-test.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "aztec/build/test-results/**/*.xml"
 
   - label: "Connected Tests"
     key: "connected-test"
     command: .buildkite/commands/connected-tests.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "aztec/build/test-results/**/*.xml"
 
   - label: "Publish :aztec"
     key: "publish-aztec"
     command: .buildkite/commands/publish-aztec.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   - label: "Publish :glide-loader"
     key: "publish-glide-loader"
     depends_on:
       - "publish-aztec"
     command: .buildkite/commands/publish-glide-loader.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   - label: "Publish :picasso-loader"
     key: "publish-picasso-loader"
     depends_on:
       - "publish-aztec"
     command: .buildkite/commands/publish-picasso-loader.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   - label: "Publish :wordpress-shortcodes"
     key: "publish-wordpress-shortcodes"
     depends_on:
       - "publish-aztec"
     command: .buildkite/commands/publish-wordpress-shortcodes.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   - label: "Publish :wordpress-comments"
     key: "publish-wordpress-comments"
     depends_on:
       - "publish-aztec"
     command: .buildkite/commands/publish-wordpress-comments.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   - label: "Publish :media-placeholders"
     key: "publish-media-placeholders"
     depends_on:
       - "publish-aztec"
     command: .buildkite/commands/publish-media-placeholders.sh
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,12 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 # Run everything on the `android` queue
 agents:
   queue: android
@@ -16,7 +10,7 @@ steps:
     command: |
       echo "--- 📊 Analyzing"
       ./gradlew buildHealth
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
     notify:

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.14.0
+    - automattic/a8c-ci-toolkit#3.4.2
 
 # Run everything on the `android` queue
 agents:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+ # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+ # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"


### PR DESCRIPTION
### Description

This PR updates `a8c-ci-toolkit` to [3.4.2](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.4.2).

FYI: The breaking change in `3.0.0` is due to removing the `nvm_install` command, but this repo doesn't use that anywhere anyway. As such, it is safe to apply this update.

### Testing Instructions

- Make sure CI is green (🟢).