### PR TITLE
Fix invalid selection/span ranges causing editor crashes

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1588,6 +1588,31 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
 
     // Helper ======================================================================================
 
+    /**
+     * Some Android versions/framework builds are very strict about selection offsets and will crash
+     * when selection handles try to position at an invalid cursor offset (e.g. -1 or > text length).
+     *
+     * Aztec can temporarily compute such offsets while mutating text (indent/outdent, span re-application, etc),
+     * so we clamp selection to a valid range here to avoid framework crashes.
+     *
+     * NOTE: We clamp to [0, safeLength] to avoid placing selection on the end-of-buffer marker.
+     */
+    override fun setSelection(index: Int) {
+        val max = EndOfBufferMarkerAdder.safeLength(this)
+        super.setSelection(index.coerceIn(0, max))
+    }
+
+    override fun setSelection(start: Int, stop: Int) {
+        val max = EndOfBufferMarkerAdder.safeLength(this)
+        val s = start.coerceIn(0, max)
+        val e = stop.coerceIn(0, max)
+        if (s <= e) {
+            super.setSelection(s, e)
+        } else {
+            super.setSelection(e, s)
+        }
+    }
+
     fun consumeCursorPosition(text: SpannableStringBuilder): Int {
         var cursorPosition = Math.min(selectionStart, text.length)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -219,7 +219,22 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         this.onEach { editableText.removeSpan(it.span) }
         action()
         this.onEach {
-            editableText.setSpan(it.span, it.spanStart, it.spanEnd, it.spanFlags)
+            val len = editableText.length
+            if (len <= 0) return@onEach
+
+            val start = it.spanStart.coerceIn(0, len)
+            val end = it.spanEnd.coerceIn(0, len)
+            if (start >= end) return@onEach
+
+            try {
+                editableText.setSpan(it.span, start, end, it.spanFlags)
+            } catch (_: IndexOutOfBoundsException) {
+                // Defensive: text may have been modified by other watchers by the time we restore spans.
+            } catch (_: IllegalArgumentException) {
+                // Defensive: some framework builds throw IllegalArgumentException on invalid ranges.
+            } catch (_: RuntimeException) {
+                // Defensive: SpannableStringBuilder.setSpan can throw RuntimeException for invalid ranges.
+            }
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/SuggestionWatcher.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/SuggestionWatcher.kt
@@ -142,19 +142,26 @@ class SuggestionWatcher(aztecText: AztecText) : TextWatcher {
 
     private fun reapplyCarriedOverInlineSpans(editableText: Spannable) {
         carryOverSpans.forEach {
-            if (it.start >= 0 && it.end <= editableText.length && it.start < it.end) {
-                try {
-                    editableText.setSpan(
-                        it.span,
-                        it.start,
-                        it.end,
-                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                    )
-                } catch (e: IndexOutOfBoundsException) {
-                    // This is a workaround for a possible bug in the Android framework
-                    // https://github.com/wordpress-mobile/WordPress-Android/issues/20481
-                    e.printStackTrace()
-                }
+            val len = editableText.length
+            if (len <= 0) return@forEach
+
+            val start = it.start.coerceIn(0, len)
+            val end = it.end.coerceIn(0, len)
+            if (start >= end) return@forEach
+
+            try {
+                editableText.setSpan(
+                    it.span,
+                    start,
+                    end,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            } catch (_: IndexOutOfBoundsException) {
+                // Defensive: spans can become invalid if the framework modifies text concurrently.
+            } catch (_: IllegalArgumentException) {
+                // Defensive: newer framework builds can throw on edge-case span/selection interactions.
+            } catch (_: RuntimeException) {
+                // Defensive: SpannableStringBuilder.setSpan can throw RuntimeException for invalid ranges.
             }
         }
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/IndentTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/IndentTest.kt
@@ -250,6 +250,27 @@ class IndentTest {
 
     @Test
     @Throws(Exception::class)
+    fun testOutdentAtStartOfDocumentDoesNotCrashAndClampsSelection() {
+        // Regression test:
+        // Outdenting when the caret is at position 0 and the first character is a tab used to compute
+        // selection = -1 and crash inside EditText.setSelection (setSpan(-1...-1)).
+        editText.fromHtml("\t123")
+
+        // Place caret at the very beginning (this matches the crash repro from the app).
+        editText.setSelection(0)
+        Assert.assertTrue(editText.isOutdentAvailable())
+
+        // Should not throw.
+        editText.outdent()
+
+        // Verify text was outdented and selection remained valid.
+        Assert.assertEquals("123", editText.toHtml())
+        Assert.assertEquals(0, editText.selectionStart)
+        Assert.assertEquals(0, editText.selectionEnd)
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun doesNotIndentMedia() {
         editText.fromHtml("<h1>Heading 1</h1><img src=\"test.jpg\" /><h1>Heading 2</h1>")
 


### PR DESCRIPTION
[DODROID-621](https://linear.app/a8c/issue/DODROID-621/indexoutofboundsexception-when-outdenting)

Prevents crashes caused by invalid selection offsets and invalid span ranges during text mutations (e.g., outdent/indent, span restoration), which can surface as SpannableStringBuilder/selection handle failures on newer Android builds.

The crash recording:
https://github.com/user-attachments/assets/f32a42c5-fdf2-4db3-a55f-19c0b6494587

### Changes:
- Clamp AztecText.setSelection(...) to a valid range (also avoiding the end-of-buffer marker).
- Guard/clamp span restoration ranges in SuggestionWatcher and LineBlockFormatter to avoid setSpan crashes on edge cases.
- Add a regression test reproducing the “outdent at start of document” crash.

### Testing Steps
- Run the demo app
- Long-click -> Select all -> Cut
- Ensure the cursor is at the first line at position 0
- Tap the `Indent` button on the toolbar
- Enter some text
- Move the cursor back to position 0
- Tap the `Outdent` button
- [ ] Verify the app doesn't crash
- Smoke-test the editor in the demo app, especially the indentation

### The crashes

```
Exception java.lang.IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0
  at android.text.SpannableStringBuilder.checkRange (SpannableStringBuilder.java:1341)
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:695)
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:687)
  at androidx.emoji2.text.SpannableBuilder.setSpan (SpannableBuilder.java:135)
  at android.text.Selection.setSelection (Selection.java:94)
  at android.text.Selection.setSelection (Selection.java:78)
  at android.widget.EditText.setSelection (EditText.java:147)
  at org.wordpress.aztec.formatting.IndentFormatter.outdent (IndentFormatter.kt:111)
  at org.wordpress.aztec.formatting.BlockFormatter.outdent (BlockFormatter.kt:80)
  at org.wordpress.aztec.AztecText.outdent (AztecText.kt:1217)
  at org.wordpress.aztec.toolbar.AztecToolbar.onToolbarAction (AztecToolbar.kt:659)
  at org.wordpress.aztec.toolbar.AztecToolbar.setupToolbarItems$lambda$18$lambda$17 (AztecToolbar.kt:799)
```

```
Exception java.lang.RuntimeException:
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:694)
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:677)
  at androidx.emoji2.text.SpannableBuilder.setSpan (SpannableBuilder.java:135)
  at org.wordpress.aztec.formatting.LineBlockFormatter.applyWithRemovedSpans (LineBlockFormatter.kt:222)
  at org.wordpress.aztec.formatting.LineBlockFormatter.insertSpanAfterBlock (LineBlockFormatter.kt:201)
  at org.wordpress.aztec.formatting.LineBlockFormatter.applyHorizontalRule (LineBlockFormatter.kt:121)
  at org.wordpress.aztec.AztecText.toggleFormatting (AztecText.kt:1459)
  at org.wordpress.aztec.toolbar.AztecToolbar.onToolbarAction (AztecToolbar.kt:615)
  at org.wordpress.aztec.toolbar.AztecToolbar.setupToolbarItems$lambda$18$lambda$17 (AztecToolbar.kt:799)
  at android.view.View.performClick (View.java:8464)
```

```
Exception java.lang.IllegalArgumentException: Invalid offset: 3. Valid range is [0, 2]
  at android.text.method.WordIterator.checkOffsetIsValid (WordIterator.java:401)
  at android.text.method.WordIterator.isBoundary (WordIterator.java:112)
  at android.widget.Editor$SelectionHandleView.positionAtCursorOffset (Editor.java:7941)
  at android.widget.Editor$HandleView.updatePosition (Editor.java:6297)
  at android.widget.Editor$HandleView.updateDrawable (Editor.java:6052)
  at android.widget.Editor$SelectionHandleView.updateSelection (Editor.java:7708)
  at android.widget.Editor$HandleView.positionAtCursorOffset (Editor.java:6257)
  at android.widget.Editor$SelectionHandleView.positionAtCursorOffset (Editor.java:7940)
  at android.widget.Editor$HandleView.invalidate (Editor.java:6122)
  at android.widget.Editor$SelectionModifierCursorController.invalidateHandles (Editor.java:8981)
  at android.widget.Editor.invalidateHandlesAndActionMode (Editor.java:2595)
  at android.widget.TextView.spanChange (TextView.java:13810)
  at android.widget.TextView$ChangeWatcher.onSpanChanged (TextView.java:17629)
  at android.text.SpannableStringBuilder.sendSpanChanged (SpannableStringBuilder.java:1309)
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:754)
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:678)
  at androidx.emoji2.text.SpannableBuilder.setSpan (SpannableBuilder.java:135)
  at org.wordpress.aztec.watchers.SuggestionWatcher.reapplyCarriedOverInlineSpans (SuggestionWatcher.kt:147)
  at org.wordpress.aztec.watchers.SuggestionWatcher.onTextChanged (SuggestionWatcher.kt:82)
  at android.widget.TextView.sendOnTextChanged (TextView.java:13573)
  at android.widget.TextView.handleTextChanged (TextView.java:13702)
  at android.widget.TextView$ChangeWatcher.onTextChanged (TextView.java:17605)
  at android.text.SpannableStringBuilder.sendTextChanged (SpannableStringBuilder.java:1269)
  at android.text.SpannableStringBuilder.replace (SpannableStringBuilder.java:578)
  at androidx.emoji2.text.SpannableBuilder.replace (SpannableBuilder.java:308)
  at android.text.SpannableStringBuilder.append (SpannableStringBuilder.java:272)
  at androidx.emoji2.text.SpannableBuilder.append (SpannableBuilder.java:337)
  at androidx.emoji2.text.SpannableBuilder.append (SpannableBuilder.java:48)
  at org.wordpress.aztec.formatting.LineBlockFormatter$insertSpanAfterBlock$3.invoke (LineBlockFormatter.kt:202)
  at org.wordpress.aztec.formatting.LineBlockFormatter$insertSpanAfterBlock$3.invoke (LineBlockFormatter.kt:201)
  at org.wordpress.aztec.formatting.LineBlockFormatter.applyWithRemovedSpans (LineBlockFormatter.kt:220)
  at org.wordpress.aztec.formatting.LineBlockFormatter.insertSpanAfterBlock (LineBlockFormatter.kt:201)
  at org.wordpress.aztec.formatting.LineBlockFormatter.applyHorizontalRule (LineBlockFormatter.kt:121)
  at org.wordpress.aztec.AztecText.toggleFormatting (AztecText.kt:1459)
  at org.wordpress.aztec.toolbar.AztecToolbar.onToolbarAction (AztecToolbar.kt:615)
  at org.wordpress.aztec.toolbar.AztecToolbar.setupToolbarItems$lambda$18$lambda$17 (AztecToolbar.kt:799)
  at android.view.View.performClick (View.java:8508)
```

```
Exception java.lang.IllegalArgumentException:
  at android.text.method.WordIterator.checkOffsetIsValid (WordIterator.java:384)
  at android.text.method.WordIterator.isBoundary (WordIterator.java:94)
  at android.widget.Editor$SelectionHandleView.positionAtCursorOffset (Editor.java:5470)
  at android.widget.Editor$HandleView.invalidate (Editor.java:4580)
  at android.widget.Editor$SelectionModifierCursorController.invalidateHandles (Editor.java:6151)
  at android.widget.Editor.invalidateHandlesAndActionMode (Editor.java:1985)
  at android.widget.TextView.spanChange (TextView.java:9941)
  at android.widget.TextView$ChangeWatcher.onSpanAdded (TextView.java:12570)
  at android.text.SpannableStringBuilder.sendSpanAdded (SpannableStringBuilder.java:1283)
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:775)
  at android.text.SpannableStringBuilder.setSpan (SpannableStringBuilder.java:674)
  at androidx.emoji2.text.SpannableBuilder.setSpan (SpannableBuilder.java:135)
  at org.wordpress.aztec.watchers.SuggestionWatcher.reapplyCarriedOverInlineSpans (SuggestionWatcher.kt:147)
  at org.wordpress.aztec.watchers.SuggestionWatcher.onTextChanged (SuggestionWatcher.kt:82)
  at android.widget.TextView.sendOnTextChanged (TextView.java:9769)
  at android.widget.TextView.handleTextChanged (TextView.java:9866)
  at android.widget.TextView$ChangeWatcher.onTextChanged (TextView.java:12538)
  at android.text.SpannableStringBuilder.sendTextChanged (SpannableStringBuilder.java:1263)
  at android.text.SpannableStringBuilder.replace (SpannableStringBuilder.java:575)
  at androidx.emoji2.text.SpannableBuilder.replace (SpannableBuilder.java:308)
  at android.text.SpannableStringBuilder.insert (SpannableStringBuilder.java:224)
  at androidx.emoji2.text.SpannableBuilder.insert (SpannableBuilder.java:316)
  at androidx.emoji2.text.SpannableBuilder.insert (SpannableBuilder.java:48)
  at org.wordpress.aztec.formatting.IndentFormatter.indent (IndentFormatter.kt:49)
  at org.wordpress.aztec.formatting.BlockFormatter.indent (BlockFormatter.kt:75)
  at org.wordpress.aztec.AztecText.indent (AztecText.kt:1211)
  at org.wordpress.aztec.toolbar.AztecToolbar.onToolbarAction (AztecToolbar.kt:655)
  at org.wordpress.aztec.toolbar.AztecToolbar.setupToolbarItems$lambda$18$lambda$17 (AztecToolbar.kt:799)
  at android.view.View.performClick (View.java:6614)
```
