### PR TITLE
Fix lists indentation issues

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -66,6 +66,8 @@ import org.wordpress.aztec.plugins.wpcomments.toolbar.PageToolbarButton
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
+import org.wordpress.aztec.toolbar.ToolbarAction
+import org.wordpress.aztec.toolbar.ToolbarItems
 import org.wordpress.aztec.util.AztecLog
 import org.xml.sax.Attributes
 import java.io.File
@@ -458,6 +460,28 @@ open class MainActivity : AppCompatActivity(),
                 }
             }
         })
+
+        toolbar.enableTaskList()
+
+        toolbar.setToolbarItems(
+            ToolbarItems.BasicLayout(
+                ToolbarAction.HEADING,
+                ToolbarAction.LIST,
+                ToolbarAction.INDENT,
+                ToolbarAction.OUTDENT,
+                ToolbarAction.QUOTE,
+                ToolbarAction.BOLD,
+                ToolbarAction.ITALIC,
+                ToolbarAction.LINK,
+                ToolbarAction.UNDERLINE,
+                ToolbarAction.STRIKETHROUGH,
+                ToolbarAction.ALIGN_LEFT,
+                ToolbarAction.ALIGN_CENTER,
+                ToolbarAction.ALIGN_RIGHT,
+                ToolbarAction.HORIZONTAL_RULE,
+                ToolbarItems.PLUGINS,
+                ToolbarAction.HTML
+        ))
 
         aztec = Aztec.with(visualEditor, sourceEditor, toolbar, this)
                 .setImageGetter(GlideImageLoader(this))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/ListFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/ListFormatter.kt
@@ -5,6 +5,8 @@ import org.wordpress.aztec.spans.AztecListItemSpan
 import org.wordpress.aztec.spans.AztecListSpan
 import org.wordpress.aztec.spans.AztecOrderedListSpan
 import org.wordpress.aztec.spans.AztecOrderedListSpanAligned
+import org.wordpress.aztec.spans.AztecTaskListSpan
+import org.wordpress.aztec.spans.AztecTaskListSpanAligned
 import org.wordpress.aztec.spans.AztecUnorderedListSpan
 import org.wordpress.aztec.spans.AztecUnorderedListSpanAligned
 import org.wordpress.aztec.spans.IAztecBlockSpan
@@ -96,6 +98,14 @@ class ListFormatter(editor: AztecText) : AztecFormatter(editor) {
             is AztecOrderedListSpan -> AztecOrderedListSpan(updatedNestingLevel, attributes, listStyle)
             is AztecUnorderedListSpanAligned -> AztecUnorderedListSpanAligned(updatedNestingLevel, attributes, listStyle, alignment)
             is AztecUnorderedListSpan -> AztecUnorderedListSpan(updatedNestingLevel, attributes, listStyle)
+            is AztecTaskListSpanAligned -> {
+                val context = getContext() ?: return null
+                AztecTaskListSpanAligned(updatedNestingLevel, attributes, context, listStyle, alignment)
+            }
+            is AztecTaskListSpan -> {
+                val context = getContext() ?: return null
+                AztecTaskListSpan(updatedNestingLevel, attributes, context, listStyle)
+            }
             else -> null
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -38,9 +38,23 @@ abstract class AztecListSpan(override var nestingLevel: Int,
         val listText = text.subSequence(spanStart, spanEnd) as Spanned
 
         if (end - spanStart - 1 >= 0 && end - spanStart <= listText.length) {
-            val hasSublist = listText.getSpans(end - spanStart - 1, end - spanStart, AztecListSpan::class.java)
-                    .any { it.nestingLevel > nestingLevel }
-            if (hasSublist) {
+            // When outdenting an empty list item, a nested list span may begin at the
+            // exact start of this line due to span boundary updates. That should not
+            // suppress the indicator for the current line. Ignore sublists whose start
+            // coincides with the current line start.
+            val potentialSublists = listText.getSpans(end - spanStart - 1, end - spanStart, AztecListSpan::class.java)
+            val hasBlockingSublist = potentialSublists.any { sub ->
+                if (sub.nestingLevel <= nestingLevel) return@any false
+                val subStart = listText.getSpanStart(sub)
+                val lineStart = (listText.subSequence(0, end - spanStart) as Spanned)
+                        .lastIndexOf('\n') + 1
+                // Only treat as blocking if the nested list actually starts after the line start
+                // (i.e., the next line belongs to a deeper list). If it starts exactly at the
+                // line start, we are at the first character of that nested block, which should
+                // still show the current line indicator.
+                subStart > lineStart
+            }
+            if (hasBlockingSublist) {
                 return null
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
@@ -68,6 +68,8 @@ open class AztecTaskListSpan(
 ) : AztecListSpan(nestingLevel, listStyle.verticalPadding) {
     private var toggled: Boolean = false
         private var contextRef: WeakReference<Context> = WeakReference(context)
+
+    internal fun getContext(): Context? = contextRef.get()
     override val TAG = "ul"
 
     override val startTag: String

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ allprojects {
     }
     tasks.withType(KotlinCompile).all {
         kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_1_8
             allWarningsAsErrors = true
         }
     }
@@ -43,6 +42,30 @@ task clean(type: Delete) {
 }
 
 subprojects {
+    plugins.withId("com.android.application") {
+        android {
+            compileOptions {
+                sourceCompatibility JavaVersion.VERSION_1_8
+                targetCompatibility JavaVersion.VERSION_1_8
+            }
+        }
+    }
+    plugins.withId("com.android.library") {
+        android {
+            compileOptions {
+                sourceCompatibility JavaVersion.VERSION_1_8
+                targetCompatibility JavaVersion.VERSION_1_8
+            }
+        }
+    }
+    plugins.withId("org.jetbrains.kotlin.android") {
+        tasks.withType(KotlinCompile).configureEach {
+            kotlinOptions {
+                jvmTarget = "1.8"
+            }
+        }
+    }
+
     configurations {
         ktlint
     }


### PR DESCRIPTION
Closes [DODROID-433](https://linear.app/a8c/issue/DODROID-433/the-editor-fails-to-add-checklist-indentation)

### Description

- Fixes the indentation issue for a task list (1435aec)
- Fixes a rendering issue where outdenting an empty list item (no text) removes the visible marker (bullet/number/checkbox) even though the item stays a list internally (150484e)
- Adds the task list and indentation buttons to the demo app's toolbar (9c82adb)
- Fixes the build issue of the sample app (Java 21 compatibility) (187e981)

https://github.com/user-attachments/assets/237fbd67-e164-44a0-a1d5-ad61009bc748

### Test

- Check out the branch `dodroid-433-the-editor-fails-to-add-checklist-indentation`
- Build and run the sample app
- Create an unordered list with at least two items
- Add a new empty list item (press Enter)
- Press outdent on the empty item
- [x] Verify the bullet remains visible immediately after outdent (no typing required)
- Repeat the steps above for an ordered list
- [x] Verify numbering shows correctly after outdent
- Create a task list with at least two items
- Press indent on an item
- [x] Verify indentation works correctly
- [x] Add more items and indent them further - verify it works correctly
- Add a new empty list item (press Enter)
- Press outdent on the empty item
- [x] Verify the checkbox remains visible immediately after outdent (no typing required)

https://github.com/user-attachments/assets/2bb47e26-2f24-4af4-befc-10db87703dec


