### PR TITLE
Improved fix for IllegalArgumentException: Center point is not inside any of the rectangles

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1238,6 +1238,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         if (length() != 0) {
+            // do not set selection when we try to select end of buffer marker in empty editor
             if ((length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)) {
                 return
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1238,7 +1238,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         if (length() != 0) {
-            if((length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)){
+            if ((length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)) {
                 return
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1239,7 +1239,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
         if (length() != 0) {
             // do not set selection when we try to select end of buffer marker in empty editor
-            if ((length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)) {
+            if (selStart == 0 && selEnd == 1 && (length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)) {
                 return
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1240,6 +1240,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         if (length() != 0) {
             // do not set selection when we try to select end of buffer marker in empty editor
             if (selStart == 0 && selEnd == 1 && (length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)) {
+                deleteInlineStyleFromTheBeginning()
                 return
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1976,6 +1976,14 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     return super.onTextContextMenuItem(id)
                 }
             }
+            android.R.id.selectAll -> {
+                return if (text.toString() == Constants.END_OF_BUFFER_MARKER.toString()) {
+                    deleteInlineStyleFromTheBeginning()
+                    return true
+                } else {
+                    super.onTextContextMenuItem(id)
+                }
+            }
             else -> return super.onTextContextMenuItem(id)
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1238,6 +1238,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         if (length() != 0) {
+            if((length() == 1 && text[0] == Constants.END_OF_BUFFER_MARKER)){
+                return
+            }
+
             // if the text end has the marker, let's make sure the cursor never includes it or surpasses it
             if ((selStart == length() || selEnd == length()) && text[length() - 1] == Constants.END_OF_BUFFER_MARKER) {
                 var start = selStart
@@ -1970,14 +1974,6 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
                     Toast.makeText(context, context.getString(R.string.samsung_disabled_custom_clipboard, Build.VERSION.RELEASE), Toast.LENGTH_LONG).show()
                 } else {
                     return super.onTextContextMenuItem(id)
-                }
-            }
-            android.R.id.selectAll -> {
-                return if (text.toString() == Constants.END_OF_BUFFER_MARKER.toString()) {
-                    deleteInlineStyleFromTheBeginning()
-                    return true
-                } else {
-                    super.onTextContextMenuItem(id)
                 }
             }
             else -> return super.onTextContextMenuItem(id)


### PR DESCRIPTION
Fixes #880 880

This is an improved fix for the crash when selecting empty editor with an end of buffer marker in it.

Original fix addressed case where you press on "Select All", but the problem is that some devices have their own option for selecting text in addition to "Select All". My One Plus device has a "Select" option that causes the crash as well. Problem with this, is that each manufacturer has a different ID for that button, and we can't catch them all. I added the logic for catching other select events into the `onSelectionChanged`. 


### Test
If you have a device with an additional "Select" option in context menu.
1. In main activity set content of the editor to this `aztec.visualEditor.fromHtml("<ol><li></li></ol>")`. We use list to be able to see the span.
2. Long press in the editor and tap on "Select"
3. Notice that app does not crash. 


If you do not have a device with a "Select" option, you can still test the functionality by commenting out [this part](https://github.com/wordpress-mobile/AztecEditor-Android/blob/7a365a5c67a6b232b1ee742e7227d6d332666bac/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1979-L1986).

1. In main activity set content of the editor to this `aztec.visualEditor.fromHtml("<h1></h1>")`.
2. Long press in the editor and tap on "Select All"
3. Notice that app does not crash. 
4. Smoke test behavior around empty block span (eg. list) in editor.

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.