### PR TITLE
Bump jsoup to 1.15.3

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -5,6 +5,8 @@ import android.text.SpannableStringBuilder
 import android.text.TextUtils
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.jsoup.select.Elements
 import org.wordpress.aztec.spans.AztecQuoteSpan
 import org.wordpress.aztec.spans.AztecVisualLinebreak
 import org.wordpress.aztec.spans.EndOfParagraphMarker
@@ -30,9 +32,10 @@ object Format {
         CleaningUtils.cleanNestedBoldTags(doc)
         if (isCalypsoFormat) {
             // remove empty span tags
-            doc.select("*")
-                    .filter { !it.hasText() && it.tagName() == "span" && it.childNodes().size == 0 }
-                    .forEach { it.remove() }
+            val select: Elements = doc.select("*")
+            select.filter { element: Element ->
+                !element.hasText() && element.tagName() == "span" && element.childNodes().size == 0
+            }.forEach { it.remove() }
 
             html = replaceAll(doc.body().html(), iframePlaceholder, "iframe")
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -6,7 +6,6 @@ import android.text.TextUtils
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import org.jsoup.select.Elements
 import org.wordpress.aztec.spans.AztecQuoteSpan
 import org.wordpress.aztec.spans.AztecVisualLinebreak
 import org.wordpress.aztec.spans.EndOfParagraphMarker
@@ -32,8 +31,7 @@ object Format {
         CleaningUtils.cleanNestedBoldTags(doc)
         if (isCalypsoFormat) {
             // remove empty span tags
-            val select: Elements = doc.select("*")
-            select.filter { element: Element ->
+            doc.select("*").filter { element: Element ->
                 !element.hasText() && element.tagName() == "span" && element.childNodes().size == 0
             }.forEach { it.remove() }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/CleaningUtils.kt
@@ -2,6 +2,7 @@ package org.wordpress.aztec.util
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import org.jsoup.parser.Parser
 
 object CleaningUtils {
@@ -10,12 +11,12 @@ object CleaningUtils {
     fun cleanNestedBoldTags(doc: Document) {
         // clean all nested <b> tags that don't contain anything
         doc.select("b > b")
-        .filter { !it.hasText() }
+        .filter { element: Element -> !element.hasText() }
         .forEach { it.remove() }
 
         // unwrap text in between nested <b> tags that have some text in them
         doc.select("b > b")
-        .filter { it.hasText() }
+        .filter { element: Element -> element.hasText() }
         .forEach { it.unwrap() }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
     picassoVersion = '2.5.2'
     robolectricVersion = '4.11'
     jUnitVersion = '4.12'
-    jSoupVersion = '1.11.3'
+    jSoupVersion = '1.15.3'
     wordpressUtilsVersion = '3.5.0'
     espressoVersion = '3.0.1'
 


### PR DESCRIPTION
Version without reported security vulnerabilities

To address https://github.com/wordpress-mobile/WordPress-Android/security/dependabot/91


### Test
Smoke test the "code editor" (last button) in AztecDemo app.