### PR TITLE
Fix memory leak in EnhancedMovementMethod

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -542,7 +542,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 exclusiveBlockStyles = BlockFormatter.ExclusiveBlockStyles(styles.getBoolean(R.styleable.AztecText_exclusiveBlocks, false), verticalParagraphPadding),
                 paragraphStyle = BlockFormatter.ParagraphStyle(verticalParagraphMargin)
         )
-        EnhancedMovementMethod.taskListClickHandler = TaskListClickHandler(listStyle)
+        EnhancedMovementMethod.setTaskListClickHandler(TaskListClickHandler(listStyle))
 
         linkFormatter = LinkFormatter(this, LinkFormatter.LinkStyle(styles.getColor(
                 R.styleable.AztecText_linkColor, 0),
@@ -954,6 +954,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         if (blockEditorDialog != null && blockEditorDialog!!.isShowing) {
             blockEditorDialog!!.dismiss()
         }
+        EnhancedMovementMethod.setLinkTappedListener(null)
+        EnhancedMovementMethod.setTaskListClickHandler(null)
     }
 
     // We are exposing this method in order to allow subclasses to set their own alpha value
@@ -1178,7 +1180,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     }
 
     fun setOnLinkTappedListener(listener: OnLinkTappedListener) {
-        EnhancedMovementMethod.linkTappedListener = listener
+        EnhancedMovementMethod.setLinkTappedListener(listener)
     }
 
     fun setLinkTapEnabled(isLinkTapEnabled: Boolean) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -542,7 +542,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                 exclusiveBlockStyles = BlockFormatter.ExclusiveBlockStyles(styles.getBoolean(R.styleable.AztecText_exclusiveBlocks, false), verticalParagraphPadding),
                 paragraphStyle = BlockFormatter.ParagraphStyle(verticalParagraphMargin)
         )
-        EnhancedMovementMethod.setTaskListClickHandler(TaskListClickHandler(listStyle))
+        EnhancedMovementMethod.taskListClickHandler = TaskListClickHandler(listStyle)
 
         linkFormatter = LinkFormatter(this, LinkFormatter.LinkStyle(styles.getColor(
                 R.styleable.AztecText_linkColor, 0),
@@ -955,7 +955,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             blockEditorDialog!!.dismiss()
         }
         EnhancedMovementMethod.setLinkTappedListener(null)
-        EnhancedMovementMethod.setTaskListClickHandler(null)
     }
 
     // We are exposing this method in order to allow subclasses to set their own alpha value

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -9,14 +9,23 @@ import android.widget.TextView
 import org.wordpress.aztec.spans.AztecMediaClickableSpan
 import org.wordpress.aztec.spans.AztecURLSpan
 import org.wordpress.aztec.spans.UnknownClickableSpan
+import java.lang.ref.WeakReference
 
 /**
  * http://stackoverflow.com/a/23566268/569430
  */
 object EnhancedMovementMethod : ArrowKeyMovementMethod() {
-    var taskListClickHandler: TaskListClickHandler? = null
+    private var taskListClickHandlerRef: WeakReference<TaskListClickHandler?> = WeakReference(null)
+    private var linkTappedListenerRef: WeakReference<AztecText.OnLinkTappedListener?> = WeakReference(null)
     var isLinkTapEnabled = false
-    var linkTappedListener: AztecText.OnLinkTappedListener? = null
+
+    fun setTaskListClickHandler(handler: TaskListClickHandler?) {
+        taskListClickHandlerRef = WeakReference(handler)
+    }
+
+    fun setLinkTappedListener(listener: AztecText.OnLinkTappedListener?) {
+        linkTappedListenerRef = WeakReference(listener)
+    }
 
     override fun onTouchEvent(widget: TextView, text: Spannable, event: MotionEvent): Boolean {
         val action = event.action
@@ -38,7 +47,9 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val off = layout.getOffsetForHorizontal(line, x.toFloat())
 
             // This handles the case when the task list checkbox is clicked
-            if (taskListClickHandler?.handleTaskListClick(text, off, x, widget.totalPaddingStart) == true) return true
+            if (taskListClickHandlerRef.get()?.handleTaskListClick(text, off, x, widget.totalPaddingStart) == true){
+                return true
+            }
 
             // get the character's position. This may be the left or the right edge of the character so, find the
             //  other edge by inspecting nearby characters (if they exist)
@@ -85,7 +96,7 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
                     link.onClick(widget)
                     return true
                 } else if (link is AztecURLSpan && isLinkTapEnabled) {
-                    linkTappedListener?.onLinkTapped(widget, link.url) ?: link.onClick(widget)
+                    linkTappedListenerRef.get()?.onLinkTapped(widget, link.url) ?: link.onClick(widget)
                     return true
                 }
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -15,13 +15,10 @@ import java.lang.ref.WeakReference
  * http://stackoverflow.com/a/23566268/569430
  */
 object EnhancedMovementMethod : ArrowKeyMovementMethod() {
-    private var taskListClickHandlerRef: WeakReference<TaskListClickHandler?> = WeakReference(null)
+    var taskListClickHandler: TaskListClickHandler? = null
     private var linkTappedListenerRef: WeakReference<AztecText.OnLinkTappedListener?> = WeakReference(null)
     var isLinkTapEnabled = false
 
-    fun setTaskListClickHandler(handler: TaskListClickHandler?) {
-        taskListClickHandlerRef = WeakReference(handler)
-    }
 
     fun setLinkTappedListener(listener: AztecText.OnLinkTappedListener?) {
         linkTappedListenerRef = WeakReference(listener)
@@ -47,7 +44,7 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val off = layout.getOffsetForHorizontal(line, x.toFloat())
 
             // This handles the case when the task list checkbox is clicked
-            if (taskListClickHandlerRef.get()?.handleTaskListClick(text, off, x, widget.totalPaddingStart) == true) {
+            if (taskListClickHandler?.handleTaskListClick(text, off, x, widget.totalPaddingStart) == true) {
                 return true
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -19,7 +19,6 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
     private var linkTappedListenerRef: WeakReference<AztecText.OnLinkTappedListener?> = WeakReference(null)
     var isLinkTapEnabled = false
 
-
     fun setLinkTappedListener(listener: AztecText.OnLinkTappedListener?) {
         linkTappedListenerRef = WeakReference(listener)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -47,7 +47,7 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val off = layout.getOffsetForHorizontal(line, x.toFloat())
 
             // This handles the case when the task list checkbox is clicked
-            if (taskListClickHandlerRef.get()?.handleTaskListClick(text, off, x, widget.totalPaddingStart) == true){
+            if (taskListClickHandlerRef.get()?.handleTaskListClick(text, off, x, widget.totalPaddingStart) == true) {
                 return true
             }
 


### PR DESCRIPTION
### Fix

With a help from Leak Canary I found a leak in EnhancedMovementMethod.

In this PR we are using weak reference for a click listener. Task list listener is not leaking, so it's ok to keep it as is.


### Test
1. Add link tap handler to aztec instance in Main Activity like this:

```
 aztec = Aztec.with(visualEditor, sourceEditor, toolbar, this)
            ....
            .setLinkTapEnabled(true)
            .setOnLinkTappedListener(object : AztecText.OnLinkTappedListener {
                override fun onLinkTapped(widget: View, url: String) {
                    val intent = Intent(Intent.ACTION_VIEW)
                    intent.data = Uri.parse(url)
                    startActivity(intent)
                }
            })
            ....
```
2. Open the app in tap on the link.
3. Confirm that it works and the browser is opened.


### Review
@[USER_NAME]

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.