### PR TITLE
Allow setting spanned spanned content with processing

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1540,6 +1540,38 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return cursorPosition
     }
 
+    open fun fromParsedContent(spannedText: Spanned, isInit: Boolean = true){
+        val builder = SpannableStringBuilder()
+
+        builder.append(spannedText)
+
+        Format.preProcessSpannedText(builder, isInCalypsoMode)
+
+        switchToAztecStyle(builder, 0, builder.length)
+        disableTextChangedListener()
+
+        builder.getSpans(0, builder.length, AztecDynamicImageSpan::class.java).forEach {
+            it.textView = WeakReference(this)
+        }
+
+        val cursorPosition = consumeCursorPosition(builder)
+        setSelection(0)
+
+        setTextKeepState(builder)
+        enableTextChangedListener()
+
+        setSelection(cursorPosition)
+
+        if (isInit) {
+            initialEditorContentParsedSHA256 =
+                calculateInitialHTMLSHA(toPlainHtml(false), initialEditorContentParsedSHA256)
+        }
+
+        loadImages()
+        loadVideos()
+        mediaCallback?.mediaLoadingStarted()
+    }
+
     open fun fromHtml(source: String, isInit: Boolean = true) {
         val builder = SpannableStringBuilder()
         val parser = AztecParser(alignmentRendering, plugins)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1540,7 +1540,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return cursorPosition
     }
 
-    open fun fromSpanned(spannedText: Spanned, isInit: Boolean = true){
+    open fun fromSpanned(spannedText: Spanned, isInit: Boolean = true) {
         processSpannedContent(spannedText, isInit)
     }
 
@@ -1554,7 +1554,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         processSpannedContent(spanned)
     }
 
-    private fun processSpannedContent(spannedText: Spanned, isInit: Boolean = true){
+    private fun processSpannedContent(spannedText: Spanned, isInit: Boolean = true) {
         val builder = SpannableStringBuilder(spannedText)
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
@@ -1575,7 +1575,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         setSelection(cursorPosition)
 
         if (isInit) {
-            initialEditorContentParsedSHA256 = calculateInitialHTMLSHA(toPlainHtml(false), initialEditorContentParsedSHA256)
+            initialEditorContentParsedSHA256 =
+                calculateInitialHTMLSHA(toPlainHtml(false), initialEditorContentParsedSHA256)
         }
 
         loadImages()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1540,45 +1540,22 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return cursorPosition
     }
 
-    open fun fromParsedContent(spannedText: Spanned, isInit: Boolean = true){
-        val builder = SpannableStringBuilder()
-
-        builder.append(spannedText)
-
-        Format.preProcessSpannedText(builder, isInCalypsoMode)
-
-        switchToAztecStyle(builder, 0, builder.length)
-        disableTextChangedListener()
-
-        builder.getSpans(0, builder.length, AztecDynamicImageSpan::class.java).forEach {
-            it.textView = WeakReference(this)
-        }
-
-        val cursorPosition = consumeCursorPosition(builder)
-        setSelection(0)
-
-        setTextKeepState(builder)
-        enableTextChangedListener()
-
-        setSelection(cursorPosition)
-
-        if (isInit) {
-            initialEditorContentParsedSHA256 =
-                calculateInitialHTMLSHA(toPlainHtml(false), initialEditorContentParsedSHA256)
-        }
-
-        loadImages()
-        loadVideos()
-        mediaCallback?.mediaLoadingStarted()
+    open fun fromSpanned(spannedText: Spanned, isInit: Boolean = true){
+        processSpannedContent(spannedText, isInit)
     }
 
     open fun fromHtml(source: String, isInit: Boolean = true) {
-        val builder = SpannableStringBuilder()
         val parser = AztecParser(alignmentRendering, plugins)
 
         var cleanSource = CleaningUtils.cleanNestedBoldTags(source)
         cleanSource = Format.removeSourceEditorFormatting(cleanSource, isInCalypsoMode, isInGutenbergMode)
-        builder.append(parser.fromHtml(cleanSource, context, shouldSkipTidying(), shouldIgnoreWhitespace()))
+        val spanned = parser.fromHtml(cleanSource, context, shouldSkipTidying(), shouldIgnoreWhitespace())
+
+        processSpannedContent(spanned)
+    }
+
+    private fun processSpannedContent(spannedText: Spanned, isInit: Boolean = true){
+        val builder = SpannableStringBuilder(spannedText)
 
         Format.preProcessSpannedText(builder, isInCalypsoMode)
 


### PR DESCRIPTION
### Fix

In this PR we add a method for setting a spanned content, that will process it before setting it into the editor. This is useful if you want to parse HTML into Spanned text somewhere else (eg, on a different thread which is useful if you only use Aztec to display content).


### Test
1. Make sure demo app work, and content is being set.

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.