### PR TITLE
Fix: apply boundary checks on span start and end range

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/util/SpanWrapper.kt
@@ -36,6 +36,16 @@ class SpanWrapper<T>(var spannable: Spannable, var span: T) {
         set(flags) { setSpanOrLogError(span, start, end, flags) }
 
     private fun setSpanOrLogError(span: T, start: Int, end: Int, flags: Int) {
+        if (start < 0 || end < 0) {
+            AppLog.w(AppLog.T.EDITOR, "span starts/ends before 0")
+            return
+        }
+
+        if (end < start) {
+            AppLog.w(AppLog.T.EDITOR, "span end is before start")
+            return
+        }
+
         // Silently ignore invalid PARAGRAPH spans that don't start or end at paragraph boundary
         if (isInvalidParagraph(spannable, start, end, flags)) return
 


### PR DESCRIPTION
See: https://github.com/wordpress-mobile/AztecEditor-Android/pull/1107