### PR TITLE
[Dependency Analysis] Remove Unused Dependencies [`January 2025`]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ ext {
 
 ext {
     // mixed
+    androidxComposeCompilerVersion = '1.5.14'
+    androidxComposeLibraryVersion = '1.7.5'
+    androidxComposeMaterialVersion = '1.3.1'
     gradlePluginVersion = '3.3.1'
     kotlinCoroutinesVersion = '1.8.1'
     tagSoupVersion = '1.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,6 @@ ext {
     // mixed
     androidxComposeCompilerVersion = '1.5.14'
     androidxComposeLibraryVersion = '1.7.5'
-    androidxComposeMaterialVersion = '1.3.1'
     gradlePluginVersion = '3.3.1'
     kotlinCoroutinesVersion = '1.8.1'
     tagSoupVersion = '1.2.1'

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    implementation "androidx.compose.foundation:foundation:$androidxComposeLibraryVersion"
+    implementation "androidx.compose.foundation:foundation-layout:$androidxComposeLibraryVersion"
     implementation "androidx.compose.ui:ui:$androidxComposeLibraryVersion"
     implementation "androidx.compose.ui:ui-unit:$androidxComposeLibraryVersion"
 }

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    implementation "androidx.compose.material3:material3:$androidxComposeMaterialVersion"
     implementation "androidx.compose.foundation:foundation:$androidxComposeLibraryVersion"
     implementation "androidx.compose.ui:ui:$androidxComposeLibraryVersion"
     implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeLibraryVersion"

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     implementation "androidx.compose.foundation:foundation:$androidxComposeLibraryVersion"
     implementation "androidx.compose.ui:ui:$androidxComposeLibraryVersion"
+    implementation "androidx.compose.ui:ui-unit:$androidxComposeLibraryVersion"
 }
 
 dependencyAnalysis {

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -36,7 +36,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
+        kotlinCompilerExtensionVersion = androidxComposeCompilerVersion
     }
 }
 
@@ -47,10 +47,10 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    implementation 'androidx.compose.material3:material3:1.3.1'
-    implementation 'androidx.compose.foundation:foundation:1.7.5'
-    implementation 'androidx.compose.ui:ui:1.7.5'
-    implementation 'androidx.compose.ui:ui-tooling-preview:1.7.5'
+    implementation "androidx.compose.material3:material3:$androidxComposeMaterialVersion"
+    implementation "androidx.compose.foundation:foundation:$androidxComposeLibraryVersion"
+    implementation "androidx.compose.ui:ui:$androidxComposeLibraryVersion"
+    implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeLibraryVersion"
 }
 
 dependencyAnalysis {

--- a/media-placeholders/build.gradle
+++ b/media-placeholders/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     implementation "androidx.compose.foundation:foundation:$androidxComposeLibraryVersion"
     implementation "androidx.compose.ui:ui:$androidxComposeLibraryVersion"
-    implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeLibraryVersion"
 }
 
 dependencyAnalysis {


### PR DESCRIPTION
### Description

Based on the `unused` related advises generated by the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin (see p1738189833942969-slack-C0787KRDYDC), this PR removes the newly added but unused dependencies from this project.

---

### Reviewers

👋 @planarvoid & @danilo04, just and FYI here, that I added both of your as reviewers to this change because it relates to this #1095 PR you both worked on. 🙏 

---

### Testing Steps

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
    - Check the manually triggered [scheduled build](https://buildkite.com/automattic/azteceditor-android/builds/728) and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
2. Testing:
    - Smoke test the sample app, try out all available screens and functionality. Verify everything is working as expected.
    - Also, if you want to be thorough about reviewing the changes, you could quickly smoke test a client app of your choice (ie. [DOAndroid](https://github.com/bloom/DayOne-Android)) and see if it works as expected.