### PR TITLE
Update wordpress:utils 3.5.0 -> 3.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ ext {
     robolectricVersion = '4.13'
     jUnitVersion = '4.13.2'
     jSoupVersion = '1.15.3'
-    wordpressUtilsVersion = '3.5.0'
+    wordpressUtilsVersion = '3.15.0'
     espressoVersion = '3.0.1'
 
     // other


### PR DESCRIPTION
### Fix

Updates the `wordpress:utils` dependency to the latest: https://github.com/wordpress-mobile/WordPress-Utils-Android/releases 

Primary motivation is that the GET_ACCOUNTS permission gets pulled into any apps using Aztec. This was fixed in version 3.8.0 of `wordpress:utils`.

Many other dependencies are severely out of date as well, hopefully there is a plan to update them at some point.

### Test
Ran all unit tests and they passed

### Review
??? Not sure