### PR TITLE
Add touch event handling in AztecText when field is disabled

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -756,6 +756,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             }
         }
 
+        // We need to handle touch events to links if they are disabled.
+        if (!isEnabled &&
+            EnhancedMovementMethod.handleLinkTouchEvent(widget = this, text = text, event = event).handled) {
+            return false
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
                 && event.action == MotionEvent.ACTION_DOWN) {
             // we'll use these values in OnLongClickListener

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -242,6 +242,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     private var bypassMediaDeletedListener: Boolean = false
     private var bypassCrashPreventerInputFilter: Boolean = false
     private var overrideSamsungPredictiveBehavior: Boolean = false
+    private var allowLinkTapWhenDisable: Boolean = false
 
     var initialEditorContentParsedSHA256: ByteArray = ByteArray(0)
 
@@ -757,7 +758,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         }
 
         // We need to handle touch events to links if they are disabled.
-        if (!isEnabled &&
+        if (allowLinkTapWhenDisable && !isEnabled &&
             EnhancedMovementMethod.handleLinkTouchEvent(widget = this, text = text, event = event).handled) {
             return false
         }
@@ -1923,6 +1924,10 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
     // https://github.com/wordpress-mobile/AztecEditor-Android/issues/1023
     fun enableSamsungPredictiveBehaviorOverride() {
         overrideSamsungPredictiveBehavior = true
+    }
+
+    fun enableLinkTapWhenDisable() {
+        allowLinkTapWhenDisable = true
     }
 
     fun isMediaDeletedListenerDisabled(): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -47,54 +47,9 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
                 return true
             }
 
-            // get the character's position. This may be the left or the right edge of the character so, find the
-            //  other edge by inspecting nearby characters (if they exist)
-            val charX = layout.getPrimaryHorizontal(off)
-            val charPrevX = if (off > 0) layout.getPrimaryHorizontal(off - 1) else charX
-            val charNextX = if (off < text.length) layout.getPrimaryHorizontal(off + 1) else charX
-
-            val lineRect = Rect()
-            layout.getLineBounds(line, lineRect)
-
-            val clickedWithinLineHeight = y >= lineRect.top && y <= lineRect.bottom
-            val clickedOnSpanToTheLeftOfCursor = x.toFloat() in charPrevX..charX
-            val clickedOnSpanToTheRightOfCursor = x.toFloat() in charX..charNextX
-
-            val clickedOnSpan = clickedWithinLineHeight &&
-                    (clickedOnSpanToTheLeftOfCursor || clickedOnSpanToTheRightOfCursor)
-
-            val clickedSpanBordersAnotherOne = (text.getSpans(off, off, ClickableSpan::class.java).size == 1 &&
-                    text.getSpans(off + 1, off + 1, ClickableSpan::class.java).isNotEmpty())
-
-            val isClickedSpanAmbiguous = text.getSpans(off, off, ClickableSpan::class.java).size > 1
-
-            val failedToPinpointClickedSpan = (isClickedSpanAmbiguous || clickedSpanBordersAnotherOne)
-                    && !clickedOnSpanToTheLeftOfCursor && !clickedOnSpanToTheRightOfCursor
-
-            var link: ClickableSpan? = null
-
-            if (clickedOnSpan) {
-                if (isClickedSpanAmbiguous) {
-                    if (clickedOnSpanToTheLeftOfCursor) {
-                        link = text.getSpans(off, off, ClickableSpan::class.java)[0]
-                    } else if (clickedOnSpanToTheRightOfCursor) {
-                        link = text.getSpans(off, off, ClickableSpan::class.java)[1]
-                    }
-                } else {
-                    link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull()
-                }
-            } else if (failedToPinpointClickedSpan) {
-                link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull { text.getSpanStart(it) == off }
-            }
-
-            if (link != null) {
-                if (link is AztecMediaClickableSpan || link is UnknownClickableSpan) {
-                    link.onClick(widget)
-                    return true
-                } else if (link is AztecURLSpan && isLinkTapEnabled) {
-                    linkTappedListenerRef.get()?.onLinkTapped(widget, link.url) ?: link.onClick(widget)
-                    return true
-                }
+            // If we find that the touch event was on a link, then, we handle it and return immediately.
+            if (handleLinkTouchEvent(widget = widget, text = text, event = event).handled) {
+                return true
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -100,4 +100,74 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
 
         return super.onTouchEvent(widget, text, event)
     }
+
+    fun handleLinkTouchEvent(widget: TextView, text: Spannable, event: MotionEvent): LinkTouchEventResult {
+        var x = event.x.toInt()
+        var y = event.y.toInt()
+
+        x -= widget.totalPaddingLeft
+        y -= widget.totalPaddingTop
+
+        x += widget.scrollX
+        y += widget.scrollY
+
+        val layout = widget.layout
+        val line = layout.getLineForVertical(y)
+        val off = layout.getOffsetForHorizontal(line, x.toFloat())
+
+        // get the character's position. This may be the left or the right edge of the character so, find the
+        //  other edge by inspecting nearby characters (if they exist)
+        val charX = layout.getPrimaryHorizontal(off)
+        val charPrevX = if (off > 0) layout.getPrimaryHorizontal(off - 1) else charX
+        val charNextX = if (off < text.length) layout.getPrimaryHorizontal(off + 1) else charX
+
+        val lineRect = Rect()
+        layout.getLineBounds(line, lineRect)
+
+        val clickedWithinLineHeight = y >= lineRect.top && y <= lineRect.bottom
+        val clickedOnSpanToTheLeftOfCursor = x.toFloat() in charPrevX..charX
+        val clickedOnSpanToTheRightOfCursor = x.toFloat() in charX..charNextX
+
+        val clickedOnSpan = clickedWithinLineHeight &&
+                (clickedOnSpanToTheLeftOfCursor || clickedOnSpanToTheRightOfCursor)
+
+        val clickedSpanBordersAnotherOne = (text.getSpans(off, off, ClickableSpan::class.java).size == 1 &&
+                text.getSpans(off + 1, off + 1, ClickableSpan::class.java).isNotEmpty())
+
+        val isClickedSpanAmbiguous = text.getSpans(off, off, ClickableSpan::class.java).size > 1
+
+        val failedToPinpointClickedSpan = (isClickedSpanAmbiguous || clickedSpanBordersAnotherOne)
+                && !clickedOnSpanToTheLeftOfCursor && !clickedOnSpanToTheRightOfCursor
+
+        var link: ClickableSpan? = null
+
+        if (clickedOnSpan) {
+            link = if (isClickedSpanAmbiguous) {
+                if (clickedOnSpanToTheLeftOfCursor) {
+                    text.getSpans(off, off, ClickableSpan::class.java)[0]
+                } else {
+                    text.getSpans(off, off, ClickableSpan::class.java)[1]
+                }
+            } else {
+                text.getSpans(off, off, ClickableSpan::class.java).firstOrNull()
+            }
+        } else if (failedToPinpointClickedSpan) {
+            link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull { text.getSpanStart(it) == off }
+        }
+
+        if (link != null) {
+            if (link is AztecMediaClickableSpan || link is UnknownClickableSpan) {
+                link.onClick(widget)
+                return LinkTouchEventResult(true)
+            } else if (link is AztecURLSpan && isLinkTapEnabled) {
+                linkTappedListenerRef.get()?.onLinkTapped(widget, link.url) ?: link.onClick(widget)
+                return LinkTouchEventResult(true)
+            }
+        }
+
+        return LinkTouchEventResult(false)
+    }
 }
+
+@JvmInline
+value class LinkTouchEventResult(val handled: Boolean)


### PR DESCRIPTION
### Fix

When the `AztecText` is disabled (`isEnabled = false`), touch events aren't handled by `EnhancedMovementMethod.onTouchEvent`. In this PR, we handle touch events for links in `Aztectext.onTouchEvent` is it is disabled. Since touch events at this level are executed, we can reuse the same logic in `EnhancedMovementMethod` to handle touch events on links. 


### Test
1. Test with client side PR

### Review
@khaykov 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.