### PR TITLE
Ensure spans validity when getting text copy

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -450,14 +450,17 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
      */
     fun getTextCopy(): Editable {
         val copy = SpannableStringBuilder(text.toString())
-
         val spans: Array<Any> = text.getSpans(0, text.length, Any::class.java)
 
         for (span in spans) {
             val spanStart = text.getSpanStart(span)
             val spanEnd = text.getSpanEnd(span)
-            val flags = text.getSpanFlags(span)
-            copy.setSpan(span, spanStart, spanEnd, flags)
+
+            // Only set the span if both start and end positions are valid
+            if (spanStart >= 0 && spanEnd >= 0) {
+                val flags = text.getSpanFlags(span)
+                copy.setSpan(span, spanStart, spanEnd, flags)
+            }
         }
         return copy
     }


### PR DESCRIPTION
Not sure how to reproduce the issue, but sometimes spans that we reset might return -1 for start and end position. I suspect that service spans (like selection, etc) might be causing this.

This PR protects against this case.

We do not have a test case for copying texts in the demo app, so please test this with the client version that is utilizing it.


- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.