### PR TITLE
Fix checkbox interaction for indented (nested) task list items

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -751,16 +751,11 @@ open class AztecText : AppCompatEditText, TextWatcher, UnknownHtmlSpan.OnUnknown
         x += scrollX
         y += scrollY
 
-        // We check whether the user tap on a checkbox of a task list. The aztec text field should be enabled and we
-        // check whether the tap event was on the leading margin which is where the checkbox is located plus a padding
-        // space used to increase the target size for the tap event.
-        if (isEnabled &&
-            x + totalPaddingStart <= (blockFormatter.listStyleLeadingMargin() + AztecTaskListSpan.PADDING_SPACE)) {
+        // We check whether the user tap on a checkbox of a task list. The handler performs its
+        // own nesting-aware x-coordinate check, so we only need a rough gate here.
+        if (isEnabled) {
             val line = layout.getLineForVertical(y)
             val off = layout.getOffsetForHorizontal(line, x.toFloat())
-            // If the tap event was on the leading margin, we double check whether we are tapping on a task list item.
-            // If that is true, then we return false because we don't want to propagate the tap event to stop moving
-            // the cursor to the item tapped.
             if (getTaskListHandler()?.handleTaskListClick(
                 text,
                 off,

--- a/aztec/src/main/kotlin/org/wordpress/aztec/TaskListClickHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/TaskListClickHandler.kt
@@ -7,15 +7,18 @@ import org.wordpress.aztec.spans.AztecTaskListSpan
 
 class TaskListClickHandler(val listStyle: BlockFormatter.ListStyle) {
     fun handleTaskListClick(text: Spannable, off: Int, x: Int, startMargin: Int): Boolean {
-        // We want to make sure that text click will not trigger the checked change
-        if (x + startMargin > (listStyle.leadingMargin() + AztecTaskListSpan.PADDING_SPACE)) return false
-        val clickedList = text.getSpans(off, off, AztecTaskListSpan::class.java).firstOrNull()
+        val clickedList = text.getSpans(off, off, AztecTaskListSpan::class.java).maxByOrNull { it.nestingLevel }
+                ?: return false
+        // Account for nested leading margins: each nesting level adds one leadingMargin width
+        val depthMultiplier = (clickedList.nestingLevel / 2) + 1
+        val effectiveMargin = listStyle.leadingMargin() * depthMultiplier
+        if (x + startMargin > (effectiveMargin + AztecTaskListSpan.PADDING_SPACE)) return false
         val clickedLines = text.getSpans(off, off, AztecListItemSpan::class.java)
         val clickedLine = clickedLines.find {
             val spanStart = text.getSpanStart(it)
             spanStart == off || (spanStart == off - 1 && text.getSpanEnd(it) == off)
         }
-        if (clickedList != null && clickedLine != null && clickedList.canToggle()) {
+        if (clickedLine != null && clickedList.canToggle()) {
             clickedLine.toggleCheck()
             clickedList.refresh()
             return true

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecTaskListSpan.kt
@@ -139,9 +139,9 @@ open class AztecTaskListSpan(
     private fun isChecked(text: CharSequence, lineIndex: Int): Boolean {
         val spanStart = (text as Spanned).getSpanStart(this)
         val spanEnd = text.getSpanEnd(this)
-        val sortedSpans = text.getSpans(spanStart, spanEnd, AztecListItemSpan::class.java).sortedBy {
-            text.getSpanStart(it)
-        }
+        val sortedSpans = text.getSpans(spanStart, spanEnd, AztecListItemSpan::class.java)
+                .filter { it.nestingLevel == nestingLevel + 1 }
+                .sortedBy { text.getSpanStart(it) }
         return sortedSpans.getOrNull(lineIndex - 1)?.attributes?.getValue("checked") == "true"
     }
 


### PR DESCRIPTION
### Fix
 Fix checkbox interaction for indented (nested) task list items. 

> [!NOTE]
> This PR can be tested with DayOne-Android via the companion PR [here](https://github.com/bloom/DayOne-Android/pull/7372)
 
Three issues were addressed:                                                                       
  1. Cannot check indented items: The x-coordinate gate in AztecText.onTouchEvent() and TaskListClickHandler only allowed taps within a single leading margin width, rejecting taps on nested checkboxes positioned further right. The handler now computes the tap boundary based on the nesting depth of the tapped item.           
  2. Checking item above indented item checks both: isChecked() in AztecTaskListSpan fetched all AztecListItemSpan children (including nested ones) but used a line index that only counted direct children, causing an index mismatch. Now filters spans by nestingLevel to match.                                                    
  3. Wrong item gets strikethrough: Same root cause as #2 — after any nested item, every subsequent checkbox rendered the state of the wrong item.
                                                                                                                                                                     
### Test Steps  
1. Check out the branch dodroid-954-checklist-issue
2. Build and run the sample app                                                                                                                                                           
2. Create a task list with a few items
3. Indent one item in the middle using the indent toolbar button                                                                                                   
4. Tap the checkbox on the indented item — it should toggle independently                                                                                          
5. Tap the checkbox on the item directly above the indented item — only that item should be checked                                                                
6. Tap the checkbox on the item directly below the indented item — the correct item should be checked and struck through                                           
7. Verify items at all positions (above, below, indented) can be checked and unchecked independently                     


Make sure strings will be translated:

- [ ] If there are new strings that have to be translated, I have added them to the client's `strings.xml` as a part of the integration PR.