### PR TITLE
Allow multiple selectionChangedListeners to be set in AztecText

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -327,6 +327,8 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     private lateinit var listItemStyle: BlockFormatter.ListItemStyle
 
+    private var selectionChangedListeners = CompositeSelectionChangedListener()
+
     override fun onDraw(canvas: Canvas) {
         plugins.filterIsInstance<IOnDrawPlugin>().forEach {
             it.onDraw(canvas)
@@ -336,6 +338,19 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     interface OnSelectionChangedListener {
         fun onSelectionChanged(selStart: Int, selEnd: Int)
+    }
+
+    private class CompositeSelectionChangedListener : OnSelectionChangedListener {
+        private val listeners = mutableListOf<OnSelectionChangedListener>()
+
+        fun addListener(listener: OnSelectionChangedListener) {
+            if (!listeners.contains(listener)) listeners.add(listener)
+        }
+
+        fun removeListener(listener: OnSelectionChangedListener) = listeners.remove(listener)
+
+        override fun onSelectionChanged(selStart: Int, selEnd: Int) =
+            listeners.forEach { it.onSelectionChanged(selStart, selEnd) }
     }
 
     interface OnImeBackListener {
@@ -1211,8 +1226,12 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         return blockFormatter.isOutdentAvailable()
     }
 
-    fun setOnSelectionChangedListener(onSelectionChangedListener: OnSelectionChangedListener) {
-        this.onSelectionChangedListener = onSelectionChangedListener
+    fun setOnSelectionChangedListener(listener: OnSelectionChangedListener) {
+        selectionChangedListeners.addListener(listener)
+    }
+
+    fun removeOnSelectionChangedListener(listener: OnSelectionChangedListener) {
+        selectionChangedListeners.removeListener(listener)
     }
 
     fun getAztecKeyListener(): OnAztecKeyListener? {
@@ -1324,7 +1343,7 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
             return
         }
 
-        onSelectionChangedListener?.onSelectionChanged(selStart, selEnd)
+        selectionChangedListeners.onSelectionChanged(selStart, selEnd)
         // Gutenberg controls the selected styles so we need to prevent Aztec to modify them
         if (!isInGutenbergMode) {
             setSelectedStyles(getAppliedStyles(selStart, selEnd))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -94,6 +94,8 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
     private var toolbarItems: ToolbarItems? = null
     private var tasklistEnabled: Boolean = false
 
+    private var editorSelectionListener: AztecText.OnSelectionChangedListener? = null
+
     constructor(context: Context) : super(context) {
         initView(null)
     }
@@ -408,12 +410,14 @@ class AztecToolbar : FrameLayout, IAztecToolbar, OnMenuItemClickListener {
         this.sourceEditor = sourceEditor
         this.editor = editor
 
-        // highlight toolbar buttons based on what styles are applied to the text beneath cursor
-        this.editor!!.setOnSelectionChangedListener(object : AztecText.OnSelectionChangedListener {
+        editorSelectionListener?.let { this.editor?.removeOnSelectionChangedListener(it) }
+        editorSelectionListener = object : AztecText.OnSelectionChangedListener {
             override fun onSelectionChanged(selStart: Int, selEnd: Int) {
                 highlightAppliedStyles(selStart, selEnd)
             }
-        })
+        }
+        this.editor?.setOnSelectionChangedListener(editorSelectionListener!!)
+
         setupToolbarItems()
 
         if (sourceEditor == null) {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecTextSelectionListenerTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecTextSelectionListenerTest.kt
@@ -1,0 +1,183 @@
+package org.wordpress.aztec
+
+import android.app.Activity
+import android.widget.ToggleButton
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.toolbar.ToolbarAction
+
+@RunWith(RobolectricTestRunner::class)
+class AztecTextSelectionListenerTest {
+    private lateinit var editText: AztecText
+    private lateinit var toolbar: AztecToolbar
+    private var clientListenerCallCount = 0
+    private var lastClientSelectionStart = -1
+    private var lastClientSelectionEnd = -1
+
+    @Before
+    fun init() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+        editText = AztecText(activity)
+        editText.setCalypsoMode(false)
+        toolbar = AztecToolbar(activity)
+        toolbar.setEditor(editText, null)
+
+        // Reset counters
+        clientListenerCallCount = 0
+        lastClientSelectionStart = -1
+        lastClientSelectionEnd = -1
+    }
+
+    @Test
+    fun `test toolbar highlights styles when selection changes`() {
+        // Add a client listener
+        editText.setOnSelectionChangedListener(object : AztecText.OnSelectionChangedListener {
+            override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+                clientListenerCallCount++
+                lastClientSelectionStart = selStart
+                lastClientSelectionEnd = selEnd
+            }
+        })
+
+        // Add some text and make a selection
+        editText.setText("Hello World")
+        // setText triggers a selection change event, so we need to reset the counters
+        clientListenerCallCount = 0
+        editText.setSelection(0, 5)
+
+        // Verify client listener was called
+        Assert.assertEquals(1, clientListenerCallCount)
+        Assert.assertEquals(0, lastClientSelectionStart)
+        Assert.assertEquals(5, lastClientSelectionEnd)
+
+        // Apply bold formatting
+        val boldButton = toolbar.findViewById<ToggleButton>(ToolbarAction.BOLD.buttonId)
+        boldButton.performClick()
+
+        // Verify bold button is checked
+        Assert.assertTrue("Bold button should be checked after applying bold formatting", boldButton.isChecked)
+
+        // Make another selection
+        editText.setSelection(6, 11)
+
+        // Verify client listener was called again
+        Assert.assertEquals(2, clientListenerCallCount)
+        Assert.assertEquals(6, lastClientSelectionStart)
+        Assert.assertEquals(11, lastClientSelectionEnd)
+
+        // Verify bold button is unchecked for non-bold text
+        Assert.assertFalse("Bold button should be unchecked for non-bold text", boldButton.isChecked)
+
+        // Apply italic formatting
+        val italicButton = toolbar.findViewById<ToggleButton>(ToolbarAction.ITALIC.buttonId)
+        italicButton.performClick()
+
+        // Verify italic button is checked
+        Assert.assertTrue("Italic button should be checked after applying italic formatting", italicButton.isChecked)
+
+        // Select the bold text again
+        editText.setSelection(0, 5)
+
+        // Verify bold button is checked again
+        Assert.assertTrue("Bold button should be checked when selecting bold text", boldButton.isChecked)
+        // Verify italic button is unchecked for non-italic text
+        Assert.assertFalse("Italic button should be unchecked for non-italic text", italicButton.isChecked)
+    }
+
+    @Test
+    fun `test client listener works before toolbar setup`() {
+        // Add a client listener before setting up the toolbar
+        editText.setOnSelectionChangedListener(object : AztecText.OnSelectionChangedListener {
+            override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+                clientListenerCallCount++
+                lastClientSelectionStart = selStart
+                lastClientSelectionEnd = selEnd
+            }
+        })
+
+        // Set up the toolbar after adding the listener
+        toolbar.setEditor(editText, null)
+
+        // Add some text and make a selection
+        editText.setText("Hello World")
+        // setText triggers a selection change event, so we need to reset the counters
+        clientListenerCallCount = 0
+        editText.setSelection(0, 5)
+
+        // Verify client listener was called
+        Assert.assertEquals(1, clientListenerCallCount)
+        Assert.assertEquals(0, lastClientSelectionStart)
+        Assert.assertEquals(5, lastClientSelectionEnd)
+    }
+
+    @Test
+    fun `test client listener works after toolbar setup`() {
+        // Set up the toolbar first
+        toolbar.setEditor(editText, null)
+
+        // Add a client listener after setting up the toolbar
+        editText.setOnSelectionChangedListener(object : AztecText.OnSelectionChangedListener {
+            override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+                clientListenerCallCount++
+                lastClientSelectionStart = selStart
+                lastClientSelectionEnd = selEnd
+            }
+        })
+
+        // Add some text and make a selection
+        editText.setText("Hello World")
+        // setText triggers a selection change event, so we need to reset the counters
+        clientListenerCallCount = 0
+        editText.setSelection(0, 5)
+
+        // Verify client listener was called
+        Assert.assertEquals(1, clientListenerCallCount)
+        Assert.assertEquals(0, lastClientSelectionStart)
+        Assert.assertEquals(5, lastClientSelectionEnd)
+    }
+
+    @Test
+    fun `test multiple client listeners work together`() {
+        var secondClientListenerCallCount = 0
+        var lastSecondClientSelectionStart = -1
+        var lastSecondClientSelectionEnd = -1
+
+        // Add first client listener
+        editText.setOnSelectionChangedListener(object : AztecText.OnSelectionChangedListener {
+            override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+                clientListenerCallCount++
+                lastClientSelectionStart = selStart
+                lastClientSelectionEnd = selEnd
+            }
+        })
+
+        // Add second client listener
+        editText.setOnSelectionChangedListener(object : AztecText.OnSelectionChangedListener {
+            override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+                secondClientListenerCallCount++
+                lastSecondClientSelectionStart = selStart
+                lastSecondClientSelectionEnd = selEnd
+            }
+        })
+
+        // Add some text and make a selection
+        editText.setText("Hello World")
+        // setText triggers a selection change event, so we need to reset the counters
+        clientListenerCallCount = 0
+        secondClientListenerCallCount = 0
+        editText.setSelection(0, 5)
+
+        // Verify both client listeners were called
+        Assert.assertEquals(1, clientListenerCallCount)
+        Assert.assertEquals(1, secondClientListenerCallCount)
+        Assert.assertEquals(0, lastClientSelectionStart)
+        Assert.assertEquals(5, lastClientSelectionEnd)
+        Assert.assertEquals(0, lastSecondClientSelectionStart)
+        Assert.assertEquals(5, lastSecondClientSelectionEnd)
+    }
+}


### PR DESCRIPTION
### Fix

The `AztecText.setOnSelectionChangedListener` wasn't working from the client side, as the editor's internal code was [overriding](https://github.com/wordpress-mobile/AztecEditor-Android/blob/ca1e1e05f578f0636e3d0759c3ac97205aae2583/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt#L412) the listener for its purposes. Refactored the code to allow multiple listeners.

### Test

- Check out the `plokhoves/fix-selection-listener` branch in AS
- Run the app
- Type some text in the editor
- Select a word and apply the bold style
- [x] Observe that the selected text is displayed in bold
- Tap the selection handles and move them to select more or less text 
- [x] Observe that the bold icon on the toolbar changes the color to black when only the bolded text is selected  

https://github.com/user-attachments/assets/e362c9f7-034c-4e75-84fc-b2adfe4ed021



### Review

@mzorz 