### PR TITLE
Improve thread safety of AztecAttributes

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt
@@ -5,6 +5,7 @@ import org.xml.sax.Attributes
 import org.xml.sax.helpers.AttributesImpl
 
 class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImpl(attributes) {
+    @Synchronized
     fun setValue(key: String, value: String) {
         val index = getIndex(key)
 
@@ -22,6 +23,7 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         }
     }
 
+    @Synchronized
     private fun logInternalState() {
         AppLog.e(AppLog.T.EDITOR, "Dumping internal state:")
         AppLog.e(AppLog.T.EDITOR, "length = $length")
@@ -34,10 +36,12 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         }
     }
 
+    @Synchronized
     fun isEmpty(): Boolean {
         return length == 0
     }
 
+    @Synchronized
     fun removeAttribute(key: String) {
         if (hasAttribute(key)) {
             val index = getIndex(key)
@@ -53,10 +57,12 @@ class AztecAttributes(attributes: Attributes = AttributesImpl()) : AttributesImp
         }
     }
 
+    @Synchronized
     fun hasAttribute(key: String): Boolean {
         return getValue(key) != null
     }
 
+    @Synchronized
     override fun toString(): String {
         val sb = StringBuilder()
         try {


### PR DESCRIPTION
### Fixes #705 

We sometimes get issue with in AztecAttributes, that hint at some sort of data corruption, and I was able to syntetically cause crashes with multi threaded overloading.

In this PR we ensure that only one thread can operate on the attributes at any given time, thereby preventing race conditions and ensuring data consistency during concurrent operations.

There is not much to test, just make sure the demo app and client side implementation are working.

### Review
@[USER_NAME]

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.