### PR TITLE
[CI] Fix Slack Notify Configuration in Dependency Analysis Pipeline

### DIFF
--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -13,6 +13,15 @@ steps:
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
-    notify:
-      - slack: "#android-core-notifs"
-        if: build.state == "failed"
+
+notify:
+  - slack:
+      channels:
+        - "#android-core-notifs"
+      message: "Dependency analysis succeeded."
+    if: build.state == "passed"
+  - slack:
+      channels:
+        - "#android-core-notifs"
+      message: "Dependency analysis failed."
+    if: build.state == "failed"


### PR DESCRIPTION
Closes: [AINFRA-2124](https://linear.app/a8c/issue/AINFRA-2124)

---

### Description

Step-level `notify` in Buildkite only supports a subset of conditions, so the `build.state == "failed"` condition was silently ignored and no Slack notifications were being sent when the dependency analysis pipeline failed. This was originally discovered and fixed in [WordPress-MediaPicker-Android#90](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/90) (commit [7d002b6](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/90/commits/7d002b6fad746f3d426b08837c5191339dea7778)).

This PR applies the same fix by moving the `notify` block from step level to pipeline level and adding both `passed` and `failed` notifications with explicit messages to `#android-core-notifs`.

---

### Testing Steps

1. Trigger a manual [scheduled build](https://buildkite.com/automattic/aztec-editor-android) with:
    - **Message:** `Trigger Standalone "Dependency Analysis" Job`
    - **Commit:** `HEAD`
    - **Branch:** `ci/fix-slack-notify-in-dependency-analysis-pipeline`
    - **Environment Variables:** `PIPELINE=schedules/dependency-analysis.yml`
2. Verify the pipeline passes and a Slack notification is sent to `#android-core-notifs`
    - Success: Build: [833](https://buildkite.com/automattic/azteceditor-android/builds/833) + Slack Notification: p1772467987314019-slack-C0787KRDYDC