### PR TITLE
fix: span end should not be before the start

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -36,6 +36,16 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
         set(flags) { setSpanOrLogError(span, start, end, flags) }
 
     private fun setSpanOrLogError(span: T, start: Int, end: Int, flags: Int) {
+        if (start < 0 || end < 0) {
+            AppLog.w(AppLog.T.EDITOR, "span starts/ends before 0")
+            return
+        }
+
+        if (end < start) {
+            AppLog.w(AppLog.T.EDITOR, "span end is before start")
+            return
+        }
+
         // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
         if (isInvalidParagraph(spannable, start, end, flags)) return
 


### PR DESCRIPTION
### Fix
[IndexOutOfBoundsException crash](https://github.com/wordpress-mobile/AztecEditor-Android/issues/1106) issue.

### Test
1. We could not reproduce it on local but we had multiple reports from Firebase on Samsung devices. Looks like it's specific to some custom emoji implementation as per the logs in the original issue.

### Review
@mzorz 

Make sure strings will be translated:

- [x] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.