### PR TITLE
Add redrawViews method to PlaceholderManager

### DIFF
--- a/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
+++ b/media-placeholders/src/main/java/org/wordpress/aztec/placeholders/PlaceholderManager.kt
@@ -496,24 +496,28 @@ class PlaceholderManager(
                 return
             }
             aztecText.viewTreeObserver.removeOnGlobalLayoutListener(this)
-            val spans = aztecText.editableText.getSpans(
-                    0,
-                    aztecText.editableText.length,
-                    AztecPlaceholderSpan::class.java
-            )
+            job = redrawViews()
+        }
+    }
 
-            if (spans == null || spans.isEmpty()) {
-                return
-            }
-            job = launch {
-                clearAllViews()
-                spans.forEach {
-                    val type = it.attributes.getValue(TYPE_ATTRIBUTE)
-                    val adapter = adapters[type] ?: return@forEach
-                    it.drawable = buildPlaceholderDrawable(adapter, it.attributes)
-                    aztecText.refreshText(false)
-                    insertInPosition(it.attributes, aztecText.editableText.getSpanStart(it))
-                }
+    fun redrawViews(): Job? {
+        val spans = aztecText.editableText.getSpans(
+            0,
+            aztecText.editableText.length,
+            AztecPlaceholderSpan::class.java
+        )
+
+        if (spans == null || spans.isEmpty()) {
+            return null
+        }
+        return launch {
+            clearAllViews()
+            spans.forEach {
+                val type = it.attributes.getValue(TYPE_ATTRIBUTE)
+                val adapter = adapters[type] ?: return@forEach
+                it.drawable = buildPlaceholderDrawable(adapter, it.attributes)
+                aztecText.refreshText(false)
+                insertInPosition(it.attributes, aztecText.editableText.getSpanStart(it))
             }
         }
     }


### PR DESCRIPTION
### Fix

In order to redraw placeholder manager from a composable we need to extract the redrawViews method.


### Test
1. Test with the related DO PR

### Review
@danilo04 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.