### PR TITLE
Remove redundant context from AztecDynamicImageSpan

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -120,7 +120,7 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
                 return true
             }
             IMAGE -> {
-                handleMediaElement(opening, output, AztecImageSpan(context, loadingDrawable, nestingLevel, AztecAttributes(attributes)))
+                handleMediaElement(opening, output, AztecImageSpan(loadingDrawable, nestingLevel, AztecAttributes(attributes)))
                 return true
             }
             VIDEO -> {
@@ -145,7 +145,7 @@ class AztecTagHandler(val context: Context, val plugins: List<IAztecPlugin> = Ar
             LINE -> {
                 if (opening) {
                     // Add an extra newline above the line to prevent weird typing on the line above
-                    start(output, AztecHorizontalRuleSpan(context, AppCompatResources.getDrawable(context, R.drawable.img_hr)!!,
+                    start(output, AztecHorizontalRuleSpan(AppCompatResources.getDrawable(context, R.drawable.img_hr)!!,
                             nestingLevel, AztecAttributes(attributes)))
                     output.append(Constants.MAGIC_CHAR)
                 } else {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -104,7 +104,6 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         }
 
         val span = AztecHorizontalRuleSpan(
-                editor.context,
                 AppCompatResources.getDrawable(editor.context, R.drawable.img_hr)!!,
                 nestingLevel,
                 AztecAttributes(),
@@ -134,7 +133,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
     fun insertImage(inline: Boolean, drawable: Drawable?, attributes: Attributes, onImageTappedListener: AztecText.OnImageTappedListener?,
                     onMediaDeletedListener: AztecText.OnMediaDeletedListener?) {
         val nestingLevel = if (inline) IAztecNestable.getNestingLevelAt(editableText, selectionStart) else 0
-        val span = AztecImageSpan(editor.context, drawable, nestingLevel, AztecAttributes(attributes), onImageTappedListener,
+        val span = AztecImageSpan(drawable, nestingLevel, AztecAttributes(attributes), onImageTappedListener,
                 onMediaDeletedListener, editor)
         insertMediaSpan(inline, span)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecAudioSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecAudioSpan.kt
@@ -12,7 +12,7 @@ class AztecAudioSpan(context: Context, drawable: Drawable?, override var nesting
                      var onAudioTappedListener: AztecText.OnAudioTappedListener? = null,
                      onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                      editor: AztecText? = null) :
-        AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecMediaSpan(drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
     override val TAG: String = "audio"
 
     init {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecDynamicImageSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
@@ -9,7 +8,7 @@ import android.text.style.DynamicDrawableSpan
 import org.wordpress.aztec.AztecText
 import java.lang.ref.WeakReference
 
-abstract class AztecDynamicImageSpan(val context: Context, protected var imageDrawable: Drawable?) : DynamicDrawableSpan() {
+abstract class AztecDynamicImageSpan(protected var imageDrawable: Drawable?) : DynamicDrawableSpan() {
     var textView: WeakReference<AztecText>? = null
     var aspectRatio: Double = 1.0
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHorizontalRuleSpan.kt
@@ -1,14 +1,13 @@
 package org.wordpress.aztec.spans
 
-import android.content.Context
 import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 import java.lang.ref.WeakReference
 
-class AztecHorizontalRuleSpan(context: Context, drawable: Drawable, override var nestingLevel: Int,
+class AztecHorizontalRuleSpan(drawable: Drawable, override var nestingLevel: Int,
                               override var attributes: AztecAttributes = AztecAttributes(), editor: AztecText? = null) :
-        AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecDynamicImageSpan(drawable), IAztecFullWidthImageSpan, IAztecSpan {
     init {
         textView = WeakReference(editor)
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecImageSpan.kt
@@ -1,17 +1,16 @@
 package org.wordpress.aztec.spans
 
-import android.content.Context
 import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.AztecText
 
-class AztecImageSpan(context: Context, drawable: Drawable?,
+class AztecImageSpan(drawable: Drawable?,
                      override var nestingLevel: Int,
                      attributes: AztecAttributes = AztecAttributes(),
                      var onImageTappedListener: AztecText.OnImageTappedListener? = null,
                      onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                      editor: AztecText? = null) : IAztecFullWidthImageSpan,
-        AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor) {
+        AztecMediaSpan(drawable, attributes, onMediaDeletedListener, editor) {
     override val TAG: String = "img"
 
     override fun onClick() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.spans
 
-import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
@@ -11,9 +10,9 @@ import org.wordpress.aztec.AztecText
 import java.lang.ref.WeakReference
 import java.util.ArrayList
 
-abstract class AztecMediaSpan(context: Context, drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
+abstract class AztecMediaSpan(drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
                               var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
-                              editor: AztecText? = null) : AztecDynamicImageSpan(context, drawable), IAztecAttributedSpan {
+                              editor: AztecText? = null) : AztecDynamicImageSpan(drawable), IAztecAttributedSpan {
     abstract val TAG: String
 
     private val overlays: ArrayList<Pair<Drawable?, Int>> = ArrayList()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecVideoSpan.kt
@@ -12,7 +12,7 @@ class AztecVideoSpan(context: Context, drawable: Drawable?, override var nesting
                      var onVideoTappedListener: AztecText.OnVideoTappedListener? = null,
                      onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                      editor: AztecText? = null) :
-        AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecMediaSpan(drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
     override val TAG: String = "video"
 
     init {

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
@@ -11,7 +11,6 @@ import org.wordpress.aztec.spans.IAztecSpan
 import java.lang.ref.WeakReference
 
 class AztecPlaceholderSpan(
-        context: Context,
         drawable: Drawable?,
         override var nestingLevel: Int,
         attributes: AztecAttributes = AztecAttributes(),
@@ -19,7 +18,7 @@ class AztecPlaceholderSpan(
         editor: AztecText? = null,
         private val adapter: WeakReference<PlaceholderManager.PlaceholderAdapter>,
         override val TAG: String) :
-        AztecMediaSpan(context, drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
+        AztecMediaSpan(drawable, attributes, onMediaDeletedListener, editor), IAztecFullWidthImageSpan, IAztecSpan {
     override fun onClick() {
 
     }

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/AztecPlaceholderSpan.kt
@@ -1,6 +1,5 @@
 package org.wordpress.aztec.placeholders
 
-import android.content.Context
 import android.graphics.drawable.Drawable
 import kotlinx.coroutines.runBlocking
 import org.wordpress.aztec.AztecAttributes

--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -99,7 +99,7 @@ class PlaceholderManager(
                 ?: throw IllegalArgumentException("Adapter for inserted type not found. Register it with `registerAdapter` method")
         val attrs = getAttributesForMedia(type, attributes)
         val drawable = buildPlaceholderDrawable(adapter, attrs)
-        aztecText.insertMediaSpan(AztecPlaceholderSpan(aztecText.context, drawable, 0, attrs,
+        aztecText.insertMediaSpan(AztecPlaceholderSpan(drawable, 0, attrs,
                 this, aztecText, WeakReference(adapter), TAG = htmlTag))
         insertContentOverSpanWithId(attrs.getValue(UUID_ATTRIBUTE))
     }
@@ -166,7 +166,7 @@ class PlaceholderManager(
         attrs.setValue(UUID_ATTRIBUTE, uuid)
         attrs.setValue(TYPE_ATTRIBUTE, type)
         val drawable = buildPlaceholderDrawable(adapter, attrs)
-        val span = AztecPlaceholderSpan(aztecText.context, drawable, 0, attrs,
+        val span = AztecPlaceholderSpan(drawable, 0, attrs,
                 this, aztecText, WeakReference(adapter), TAG = htmlTag)
         aztecText.replaceMediaSpan(span) { attributes ->
             attributes.getValue(UUID_ATTRIBUTE) == uuid
@@ -460,7 +460,6 @@ class PlaceholderManager(
             aztecAttributes.setValue(UUID_ATTRIBUTE, generateUuid())
             val drawable = runBlocking { buildPlaceholderDrawable(adapter, aztecAttributes) }
             val span = AztecPlaceholderSpan(
-                    context = aztecText.context,
                     drawable = drawable,
                     nestingLevel = nestingLevel,
                     attributes = aztecAttributes,

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/HiddenGutenbergPlugin.kt
@@ -61,7 +61,6 @@ class HiddenGutenbergPlugin @JvmOverloads constructor(private val aztecText: Azt
             output.setSpan(
                     GutenbergInlineCommentSpan(
                             text,
-                            aztecText.context,
                             AppCompatResources.getDrawable(aztecText.context, android.R.drawable.ic_menu_help)!!,
                             nestingLevel
                     ),

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/WordPressCommentsPlugin.kt
@@ -42,7 +42,6 @@ class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpan
             output.setSpan(
                     WordPressCommentSpan(
                             text,
-                            visualEditor.context,
                             AppCompatResources.getDrawable(visualEditor.context, R.drawable.img_more)!!,
                             nestingLevel
                     ),
@@ -59,7 +58,6 @@ class WordPressCommentsPlugin(private val visualEditor: AztecText) : IInlineSpan
             output.setSpan(
                     WordPressCommentSpan(
                             text,
-                            visualEditor.context,
                             AppCompatResources.getDrawable(visualEditor.context, R.drawable.img_page)!!,
                             nestingLevel
                     ),

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergInlineCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/GutenbergInlineCommentSpan.kt
@@ -1,14 +1,13 @@
 package org.wordpress.aztec.plugins.wpcomments.spans
 
-import android.content.Context
 import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecDynamicImageSpan
 import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
 import java.lang.ref.WeakReference
 
-class GutenbergInlineCommentSpan @JvmOverloads constructor(val commentText: String, context: Context, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
-        AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan {
+class GutenbergInlineCommentSpan @JvmOverloads constructor(val commentText: String, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
+        AztecDynamicImageSpan(drawable), IAztecFullWidthImageSpan {
 
     init {
         textView = WeakReference(editor)

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/WordPressCommentSpan.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/spans/WordPressCommentSpan.kt
@@ -1,14 +1,13 @@
 package org.wordpress.aztec.plugins.wpcomments.spans
 
-import android.content.Context
 import android.graphics.drawable.Drawable
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecDynamicImageSpan
 import org.wordpress.aztec.spans.IAztecFullWidthImageSpan
 import java.lang.ref.WeakReference
 
-class WordPressCommentSpan @JvmOverloads constructor(val commentText: String, context: Context, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
-        AztecDynamicImageSpan(context, drawable), IAztecFullWidthImageSpan {
+class WordPressCommentSpan @JvmOverloads constructor(val commentText: String, drawable: Drawable, override var nestingLevel: Int, editor: AztecText? = null) :
+        AztecDynamicImageSpan(drawable), IAztecFullWidthImageSpan {
 
     init {
         textView = WeakReference(editor)

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/MoreToolbarButton.kt
@@ -30,7 +30,6 @@ class MoreToolbarButton(val visualEditor: AztecText) : IToolbarButton {
 
         val span = WordPressCommentSpan(
                 WordPressCommentSpan.Comment.MORE.html,
-                visualEditor.context,
                 AppCompatResources.getDrawable(visualEditor.context, R.drawable.img_more)!!,
                 nestingLevel,
                 visualEditor

--- a/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
+++ b/wordpress-comments/src/main/java/org/wordpress/aztec/plugins/wpcomments/toolbar/PageToolbarButton.kt
@@ -30,7 +30,6 @@ class PageToolbarButton(val visualEditor: AztecText) : IToolbarButton {
 
         val span = WordPressCommentSpan(
                 WordPressCommentSpan.Comment.PAGE.html,
-                visualEditor.context,
                 AppCompatResources.getDrawable(visualEditor.context, R.drawable.img_page)!!,
                 nestingLevel,
                 visualEditor


### PR DESCRIPTION
### Fix

It looks like the context in AztecDynamicImageSpan was never used, but we still pass it from all the spans that are based on AztecDynamicImageSpan. This is a vector for memory leaks, so I'm removing it.


### Test
1. Make sure the app builds, and all the spans look normal.
2. Make sure the changes make sense.

Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.