### PR TITLE
[Dependency Analysis] Remove Unused Dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,3 +57,13 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // These dependency are not needed but kept to preserve the module's default configuration.
+            exclude(":media-placeholders")
+            exclude(":picasso-loader")
+        }
+    }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,9 +47,6 @@ dependencies {
     implementation project(':wordpress-shortcodes')
     implementation project(':media-placeholders')
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
-
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -61,13 +61,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'androidx.test:core:1.4.0'
 
-    androidTestImplementation 'androidx.test:core:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
-
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 

--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "org.ccil.cowan.tagsoup:tagsoup:$tagSoupVersion"
     implementation "org.jsoup:jsoup:$jSoupVersion"
 
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.collection:collection:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
 
     implementation "org.wordpress:utils:$wordpressUtilsVersion"

--- a/aztec/src/main/res/layout/aztec_format_bar_advanced.xml
+++ b/aztec/src/main/res/layout/aztec_format_bar_advanced.xml
@@ -118,7 +118,7 @@
 
                     </RelativeLayout>
 
-                    <androidx.legacy.widget.Space
+                    <Space
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"/>

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -43,6 +43,15 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }
 
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the build fails in multiple places.
+            exclude("androidx.appcompat:appcompat")
+        }
+    }
+}
+
 project.afterEvaluate {
     publishing {
         publications {

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -25,7 +25,7 @@ android {
 dependencies {
     implementation aztecProjectDependency
 
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.collection:collection:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
 
     implementation "com.squareup.picasso:picasso:$picassoVersion"

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -26,9 +26,18 @@ dependencies {
     implementation aztecProjectDependency
 
     implementation 'androidx.collection:collection:1.1.0'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 
     implementation "com.squareup.picasso:picasso:$picassoVersion"
+}
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the build fails on 'aztec.tag'.
+            exclude("androidx.appcompat:appcompat")
+        }
+    }
 }
 
 project.afterEvaluate {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     gradle.ext.kotlinVersion = '1.9.24'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
-    gradle.ext.dependencyAnalysisVersion = '1.28.0'
+    gradle.ext.dependencyAnalysisVersion = '1.33.0'
 
     plugins {
         id "com.android.library" version gradle.ext.agpVersion

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -38,11 +38,20 @@ android {
 dependencies {
     implementation aztecProjectDependency
 
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
+}
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the build fails in multiple places.
+            exclude("androidx.appcompat:appcompat")
+        }
+    }
 }
 
 project.afterEvaluate {

--- a/wordpress-comments/build.gradle
+++ b/wordpress-comments/build.gradle
@@ -38,7 +38,6 @@ android {
 dependencies {
     implementation aztecProjectDependency
 
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 

--- a/wordpress-shortcodes/build.gradle
+++ b/wordpress-shortcodes/build.gradle
@@ -43,6 +43,15 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }
 
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the build fails in multiple places.
+            exclude("androidx.appcompat:appcompat")
+        }
+    }
+}
+
 project.afterEvaluate {
     publishing {
         publications {


### PR DESCRIPTION
Project Thread: paaHJt-6YV-p2

### Description

Based on the `unused` related advises generated by the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin, this PR removes all unused dependencies from this project.

FYI: As part of this change, the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin got also updated to its latest [1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330) version.

### Testing Steps

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
    - Check the manually triggered [scheduled build](https://buildkite.com/automattic/azteceditor-android/builds/667) and verify that everything works as expected with this newer version of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin ([1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330)).
3. Testing:
    - Smoke test the sample app, try out all available screens and functionality. Verify everything is working as expected.
    - Also, if you want to be thorough about reviewing the changes, you could quickly smoke test, either the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and/or [WCAndroid](https://github.com/woocommerce/woocommerce-android), with this version of `Aztec`, or via composite builds, and see if it works as expected.