### PR TITLE
Fix media span and task list memory leaks

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -11,11 +11,17 @@ import java.lang.ref.WeakReference
 import java.util.ArrayList
 
 abstract class AztecMediaSpan(drawable: Drawable?, override var attributes: AztecAttributes = AztecAttributes(),
-                              var onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
+                              onMediaDeletedListener: AztecText.OnMediaDeletedListener? = null,
                               editor: AztecText? = null) : AztecDynamicImageSpan(drawable), IAztecAttributedSpan {
     abstract val TAG: String
 
     private val overlays: ArrayList<Pair<Drawable?, Int>> = ArrayList()
+
+    private var onMediaDeletedListenerRef = WeakReference(onMediaDeletedListener)
+
+    fun setOnMediaDeletedListener(listener: AztecText.OnMediaDeletedListener?) {
+        onMediaDeletedListenerRef = WeakReference(listener)
+    }
 
     init {
         textView = editor?.let { WeakReference(editor) }
@@ -96,9 +102,9 @@ abstract class AztecMediaSpan(drawable: Drawable?, override var attributes: Azte
     abstract fun onClick()
 
     fun onMediaDeleted() {
-        onMediaDeletedListener?.onMediaDeleted(attributes)
+        onMediaDeletedListenerRef.get()?.onMediaDeleted(attributes)
     }
     fun beforeMediaDeleted() {
-        onMediaDeletedListener?.beforeMediaDeleted(attributes)
+        onMediaDeletedListenerRef.get()?.beforeMediaDeleted(attributes)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
@@ -101,12 +101,12 @@ open class AztecTaskListSpan(
         val drawableHeight = (0.8 * (p.fontMetrics.bottom - p.fontMetrics.top))
         // Make sure the marker is correctly aligned on RTL languages
         val markerStartPosition: Float = x + (listStyle.indicatorMargin * dir) * 1f
-        val d: Drawable = contextRef.get()!!.resources.getDrawable(R.drawable.ic_checkbox, null)
+        val d: Drawable? = contextRef.get()?.resources?.getDrawable(R.drawable.ic_checkbox, null)
         val leftBound = markerStartPosition.toInt()
         if (isChecked(text, lineIndex)) {
-            d.state = intArrayOf(android.R.attr.state_checked)
+            d?.state = intArrayOf(android.R.attr.state_checked)
         } else {
-            d.state = intArrayOf()
+            d?.state = intArrayOf()
         }
         val (startShift, endShift) = if (dir > 0) {
             0.8 to 0.2
@@ -114,11 +114,11 @@ open class AztecTaskListSpan(
             0.2 to 0.8
         }
 
-        d.setBounds((leftBound - drawableHeight * startShift).toInt().coerceAtLeast(0),
+        d?.setBounds((leftBound - drawableHeight * startShift).toInt().coerceAtLeast(0),
                 (baseline - drawableHeight * 0.8).toInt(),
                 (leftBound + drawableHeight * endShift).toInt(),
                 (baseline + drawableHeight * 0.2).toInt())
-        d.draw(c)
+        d?.draw(c)
 
         p.color = oldColor
         p.style = style

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
@@ -30,6 +30,7 @@ import org.wordpress.aztec.ITextFormat
 import org.wordpress.aztec.R
 import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.setTaskList
+import java.lang.ref.WeakReference
 
 fun createTaskListSpan(
         nestingLevel: Int,
@@ -61,11 +62,12 @@ class AztecTaskListSpanAligned(
 open class AztecTaskListSpan(
         override var nestingLevel: Int,
         override var attributes: AztecAttributes = AztecAttributes(),
-        val context: Context,
+        context: Context,
         var listStyle: BlockFormatter.ListStyle = BlockFormatter.ListStyle(0, 0, 0, 0, 0),
         var onRefresh: ((AztecTaskListSpan) -> Unit)? = null
 ) : AztecListSpan(nestingLevel, listStyle.verticalPadding) {
     private var toggled: Boolean = false
+        private var contextRef: WeakReference<Context> = WeakReference(context)
     override val TAG = "ul"
 
     override val startTag: String
@@ -82,7 +84,7 @@ open class AztecTaskListSpan(
                                    top: Int, baseline: Int, bottom: Int,
                                    text: CharSequence, start: Int, end: Int,
                                    first: Boolean, l: Layout) {
-        if (!first) return
+        if (!first || contextRef.get() == null) return
 
         val spanStart = (text as Spanned).getSpanStart(this)
         val spanEnd = text.getSpanEnd(this)
@@ -99,7 +101,7 @@ open class AztecTaskListSpan(
         val drawableHeight = (0.8 * (p.fontMetrics.bottom - p.fontMetrics.top))
         // Make sure the marker is correctly aligned on RTL languages
         val markerStartPosition: Float = x + (listStyle.indicatorMargin * dir) * 1f
-        val d: Drawable = context.resources.getDrawable(R.drawable.ic_checkbox, null)
+        val d: Drawable = contextRef.get()!!.resources.getDrawable(R.drawable.ic_checkbox, null)
         val leftBound = markerStartPosition.toInt()
         if (isChecked(text, lineIndex)) {
             d.state = intArrayOf(android.R.attr.state_checked)


### PR DESCRIPTION
### Fix
This PR fixes memory leaks in media and task list spans.

### Test
1. Toggle items in task list, make sure they work as expected.
2. Delete images, confirm that you see a "media deleted" snackbar.
3. Perform same actions after changing device orientation or bringing up to foreground from background.

